### PR TITLE
Extracting email properly from Cognito

### DIFF
--- a/src/app/utilities/auth/nextAuthOptions.ts
+++ b/src/app/utilities/auth/nextAuthOptions.ts
@@ -2,6 +2,7 @@ import {
   AuthError,
   confirmSignUp,
   getCurrentUser,
+  GetCurrentUserOutput,
   resendSignUpCode,
   signIn,
   SignInOutput,
@@ -22,10 +23,11 @@ import {
 } from '../amplify/constants';
 
 const getUser = async () => {
-  const user = await getCurrentUser();
+  const user: GetCurrentUserOutput = await getCurrentUser();
+
   return {
     id: user.userId,
-    email: user.username,
+    email: user.signInDetails?.loginId,
   };
 };
 


### PR DESCRIPTION
Collecting email info from Cognito sign-in properly, from a different attribute.

**NOTE**: Cognito sign-in options can be set as `Username`, `Email` etc. Setting `Username` enables the username to be the same as login-id. In case of `Email` (which is how our Cognito is set up), although the login-id is the user provided email, Cognito uses its unique generated id as username. So, we needed to use the login-id to extract the email. 