### PR TITLE
API throttling (test)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "isomorphic-dompurify": "^2.12.0",
         "next": "14.0.3",
         "next-auth": "^4.24.7",
+        "rate-limiter-flexible": "^5.0.3",
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.52.0",
@@ -10576,6 +10577,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/rate-limiter-flexible": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-5.0.3.tgz",
+      "integrity": "sha512-lWx2y8NBVlTOLPyqs+6y7dxfEpT6YFqKy3MzWbCy95sTTOhOuxufP2QvRyOHpfXpB9OUJPbVLybw3z3AVAS5fA=="
     },
     "node_modules/react": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "isomorphic-dompurify": "^2.12.0",
     "next": "14.0.3",
     "next-auth": "^4.24.7",
+    "rate-limiter-flexible": "^5.0.3",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.52.0",

--- a/src/app/api/test/route.ts
+++ b/src/app/api/test/route.ts
@@ -1,0 +1,14 @@
+import { consumeRateWithIp } from '@/app/utilities/api/rateLimiter';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  try {
+    const data = await consumeRateWithIp(req);
+
+    return NextResponse.json({ status: 200, data });
+  } catch (error) {
+    const status = 400;
+
+    return NextResponse.json({ status, error }, { status });
+  }
+}

--- a/src/app/utilities/api/constants.ts
+++ b/src/app/utilities/api/constants.ts
@@ -1,0 +1,2 @@
+export const API_POINT_CONSUMPTION_LIMIT = 10;
+export const API_CONSUMPTION_INTERVAL = 60; // In seconds

--- a/src/app/utilities/api/rateLimiter.ts
+++ b/src/app/utilities/api/rateLimiter.ts
@@ -1,0 +1,32 @@
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+import {
+  API_CONSUMPTION_INTERVAL,
+  API_POINT_CONSUMPTION_LIMIT,
+} from './constants';
+import { NextRequest } from 'next/server';
+
+const rateLimiter = new RateLimiterMemory({
+  points: API_POINT_CONSUMPTION_LIMIT,
+  duration: API_CONSUMPTION_INTERVAL,
+});
+
+export const consumeRateWithIp = async (
+  req: NextRequest,
+  pointsToConsume?: number
+) => {
+  const ip =
+    req.ip ||
+    req.headers.get('x-forwarded-for') ||
+    req.headers.get('x-real-ip') ||
+    'unknown';
+
+  try {
+    const res = await rateLimiter.consume(ip, pointsToConsume);
+
+    return { ip, data: res };
+  } catch (ex) {
+    throw { ip, error: ex };
+  }
+};
+
+export default rateLimiter;


### PR DESCRIPTION
API rate-limiting test through process memory usage. Allowed 10 requests in a 60 second window, can be tested using `/api/test` URL.