### PR TITLE
Check date value based on month

### DIFF
--- a/src/app/components/auth/AuthInitSignUp.tsx
+++ b/src/app/components/auth/AuthInitSignUp.tsx
@@ -179,6 +179,18 @@ const AuthInitSignUp: React.FC = () => {
           options={OPTIONS_DATE}
           radioMode
           required
+          rules={{
+            validate: () => {
+              const date = methods.getValues('date');
+              const month = methods.getValues('month') || -1;
+              const year = methods.getValues('year') || -1;
+              if (month === -1 || year === -1) {
+                return 'Please select Month/Year first';
+              } else {
+                return date <= new Date(year[0], month[0] + 1, 0).getDate();
+              }
+            },
+          }}
         />
         <Dropdown
           name='month'


### PR DESCRIPTION
In the sign up form, there are three dropdowns : date, month, and year.
when a user select a value for each input (date, month, year), ensure that users must first select the month and year when choosing a date, and that the date cannot exceed the number of days in that month.