### PR TITLE
Stripe checkout - adding allowed countries for shipping

### DIFF
--- a/src/app/api/course/createCheckoutUrl/route.ts
+++ b/src/app/api/course/createCheckoutUrl/route.ts
@@ -8,6 +8,7 @@ import getStripe from '@/app/utilities/stripe/getStripe';
 import {
   STRIPE_INTRO_PRODUCT_PRICE_LOOKUP_KEY,
   STRIPE_PRICE_META_MOODLE_COURSE_ID_KEY,
+  STRIPE_SHIPPING_ALLOWED_COUNTRIES,
 } from '@/app/utilities/stripe/constants';
 import APIError from '@/app/interfaces/APIError';
 
@@ -47,6 +48,15 @@ export async function POST(req: NextRequest): Promise<Response> {
       mode: 'payment',
       allow_promotion_codes: true,
       ...(customer_email && { customer_email }),
+      shipping_address_collection: {
+        allowed_countries: [
+          STRIPE_SHIPPING_ALLOWED_COUNTRIES.AUSTRALIA,
+          STRIPE_SHIPPING_ALLOWED_COUNTRIES.USA,
+          STRIPE_SHIPPING_ALLOWED_COUNTRIES.UNITED_KINGDOM,
+          STRIPE_SHIPPING_ALLOWED_COUNTRIES.CANADA,
+          STRIPE_SHIPPING_ALLOWED_COUNTRIES.NEW_ZEALAND,
+        ],
+      },
       success_url: `${COURSE_CHECKOUT_CALLBACK_URL}?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${COURSE_CHECKOUT_CALLBACK_URL}?status=canceled&session_id={CHECKOUT_SESSION_ID}`,
     });

--- a/src/app/components/toaster/toaster.module.css
+++ b/src/app/components/toaster/toaster.module.css
@@ -19,7 +19,7 @@
   justify-content: center;
   margin-bottom: 15px;
   will-change: transform;
-  animation: 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) 0s 1 normal forwards
+  animation: 500ms cubic-bezier(0.21, 1.02, 0.73, 1) 0s 1 normal forwards
     running containerItemPopUp;
 }
 
@@ -107,7 +107,7 @@
 }
 
 .hide {
-  animation: 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards containerItemHide;
+  animation: 500ms cubic-bezier(0.21, 1.02, 0.73, 1) forwards containerItemHide;
 }
 
 @keyframes containerItemPopUp {

--- a/src/app/utilities/moodle/getMoodleUserByEmail.ts
+++ b/src/app/utilities/moodle/getMoodleUserByEmail.ts
@@ -8,14 +8,13 @@ export async function getMoodleUserByEmail(
   try {
     const { src, secret } = getMoodleAPIInfo();
 
-    const url = `${src}?
-        ${getSearchQuery({
-          wstoken: secret,
-          wsfunction: 'core_user_get_users_by_field',
-          field: 'email',
-          'values[]': email,
-          moodlewsrestformat: 'json',
-        })}`;
+    const url = `${src}?${getSearchQuery({
+      wstoken: secret,
+      wsfunction: 'core_user_get_users_by_field',
+      field: 'email',
+      'values[]': email,
+      moodlewsrestformat: 'json',
+    })}`;
 
     const res = await fetch(url);
     const json: MoodleUserBasic[] | MoodleException = await res.json();

--- a/src/app/utilities/stripe/constants.ts
+++ b/src/app/utilities/stripe/constants.ts
@@ -42,3 +42,11 @@ export enum STRIPE_SESSION_PAYMENT_STATUS {
   UNPAID = 'unpaid',
   NO_PAYMENT_REQUIRED = 'no_payment_required',
 }
+
+export enum STRIPE_SHIPPING_ALLOWED_COUNTRIES {
+  AUSTRALIA = 'AU',
+  USA = 'US',
+  UNITED_KINGDOM = 'GB',
+  CANADA = 'CA',
+  NEW_ZEALAND = 'NZ',
+}


### PR DESCRIPTION
- Stripe checkout - countries allowed for shipping
  - Australia
  - New Zealand
  - United Kingdom
  - United States of America
  - Canada
- Increased transition duration for smoother toaster animation
- `getMoodleUserByEmail` URL setup: typo fix  