### PR TITLE
Title Slug in url for better SEO

### DIFF
--- a/src/app/articles/article/page.tsx
+++ b/src/app/articles/article/page.tsx
@@ -10,21 +10,21 @@ import Typography, {
 import Subscribe from '@/app/components/subscribe/subscribe';
 import { MetadataProps } from '@/app/interfaces/MetadataProps';
 import { HOST_URL, META_KEY } from '@/app/utilities/constants';
-import { createMetadata } from '@/app/utilities/common';
+import { createMetadata, slugify } from '@/app/utilities/common';
 
 export async function generateMetadata({
   searchParams,
 }: MetadataProps): Promise<Metadata> {
-  const articleId = searchParams?.articleId;
+  const titleSlug = searchParams?.title;
   const { articles } = articleData;
-  const article = articles.find(({ id }) => id === articleId);
+  const article = articles.find(({ title }) => slugify(title) === titleSlug);
 
   if (!article) {
     return {};
   }
 
   const { title, keywords, imageUrl, description } = article;
-  const canonical = `${HOST_URL}/articles/article?articleId=${articleId}`;
+  const canonical = `${HOST_URL}/articles/article?articleId=${titleSlug}`;
   const images = [{ url: imageUrl }];
 
   return createMetadata(META_KEY.ARTICLE, {
@@ -37,9 +37,11 @@ export async function generateMetadata({
 }
 
 export default function OneArticle({ searchParams }: MetadataProps) {
-  const articleId = searchParams?.articleId;
+  const titleSlug = searchParams?.title;
   const { articles } = articleData;
-  const article = articles.find((article) => article.id === articleId);
+  const article = articles.find(
+    (article) => slugify(article.title) === titleSlug
+  );
 
   if (!article) {
     return (

--- a/src/app/blogs/blog/page.tsx
+++ b/src/app/blogs/blog/page.tsx
@@ -12,13 +12,14 @@ import { MetadataProps } from '@/app/interfaces/MetadataProps';
 import { Metadata } from 'next';
 import { HOST_URL, META_KEY } from '@/app/utilities/constants';
 import { createMetadata } from '@/app/utilities/common';
+import { slugify } from '@/app/utilities/common';
 
 export async function generateMetadata({
   searchParams,
 }: MetadataProps): Promise<Metadata> {
-  const blogId = searchParams.blogId;
+  const titleSlug = searchParams?.title;
   const { blogs } = blogData;
-  const blog = blogs.find(({ id }) => id === blogId);
+  const blog = blogs.find(({ title }) => slugify(title) === titleSlug);
 
   if (!blog) {
     return {};
@@ -27,7 +28,7 @@ export async function generateMetadata({
   const { title, keywords, imageUrl, description } = blog;
   // NOTE
   // Previous `type` was 'blog', which the `openGraph` attribute doesn't accept as `type`
-  const canonical = `${HOST_URL}/blogs/blog?blogId=${blogId}`;
+  const canonical = `${HOST_URL}/blogs/blog?blogId=${titleSlug}`;
   const images = [{ url: imageUrl }];
 
   return createMetadata(META_KEY.BLOG, {
@@ -40,9 +41,9 @@ export async function generateMetadata({
 }
 
 export default function OneBlog({ searchParams }: MetadataProps) {
-  const blogId = searchParams.blogId;
+  const titleSlug = searchParams?.title;
   const { blogs } = blogData;
-  const blog = blogs.find(({ id }) => id === blogId);
+  const blog = blogs.find((blog) => slugify(blog.title) === titleSlug);
 
   if (!blog) {
     return (

--- a/src/app/components/article/Article.tsx
+++ b/src/app/components/article/Article.tsx
@@ -4,13 +4,14 @@ import styles from './article.module.css';
 import { ArticleInterface } from '@/app/interfaces/ArticleInterface';
 import Image from 'next/image';
 import LearnMore from '../LearnMore/LearnMore';
+import { slugify } from '@/app/utilities/common';
 
 export default function Article({
-  id,
   title,
   imageUrl,
   description,
 }: ArticleInterface): JSX.Element {
+  const articleSlug = slugify(title);
   return (
     <div className={styles.card}>
       <div className={styles.cardImage}>
@@ -22,7 +23,7 @@ export default function Article({
             {description}
           </Typography>
         </div>
-        <LearnMore dest={`/articles/article/?articleId=${id}`} />
+        <LearnMore dest={`/articles/article/?title=${articleSlug}`} />
       </div>
     </div>
   );

--- a/src/app/components/article/card.tsx
+++ b/src/app/components/article/card.tsx
@@ -4,13 +4,14 @@ import articleData from '../../articles/articleData.json';
 import styles from './article.module.css';
 import { ArticleInterface } from '@/app/interfaces/ArticleInterface';
 import { useSearchParams } from 'next/navigation';
+import { slugify } from '@/app/utilities/common';
 
 const CardList: React.FC = () => {
   const searchParams = useSearchParams();
-  const blogId = searchParams.get('articleId');
+  const titleSlug = searchParams.get('title');
 
   const articles: ArticleInterface[] = articleData.articles
-    .filter((article) => article.id != blogId)
+    .filter((article) => slugify(article.title) != titleSlug)
     .reverse()
     .slice(0, 3);
 

--- a/src/app/components/blog/Blog.tsx
+++ b/src/app/components/blog/Blog.tsx
@@ -4,13 +4,15 @@ import styles from './blog.module.css';
 import Image from 'next/image';
 import { BlogInterface } from '@/app/interfaces/BlogInterface';
 import LearnMore from '../LearnMore/LearnMore';
+import { slugify } from '@/app/utilities/common';
 
 export default function Blog({
-  id,
+  //id,
   title,
   imageUrl,
   description,
 }: BlogInterface): JSX.Element {
+  const blogSlug = slugify(title);
   return (
     <div className={styles.card}>
       <div className={styles.cardImage}>
@@ -22,7 +24,7 @@ export default function Blog({
             {description}
           </Typography>
         </div>
-        <LearnMore dest={`/blogs/blog/?blogId=${id}`} />
+        <LearnMore dest={`/blogs/blog/?title=${blogSlug}`} />
       </div>
     </div>
   );

--- a/src/app/components/blog/BlogCardList.tsx
+++ b/src/app/components/blog/BlogCardList.tsx
@@ -4,16 +4,23 @@ import blogData from '../../blogs/blogData.json';
 import styles from './blog.module.css';
 import { BlogInterface } from '@/app/interfaces/BlogInterface';
 import { useSearchParams } from 'next/navigation';
+import { slugify } from '@/app/utilities/common';
 
 const BlogCardList: React.FC = () => {
   const searchParams = useSearchParams();
-  const blogId = searchParams.get('blogId');
+  const titleSlug = searchParams.get('title');
+  //const blogId = searchParams.get('blogId');
 
   //filter out the blog if user already inside that blog
   const blogs: BlogInterface[] = blogData.blogs
-    .filter((blog) => blog.id != blogId)
+    .filter((blog) => slugify(blog.title) != titleSlug)
     .reverse()
     .slice(0, 3);
+
+  // const blogs: BlogInterface[] = blogData.blogs
+  //   .filter((blog) => blog.id != blogId)
+  //   .reverse()
+  //   .slice(0, 3);
 
   return (
     <div className={styles.cardList}>

--- a/src/app/utilities/common.ts
+++ b/src/app/utilities/common.ts
@@ -56,6 +56,16 @@ export const throttle = <T extends AnyFunction>(
   };
 };
 
+export const slugify = (text: string) =>
+  text
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(/[^\w-]+/g, '') // Remove all non-word chars
+    .replace(/--+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, ''); // Trim - from end of text
+
 export const createMetadata = (
   key: META_KEY,
   customMetadata?: Partial<MetadataParams>


### PR DESCRIPTION
# Pull Request: URL Structure Update

---

This pull request introduces a update to the article and blog URL structures, moving from ID-based parameters to more descriptive, slug-based titles. This change aims to improve SEO and enhance the readability and user-friendliness of the URLs. 

> **Note:** The optimal approach in Next.js for achieving slug-based URLs is typically using the native dynamic routing (renaming a file/folder to `[slug]`). However, this implementation adheres to the specific URL structure (`?title=slug`) as defined in the task assigned to me. I would suggest dynamic routing over merging this pull request.

### Article URLs

* **Old URL Structure:**
    `https://neurodiversityacademy.com/articles/article?articleId=16`

* **New URL Structure:**
    `https://neurodiversityacademy.com/articles/article?title=article-title-slug`

### Blog URLs

* **Old URL Structure:**
    `https://neurodiversityacademy.com/articles/blog?blogID=1`

* **New URL Structure:**
    `https://neurodiversityacademy.com/articles/blog?title=blog-title-slug`

Please review the changes and provide your feedback.