### PR TITLE
Publish Nepean Community College as live provider

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -18,4 +18,4 @@ COURSES_TABLE_NAME=
 # Detail: /endorsedproviders/<guid>?demo=<same-guid> (non-live providers)
 # Live providers: /endorsedproviders/<slug> (no demo pass required)
 # No pass on / → live endorsed section only; slug paths for non-live → 404
-ENDORSED_DEMO_ACCESS={"28484141-69ae-4eed-8d54-8a7522dd2c21":"academia","ee80a2e3-0494-4181-b6b7-6cec69612850":"collarts","7aaff149-22a9-4322-b1a9-a48df6fe5d6a":"nepean-community-college"}
+ENDORSED_DEMO_ACCESS={"28484141-69ae-4eed-8d54-8a7522dd2c21":"academia","ee80a2e3-0494-4181-b6b7-6cec69612850":"collarts"}

--- a/src/app/components/endorsedProviders/__tests__/EndorsedProviders.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedProviders.test.tsx
@@ -15,7 +15,7 @@ describe('EndorsedProviders demo access', () => {
     const { getAllByRole, getByText } = render(<EndorsedProviders />);
 
     expect(getByText('NDA Endorsed Providers')).toBeInTheDocument();
-    expect(getAllByRole('link')).toHaveLength(2);
+    expect(getAllByRole('link')).toHaveLength(3);
   });
 
   it('renders live cards plus one demo card for valid non-live demo slug', () => {
@@ -24,7 +24,7 @@ describe('EndorsedProviders demo access', () => {
     );
 
     expect(getByText('NDA Endorsed Providers')).toBeInTheDocument();
-    expect(getAllByRole('link')).toHaveLength(3);
+    expect(getAllByRole('link')).toHaveLength(4);
   });
 
   it('uses slug-based detail href for live provider cards', () => {
@@ -36,6 +36,9 @@ describe('EndorsedProviders demo access', () => {
     expect(hrefs).toContain(buildEndorsedLiveDetailHref('hsh'));
     expect(hrefs).toContain(
       buildEndorsedLiveDetailHref('blueprint-career-development')
+    );
+    expect(hrefs).toContain(
+      buildEndorsedLiveDetailHref('nepean-community-college')
     );
   });
 
@@ -56,6 +59,6 @@ describe('EndorsedProviders demo access', () => {
       <EndorsedProviders demoGuid='test-guid' demoSlug='nonexistent-slug' />
     );
 
-    expect(getAllByRole('link')).toHaveLength(2);
+    expect(getAllByRole('link')).toHaveLength(3);
   });
 });

--- a/src/app/components/endorsedProviders/endorsedProviderPageData.ts
+++ b/src/app/components/endorsedProviders/endorsedProviderPageData.ts
@@ -268,7 +268,7 @@ export const INTRO_SECTION_BY_SLUG: Record<string, EndorsedIntroSection> = {
   },
   'blueprint-career-development': {
     heading: 'About this organisation',
-    body: 'Blueprint Career Development is an Australian Registered Training Organisation (RTO #30978) delivering vocational education focused on practical skills, career pathways, and employment outcomes. They specialise in training and assessment (TAE), business, hospitality, and career development, offering nationally recognised qualifications with a strong focus on personalised, industry-relevant training that prepares learners for the workforce. See the results and insights from the endorsement assessment below.',
+    body: 'Blueprint Career Development is an Australian Registered Training Organisation (RTO #30978) delivering vocational education focused on practical skills, career pathways, and employment outcomes. They specialise in training and assessment (TAE), business, hospitality, offering nationally recognised qualifications with a strong focus on personalised, industry-relevant training that prepares learners for the workforce. See the results and insights from the endorsement assessment below.',
   },
   collarts: {
     heading: 'About this organisation',

--- a/src/app/components/endorsedProviders/endorsedProviders.json
+++ b/src/app/components/endorsedProviders/endorsedProviders.json
@@ -27,6 +27,7 @@
   },
   {
     "id": "Nepean Community College",
+    "live": true,
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/NepeanCover.jpeg",
     "institutionCoursesUrl": "https://ncc.nsw.edu.au/our-courses/"

--- a/src/app/utilities/__tests__/demoDetailAccess.test.ts
+++ b/src/app/utilities/__tests__/demoDetailAccess.test.ts
@@ -37,6 +37,11 @@ describe('resolveDetailDemoAccess', () => {
     ).toEqual({
       internalSlug: 'blueprint-career-development',
     });
+    expect(
+      resolveDetailDemoAccess('nepean-community-college', EMPTY_SEARCH_PARAMS)
+    ).toEqual({
+      internalSlug: 'nepean-community-college',
+    });
   });
 
   it('returns null when demo param is missing for non-live guid path', () => {


### PR DESCRIPTION
## Summary
- Publish Nepean Community College as a live endorsed provider with a public slug URL.
- Remove Nepean from demo-only access so `ENDORSED_DEMO_ACCESS` only contains Academia and Collarts.
- Remove redundant Blueprint wording and update live-provider tests for HSH, Blueprint, and Nepean.

## Test plan
- `npm test -- --testPathPattern="EndorsedProviders|demoDetailAccess"`
- `npm run build`

## Deployment note
Set `ENDORSED_DEMO_ACCESS` in Vercel to:

```json
{"28484141-69ae-4eed-8d54-8a7522dd2c21":"academia","ee80a2e3-0494-4181-b6b7-6cec69612850":"collarts"}
```