### PR TITLE
fix: replace isomorphic-dompurify with xss to fix Vercel SSR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "axios": "^1.18.1",
         "classnames": "^2.5.1",
         "embla-carousel-react": "^8.6.0",
-        "isomorphic-dompurify": "^3.18.0",
         "next": "^16.2.10",
         "next-auth": "5.0.0-beta.31",
         "rate-limiter-flexible": "^11.2.0",
@@ -29,7 +28,8 @@
         "react-hook-form": "^7.81.0",
         "react-icons": "^5.7.0",
         "stripe": "^22.3.1",
-        "uuid": "^14.0.1"
+        "uuid": "^14.0.1",
+        "xss": "^1.0.15"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -65,7 +65,9 @@
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@csstools/css-calc": "^3.2.0",
@@ -81,7 +83,9 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -97,7 +101,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -106,7 +112,9 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@auth/core": {
       "version": "0.41.2",
@@ -1293,7 +1301,9 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -1305,6 +1315,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
       "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1316,6 +1327,7 @@
         }
       ],
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1324,6 +1336,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
       "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1335,6 +1348,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1347,6 +1361,7 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
       "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1358,6 +1373,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.1.0",
         "@csstools/css-calc": "^3.2.1"
@@ -1374,6 +1390,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1385,6 +1402,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1396,6 +1414,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
       "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1407,6 +1426,7 @@
         }
       ],
       "license": "MIT-0",
+      "peer": true,
       "peerDependencies": {
         "css-tree": "^3.2.1"
       },
@@ -1420,6 +1440,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1431,6 +1452,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1718,7 +1740,9 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -3628,13 +3652,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -4847,7 +4864,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -5228,6 +5247,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5273,7 +5298,9 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -5287,6 +5314,12 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
       "license": "MIT"
     },
     "node_modules/cssstyle": {
@@ -5457,7 +5490,9 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -5541,6 +5576,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -5670,15 +5706,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7342,7 +7369,9 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -7868,6 +7897,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -8052,19 +8082,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isomorphic-dompurify": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.18.0.tgz",
-      "integrity": "sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "^3.4.11",
-        "jsdom": "^29.1.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -9246,7 +9263,9 @@
       "version": "29.1.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -9286,7 +9305,9 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -9298,7 +9319,9 @@
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -9307,7 +9330,9 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "entities": "^8.0.0"
       },
@@ -9562,7 +9587,9 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "license": "CC0-1.0"
+      "dev": true,
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -10530,6 +10557,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10727,7 +10755,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10920,6 +10950,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -11613,6 +11644,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -11726,7 +11758,9 @@
       "version": "7.4.8",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
       "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.4.8"
       },
@@ -11738,7 +11772,9 @@
       "version": "7.4.8",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
       "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -11764,7 +11800,9 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
       "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -11776,7 +11814,9 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -12103,7 +12143,9 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.18.1"
       }
@@ -12226,6 +12268,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -12248,7 +12291,9 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -12271,7 +12316,9 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -12280,7 +12327,9 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -12551,6 +12600,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -12575,7 +12625,24 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "axios": "^1.18.1",
     "classnames": "^2.5.1",
     "embla-carousel-react": "^8.6.0",
-    "isomorphic-dompurify": "^3.18.0",
     "next": "^16.2.10",
     "next-auth": "5.0.0-beta.31",
     "rate-limiter-flexible": "^11.2.0",
@@ -35,7 +34,8 @@
     "react-hook-form": "^7.81.0",
     "react-icons": "^5.7.0",
     "stripe": "^22.3.1",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "xss": "^1.0.15"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/app/components/course/CourseDetails/CourseDetailsBody/CourseDetailsBodyText.tsx
+++ b/src/app/components/course/CourseDetails/CourseDetailsBody/CourseDetailsBodyText.tsx
@@ -1,9 +1,9 @@
-import DOMPurify from 'isomorphic-dompurify';
 import React from 'react';
 import Typography, { TypographyVariant } from '../../../typography/Typography';
 import styles from '../../CourseDetails/courseDetails.module.css';
 import ActionButton from '@/app/components/buttons/ActionButton';
 import { BUTTON_STYLE } from '@/app/utilities/constants';
+import { sanitizeHtml } from '@/app/utilities/sanitizeHtml';
 
 interface CourseDetailsBodyTextProps {
   id: string;
@@ -15,7 +15,7 @@ const CourseDetailsBodyText: React.FC<CourseDetailsBodyTextProps> = ({
   data,
 }) => {
   const paragraphs = data?.split('\n').map((paragraph, index) => {
-    const sanitizedHTML = DOMPurify.sanitize?.(paragraph);
+    const sanitizedHTML = sanitizeHtml(paragraph);
     return (
       <div key={index} className={styles.courseDetailsBodyText}>
         <Typography variant={TypographyVariant.Body2}>

--- a/src/app/components/textHeavyArticle/TextHeavyArticle.tsx
+++ b/src/app/components/textHeavyArticle/TextHeavyArticle.tsx
@@ -5,8 +5,8 @@ import Typography, { TypographyVariant } from '../typography/Typography';
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from './textHeavyArticle.module.css';
-import DOMPurify from 'isomorphic-dompurify';
 import useWindowWidth from '@/app/hooks/useWindowWidth';
+import { sanitizeHtml } from '@/app/utilities/sanitizeHtml';
 
 export default function TextHeavyArticle({
   header,
@@ -18,9 +18,9 @@ export default function TextHeavyArticle({
   const windowWidth = useWindowWidth();
 
   const paragraphs = bodyText.split('\n').map((paragraph, index) => {
-    const sanitizedHTML = DOMPurify.sanitize?.(paragraph, {
-      ADD_TAGS: ['iframe'],
-      ADD_ATTR: ['target'],
+    const sanitizedHTML = sanitizeHtml(paragraph, {
+      allowIframes: true,
+      allowTargetAttr: true,
     });
     return (
       <div key={index}>

--- a/src/app/components/textHeavyBlog/textHeavyBlog.tsx
+++ b/src/app/components/textHeavyBlog/textHeavyBlog.tsx
@@ -5,8 +5,8 @@ import Typography, { TypographyVariant } from '../typography/Typography';
 import Image from 'next/image';
 import Link from 'next/link';
 import styles from './textHeavyBlog.module.css';
-import DOMPurify from 'isomorphic-dompurify';
 import useWindowWidth from '@/app/hooks/useWindowWidth';
+import { sanitizeHtml } from '@/app/utilities/sanitizeHtml';
 
 export default function TextHeavyBlog({
   header,
@@ -16,8 +16,8 @@ export default function TextHeavyBlog({
   const windowWidth = useWindowWidth();
 
   const paragraphs = bodyText.split('\n').map((paragraph, index) => {
-    const sanitizedHTML = DOMPurify.sanitize?.(paragraph, {
-      ADD_ATTR: ['target'],
+    const sanitizedHTML = sanitizeHtml(paragraph, {
+      allowTargetAttr: true,
     });
     return (
       <div key={index}>

--- a/src/app/utilities/__tests__/sanitizeHtml.test.ts
+++ b/src/app/utilities/__tests__/sanitizeHtml.test.ts
@@ -1,0 +1,40 @@
+import { sanitizeHtml } from '../sanitizeHtml';
+
+describe('sanitizeHtml', () => {
+  it('returns empty string for nullish input', () => {
+    expect(sanitizeHtml(null)).toBe('');
+    expect(sanitizeHtml(undefined)).toBe('');
+    expect(sanitizeHtml('')).toBe('');
+  });
+
+  it('strips script tags by default', () => {
+    expect(sanitizeHtml('<p>ok</p><script>alert(1)</script>')).toBe('<p>ok</p>');
+  });
+
+  it('allows target on anchors when requested', () => {
+    const result = sanitizeHtml('<a href="https://example.com" target="_blank">link</a>', {
+      allowTargetAttr: true,
+    });
+
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('href="https://example.com"');
+  });
+
+  it('allows youtube iframes when requested', () => {
+    const result = sanitizeHtml(
+      '<iframe src="https://www.youtube.com/embed/abc" width="560" height="315"></iframe>',
+      { allowIframes: true },
+    );
+
+    expect(result).toContain('<iframe');
+    expect(result).toContain('youtube.com/embed/abc');
+  });
+
+  it('removes iframes when not allowed', () => {
+    const result = sanitizeHtml(
+      '<p>before</p><iframe src="https://www.youtube.com/embed/abc"></iframe>',
+    );
+
+    expect(result).toBe('<p>before</p>');
+  });
+});

--- a/src/app/utilities/sanitizeHtml.ts
+++ b/src/app/utilities/sanitizeHtml.ts
@@ -1,0 +1,63 @@
+import xss, { getDefaultWhiteList } from 'xss';
+import type { IFilterXSSOptions, IWhiteList } from 'xss';
+
+export interface SanitizeHtmlOptions {
+  allowIframes?: boolean;
+  allowTargetAttr?: boolean;
+}
+
+const IFRAME_ATTRIBUTES = [
+  'src',
+  'width',
+  'height',
+  'allow',
+  'allowfullscreen',
+  'frameborder',
+  'scrolling',
+  'title',
+  'referrerpolicy',
+];
+
+const ALLOWED_IFRAME_HOST_PATTERN =
+  /^(https?:)?\/\/(www\.)?(youtube\.com|youtube-nocookie\.com|player\.vimeo\.com)\//i;
+
+/**
+ * Server-safe HTML sanitizer (no jsdom). Replaces isomorphic-dompurify so
+ * Vercel/Lambda SSR never loads ESM-only jsdom transitive deps.
+ */
+export const sanitizeHtml = (
+  dirty: string | undefined | null,
+  options: SanitizeHtmlOptions = {},
+): string => {
+  if (!dirty) {
+    return '';
+  }
+
+  const { allowIframes = false, allowTargetAttr = false } = options;
+  const whiteList: IWhiteList = { ...getDefaultWhiteList() };
+
+  if (allowIframes) {
+    whiteList.iframe = IFRAME_ATTRIBUTES;
+  }
+
+  if (allowTargetAttr && whiteList.a) {
+    whiteList.a = Array.from(new Set([...whiteList.a, 'target', 'rel']));
+  }
+
+  const filterOptions: IFilterXSSOptions = {
+    whiteList,
+    stripIgnoreTag: true,
+    stripIgnoreTagBody: ['script', 'style'],
+  };
+
+  if (allowIframes) {
+    filterOptions.onTagAttr = (tag, name, value) => {
+      if (tag === 'iframe' && name === 'src' && !ALLOWED_IFRAME_HOST_PATTERN.test(value)) {
+        return '';
+      }
+      return undefined;
+    };
+  }
+
+  return xss(dirty, filterOptions);
+};


### PR DESCRIPTION
## Summary
- Remove `isomorphic-dompurify` / `jsdom` from the serverless SSR path (fixes `ERR_REQUIRE_ESM` on Vercel/Lambda even with Node 24).
- Add a shared `sanitizeHtml` util backed by `xss`, and use it for articles, blogs, and course body HTML.

## Test plan
- [ ] `npm test -- src/app/utilities/__tests__/sanitizeHtml.test.ts`
- [ ] `npx next build --turbopack && NODE_OPTIONS=--no-experimental-require-module npx next start`
- [ ] Confirm `/articles/<slug>` returns HTTP 200 with no `jsdom` / `ERR_REQUIRE_ESM` in server logs
- [ ] Spot-check article/blog HTML still renders (scripts stripped, allowed tags retained)


Made with [Cursor](https://cursor.com)