### PR TITLE
feat(endorsements): add endorsed organisations to endorsements page

### DIFF
--- a/src/app/endorsements/__tests__/page.test.tsx
+++ b/src/app/endorsements/__tests__/page.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: { alt?: string }) => <img alt={props.alt ?? ''} />,
+}));
+
+jest.mock('../../components/bannerStudents/HomeBanner', () => ({
+  __esModule: true,
+  default: () => <div data-testid='home-banner' />,
+}));
+
+jest.mock('../../components/teacherSection/Teacher', () => ({
+  __esModule: true,
+  default: () => <div data-testid='teacher' />,
+}));
+
+jest.mock('../../components/handbook', () => ({
+  __esModule: true,
+  default: () => <div data-testid='handbook' />,
+}));
+
+jest.mock('../../components/fact/Fact', () => ({
+  __esModule: true,
+  default: () => <div data-testid='fact' />,
+}));
+
+jest.mock('../../components/endorsements/EndorsementProcess', () => ({
+  __esModule: true,
+  default: () => <div data-testid='endorsement-process' />,
+}));
+
+jest.mock('../../components/partnerSection/Partner', () => ({
+  __esModule: true,
+  default: () => <div data-testid='partner' />,
+}));
+
+jest.mock('../../components/podcast/DisplayPodcast', () => ({
+  __esModule: true,
+  default: () => <div data-testid='podcast' />,
+}));
+
+jest.mock('../../components/articleList/articleList', () => ({
+  __esModule: true,
+  default: () => <div data-testid='article-list' />,
+}));
+
+jest.mock('../../components/subscribe/subscribe', () => ({
+  __esModule: true,
+  default: () => <div data-testid='subscribe' />,
+}));
+
+jest.mock('../../components/accordion/Accordian', () => ({
+  __esModule: true,
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div data-testid='accordion'>
+      <h3>{title}</h3>
+      {children}
+    </div>
+  ),
+}));
+
+import Page from '../page';
+
+describe('Endorsements page', () => {
+  it('renders live endorsed organisations', () => {
+    render(<Page />);
+
+    expect(screen.getByText('NDA Endorsed Providers')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Explore More' })).toHaveLength(4);
+  });
+});

--- a/src/app/endorsements/page.tsx
+++ b/src/app/endorsements/page.tsx
@@ -5,6 +5,7 @@ import EndorsementProcess from '../components/endorsements/EndorsementProcess';
 import Teacher from '../components/teacherSection/Teacher';
 import Handbook from '../components/handbook';
 import Fact from '../components/fact/Fact';
+import EndorsedProviders from '../components/endorsedProviders/EndorsedProviders';
 import Partner from '../components/partnerSection/Partner';
 import DisplayPodcast from '../components/podcast/DisplayPodcast';
 import ArticleList from '../components/articleList/articleList';
@@ -28,6 +29,7 @@ export default function Page() {
       <Handbook />
       <Fact />
       <EndorsementProcess />
+      <EndorsedProviders />
       <Partner />
       <DisplayPodcast
         scriptSrc='https://www.buzzsprout.com/2132579.js?container_id=buzzsprout-large-player&player=large'


### PR DESCRIPTION
## Summary
- Renders the existing `EndorsedProviders` listing on `/endorsements` (after the endorsement process, before partners)
- Adds a page smoke test asserting the four live provider CTAs appear

## Test plan
- [x] `npx jest` endorsements page + EndorsedProviders tests
- [x] `npm run format:check`, `lint`, `typecheck`
- [x] `npm run test:ci` + `coverage:changed`
- [x] `npx next build`
- [ ] Confirm `/endorsements` shows Nepean, HSH, Blueprint, and Collarts cards in preview
- [ ] Click through to `/endorsedproviders/[slug]` from each card


Made with [Cursor](https://cursor.com)