### PR TITLE
refactor(test): centralise shared Jest mocks in testUtils

### DIFF
--- a/src/app/components/LearnMore/__tests__/LearnMore.test.tsx
+++ b/src/app/components/LearnMore/__tests__/LearnMore.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/__tests__/presentationalSections.test.tsx
+++ b/src/app/components/__tests__/presentationalSections.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('../article/card', () => ({
   __esModule: true,

--- a/src/app/components/about/__tests__/aboutPages.test.tsx
+++ b/src/app/components/about/__tests__/aboutPages.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import Founders from '../../aboutFounders/Founders';
 import Journey from '../../aboutJourney/Journey';

--- a/src/app/components/aboutAdvisors/__tests__/Advisors.test.tsx
+++ b/src/app/components/aboutAdvisors/__tests__/Advisors.test.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import Advisors from '../Advisors';
 

--- a/src/app/components/article/__tests__/Article.test.tsx
+++ b/src/app/components/article/__tests__/Article.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _fill, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/article/__tests__/card.test.tsx
+++ b/src/app/components/article/__tests__/card.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/navigation', () => ({
   useSearchParams: jest.fn(),

--- a/src/app/components/auth/__tests__/auth.test.tsx
+++ b/src/app/components/auth/__tests__/auth.test.tsx
@@ -16,13 +16,7 @@ jest.mock('next/navigation', () => ({
   usePathname: () => '/test',
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _priority, _fill, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/badges/__tests__/BadgeDisplay.test.tsx
+++ b/src/app/components/badges/__tests__/BadgeDisplay.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import BadgeDisplay from '../BadgeDisplay';
 

--- a/src/app/components/banner/__tests__/HomeBanner.test.tsx
+++ b/src/app/components/banner/__tests__/HomeBanner.test.tsx
@@ -1,26 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-  getImageProps: ({
-    src,
-    alt,
-    className,
-  }: {
-    src?: { src?: string } | string;
-    alt?: string;
-    className?: string;
-  }) => ({
-    props: {
-      src: typeof src === 'string' ? src : (src?.src ?? '/hero.webp'),
-      srcSet: typeof src === 'string' ? src : (src?.src ?? '/hero.webp'),
-      alt: alt ?? '',
-      className,
-    },
-  }),
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/bannerStudents/__tests__/HomeBanner.test.tsx
+++ b/src/app/components/bannerStudents/__tests__/HomeBanner.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/blog/__tests__/Blog.test.tsx
+++ b/src/app/components/blog/__tests__/Blog.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _fill, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/blog/__tests__/BlogCardList.test.tsx
+++ b/src/app/components/blog/__tests__/BlogCardList.test.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ReadonlyURLSearchParams } from 'next/navigation';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('../Blog', () => ({
   __esModule: true,

--- a/src/app/components/buttons/__tests__/Buttons.test.tsx
+++ b/src/app/components/buttons/__tests__/Buttons.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/contactUs/__tests__/ContactUs.test.tsx
+++ b/src/app/components/contactUs/__tests__/ContactUs.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/contactUs/__tests__/ContactUsForm.test.tsx
+++ b/src/app/components/contactUs/__tests__/ContactUsForm.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/utilities/register/registerContactData', () => ({
   registerContactData: jest.fn(),

--- a/src/app/components/course/ApplyNowPopup/__tests__/ApplyNowPopup.test.tsx
+++ b/src/app/components/course/ApplyNowPopup/__tests__/ApplyNowPopup.test.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _quality, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/hooks/useHideOverflowEffect', () => ({
   __esModule: true,

--- a/src/app/components/course/CourseDetails/CourseDetailsBody/__tests__/CourseDetailsBodyText.test.tsx
+++ b/src/app/components/course/CourseDetails/CourseDetailsBody/__tests__/CourseDetailsBodyText.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/course/CourseDetails/CourseDetailsMiddleBanner/__tests__/CourseDetailsMiddleBanner.test.tsx
+++ b/src/app/components/course/CourseDetails/CourseDetailsMiddleBanner/__tests__/CourseDetailsMiddleBanner.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import CourseDetailsMiddleBanner from '../CourseDetailsMiddleBanner';
 import CourseDetailsProvider from '@/app/utilities/course/CourseDetailsProvider';

--- a/src/app/components/course/CourseDetails/CourseDetailsTopBanner/__tests__/CourseDetailsTopBanner.test.tsx
+++ b/src/app/components/course/CourseDetails/CourseDetailsTopBanner/__tests__/CourseDetailsTopBanner.test.tsx
@@ -3,13 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CourseDetailsProps } from '@/app/interfaces/Course';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _priority, _fill, _quality, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('../../CourseDetailsMiddleBanner/CourseDetailsMiddleBanner', () => ({
   __esModule: true,

--- a/src/app/components/course/CourseEnrolPrompt/__tests__/CourseEnrolPrompt.test.tsx
+++ b/src/app/components/course/CourseEnrolPrompt/__tests__/CourseEnrolPrompt.test.tsx
@@ -26,13 +26,7 @@ jest.mock('@/app/utilities/course/createCheckoutUrl', () => ({
   default: (...args: unknown[]) => mockCreateCheckoutUrl(...args),
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _priority, _fill, _quality, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import { useSession } from 'next-auth/react';
 import CourseEnrolPrompt from '../index';

--- a/src/app/components/course/CoursePrimaryFilter/__tests__/CoursePrimaryFilter.test.tsx
+++ b/src/app/components/course/CoursePrimaryFilter/__tests__/CoursePrimaryFilter.test.tsx
@@ -9,10 +9,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/hooks/useUpdatedValue', () => ({
   __esModule: true,

--- a/src/app/components/course/CourseSearch/__tests__/CourseSearchResult.test.tsx
+++ b/src/app/components/course/CourseSearch/__tests__/CourseSearchResult.test.tsx
@@ -3,13 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 
 const mockLoadData = jest.fn();
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _priority, _fill, _quality, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/course/CourseSecondaryFilter/__tests__/CourseSecondaryFilter.test.tsx
+++ b/src/app/components/course/CourseSecondaryFilter/__tests__/CourseSecondaryFilter.test.tsx
@@ -3,10 +3,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 
 const mockLoadData = jest.fn();
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/hooks/useUpdatedValue', () => ({
   __esModule: true,

--- a/src/app/components/course/__tests__/course.test.tsx
+++ b/src/app/components/course/__tests__/course.test.tsx
@@ -16,13 +16,7 @@ jest.mock('next/navigation', () => ({
   usePathname: () => '/courses',
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _priority, _fill, _quality, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/emergingInstitutions/__tests__/EmergingInstitutionCard.test.tsx
+++ b/src/app/components/emergingInstitutions/__tests__/EmergingInstitutionCard.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/emergingInstitutions/__tests__/EmergingInstitutions.test.tsx
+++ b/src/app/components/emergingInstitutions/__tests__/EmergingInstitutions.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,
@@ -62,15 +59,7 @@ jest.mock(
   }),
 );
 
-jest.mock('../../accordion/Accordian', () => ({
-  __esModule: true,
-  default: ({ title, children }: { title: React.ReactNode; children: React.ReactNode }) => (
-    <div data-testid='accordion'>
-      <div data-testid='accordion-title'>{typeof title === 'string' ? title : title}</div>
-      <div>{children}</div>
-    </div>
-  ),
-}));
+jest.mock('../../accordion/Accordian', () => require('@/testUtils/mockAccordion'));
 
 const mockStatIcon = {
   src: '/test.png',

--- a/src/app/components/emergingInstitutions/__tests__/EmergingProviderStudentSuitability.test.tsx
+++ b/src/app/components/emergingInstitutions/__tests__/EmergingProviderStudentSuitability.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import EmergingProviderStudentSuitability from '../EmergingProviderStudentSuitability';
 

--- a/src/app/components/endorsedProviders/__tests__/EndorsedCertifiedBadge.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedCertifiedBadge.test.tsx
@@ -1,10 +1,7 @@
 import { render } from '@testing-library/react';
 import EndorsedCertifiedBadge from '../EndorsedCertifiedBadge';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: { alt: string }) => <img alt={props.alt} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 describe('EndorsedCertifiedBadge', () => {
   it('renders gold star when certified', () => {

--- a/src/app/components/endorsedProviders/__tests__/EndorsedInstitutionCoverHero.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedInstitutionCoverHero.test.tsx
@@ -7,10 +7,7 @@ import {
 } from '@/app/utilities/__tests__/gaTestHelpers';
 import { NDA_CERTIFIED_LEGEND } from '@/app/utilities/endorsedProvidersDemo';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: { alt: string }) => <img alt={props.alt} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock(
   '@/app/components/course/CourseDetails/CourseDetailsMiddleBanner/CourseDetailsMiddleBannerIcon',

--- a/src/app/components/endorsedProviders/__tests__/EndorsedProviderEnhancements.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedProviderEnhancements.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _fill, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import EndorsedProviderEnhancements from '../EndorsedProviderEnhancements';
 import type { SupportFrameworkSection } from '../endorsedProviderPageData';

--- a/src/app/components/endorsedProviders/__tests__/EndorsedProviders.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedProviders.test.tsx
@@ -6,10 +6,7 @@ import {
 } from '@/app/utilities/demoAccess';
 import { NDA_CERTIFIED_LEGEND } from '@/app/utilities/endorsedProvidersDemo';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: { alt: string }) => <img alt={props.alt} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 describe('EndorsedProviders demo access', () => {
   it('renders live provider cards without demo props', () => {

--- a/src/app/components/endorsedProviders/__tests__/EndorsedProvidersFAQs.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedProvidersFAQs.test.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('@/app/components/accordion/Accordian', () => ({
-  __esModule: true,
-  default: ({ title, children }: { title: React.ReactNode; children: React.ReactNode }) => (
-    <div data-testid='accordion'>
-      <div>{title}</div>
-      <div>{children}</div>
-    </div>
-  ),
-}));
+jest.mock('@/app/components/accordion/Accordian', () => require('@/testUtils/mockAccordion'));
 
 import EndorsedProvidersFAQs from '../EndorsedProvidersFAQs';
 import type { EndorsedFaqSection } from '../endorsedProviderPageData';

--- a/src/app/components/endorsedProviders/__tests__/EndorsedVetKeyDataPoints.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/EndorsedVetKeyDataPoints.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { _fill, _quality, ...rest } = props;
-    return <img {...rest} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import EndorsedVetKeyDataPoints from '../EndorsedVetKeyDataPoints';
 import type { VetKeyDataPoint } from '../endorsedProviderPageData';

--- a/src/app/components/endorsements/__tests__/EndorsementProcess.test.tsx
+++ b/src/app/components/endorsements/__tests__/EndorsementProcess.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import EndorsementProcess from '../EndorsementProcess';
 

--- a/src/app/components/exploreMore/__tests__/ExploreMore.test.tsx
+++ b/src/app/components/exploreMore/__tests__/ExploreMore.test.tsx
@@ -12,10 +12,7 @@ jest.mock('next/navigation', () => ({
   usePathname: () => '/test',
 }));
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/footer/__tests__/Footer.test.tsx
+++ b/src/app/components/footer/__tests__/Footer.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/formElements/ClearButton/__tests__/ClearButton.test.tsx
+++ b/src/app/components/formElements/ClearButton/__tests__/ClearButton.test.tsx
@@ -3,10 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { useForm, useWatch, FormProvider } from 'react-hook-form';
 import ClearButton from '../ClearButton';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} alt='' />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 interface FormValues {
   name: string;

--- a/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
+++ b/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
@@ -3,17 +3,7 @@ import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { useForm, FormProvider, FieldValues } from 'react-hook-form';
 import Dropdown from '../Dropdown';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} alt='' />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 interface WrapperProps {
   children: React.ReactNode;

--- a/src/app/components/formElements/Pill/__tests__/Pill.test.tsx
+++ b/src/app/components/formElements/Pill/__tests__/Pill.test.tsx
@@ -3,10 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import Pill from '../Pill';
 import { PillRef } from '@/app/interfaces/Pill';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} alt='' />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 describe('Pill', () => {
   it('renders label text', () => {

--- a/src/app/components/formElements/__tests__/formElements.test.tsx
+++ b/src/app/components/formElements/__tests__/formElements.test.tsx
@@ -9,17 +9,7 @@ import Radio from '../Radio/Radio';
 import Toggle from '../Toggle/Toggle';
 import Slider from '../Slider/Slider';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 interface WrapperProps {
   children: React.ReactNode;

--- a/src/app/components/handbook/__tests__/Handbook.test.tsx
+++ b/src/app/components/handbook/__tests__/Handbook.test.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/hooks/useHideOverflowEffect', () => ({
   __esModule: true,

--- a/src/app/components/handbook/__tests__/HandbookPopup.test.tsx
+++ b/src/app/components/handbook/__tests__/HandbookPopup.test.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/hooks/useHideOverflowEffect', () => ({
   __esModule: true,

--- a/src/app/components/howItWorks/__tests__/HowItWorks.test.tsx
+++ b/src/app/components/howItWorks/__tests__/HowItWorks.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import HowItWorks from '../HowItWorks';
 

--- a/src/app/components/navbar/__tests__/Navbar.test.tsx
+++ b/src/app/components/navbar/__tests__/Navbar.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { onClick, ...rest } = props;
-    return <img {...rest} onClick={onClick as React.MouseEventHandler<HTMLImageElement>} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/navbar/__tests__/UserOutlet.test.tsx
+++ b/src/app/components/navbar/__tests__/UserOutlet.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/partnerSection/__tests__/Partner.test.tsx
+++ b/src/app/components/partnerSection/__tests__/Partner.test.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, alt, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} alt={alt as string} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 const mockScrollPrev = jest.fn();
 const mockScrollNext = jest.fn();

--- a/src/app/components/podcast/__tests__/Podcast.test.tsx
+++ b/src/app/components/podcast/__tests__/Podcast.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/ProfileAttributes/__tests__/ProfileAttribute.test.tsx
+++ b/src/app/components/profile/ProfileAttributes/__tests__/ProfileAttribute.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/ProfileAttributes/__tests__/ProfileAttributes.test.tsx
+++ b/src/app/components/profile/ProfileAttributes/__tests__/ProfileAttributes.test.tsx
@@ -7,10 +7,7 @@ import {
   STRATEGY_FIELDS,
 } from '@/app/utilities/profile/constants';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/ProfileGoalSection/__tests__/Form.test.tsx
+++ b/src/app/components/profile/ProfileGoalSection/__tests__/Form.test.tsx
@@ -2,10 +2,7 @@ import React, { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ProfileSectionRef } from '@/app/interfaces/Profile';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/ProfileInfoSection/__tests__/ProfileInfoSection.test.tsx
+++ b/src/app/components/profile/ProfileInfoSection/__tests__/ProfileInfoSection.test.tsx
@@ -2,10 +2,7 @@ import React, { createRef } from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ProfileSectionRef } from '@/app/interfaces/Profile';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/ProfilePreferenceSection/__tests__/Form.test.tsx
+++ b/src/app/components/profile/ProfilePreferenceSection/__tests__/Form.test.tsx
@@ -2,10 +2,7 @@ import React, { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ProfileSectionRef } from '@/app/interfaces/Profile';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/ProfileStrategySection/__tests__/Form.test.tsx
+++ b/src/app/components/profile/ProfileStrategySection/__tests__/Form.test.tsx
@@ -2,10 +2,7 @@ import React, { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ProfileSectionRef } from '@/app/interfaces/Profile';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/__tests__/Profile.test.tsx
+++ b/src/app/components/profile/__tests__/Profile.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { onClick, ...rest } = props;
-    return <img {...rest} onClick={onClick as React.MouseEventHandler<HTMLImageElement>} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/__tests__/ProfileBody.test.tsx
+++ b/src/app/components/profile/__tests__/ProfileBody.test.tsx
@@ -1,10 +1,7 @@
 import React, { forwardRef, useImperativeHandle } from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/profile/__tests__/ProfileSections.test.tsx
+++ b/src/app/components/profile/__tests__/ProfileSections.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/subscribe/__tests__/subscribe.test.tsx
+++ b/src/app/components/subscribe/__tests__/subscribe.test.tsx
@@ -1,17 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => {
-    const { src, fill: _fill, ...rest } = props;
-    const imgSrc =
-      typeof src === 'object' && src !== null
-        ? (src as { src?: string }).src || ''
-        : String(src || '');
-    return <img {...rest} src={imgSrc} />;
-  },
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('@/app/utilities/register/registerSubscriptionData', () => ({
   registerSubscriptionData: jest.fn(),

--- a/src/app/components/tabSection/__tests__/CourseDetailsBenefitsBody.test.tsx
+++ b/src/app/components/tabSection/__tests__/CourseDetailsBenefitsBody.test.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('@/app/components/accordion/Accordian', () => ({
-  __esModule: true,
-  default: ({ title, children }: { title: React.ReactNode; children: React.ReactNode }) => (
-    <div data-testid='accordion'>
-      <div data-testid='accordion-title'>{title}</div>
-      <div>{children}</div>
-    </div>
-  ),
-}));
+jest.mock('@/app/components/accordion/Accordian', () => require('@/testUtils/mockAccordion'));
 
 jest.mock('@/app/utilities/course/CourseDetailsProvider', () => {
   const React = require('react');

--- a/src/app/components/tabSection/__tests__/TabSection.test.tsx
+++ b/src/app/components/tabSection/__tests__/TabSection.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 import TabSection, { TabSectionTab } from '../TabSection';
 import TabSectionStringList from '../TabSectionStringList';

--- a/src/app/components/teacherSection/__tests__/Teacher.test.tsx
+++ b/src/app/components/teacherSection/__tests__/Teacher.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/textHeavyArticle/__tests__/TextHeavyArticle.test.tsx
+++ b/src/app/components/textHeavyArticle/__tests__/TextHeavyArticle.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/textHeavyBlog/__tests__/textHeavyBlog.test.tsx
+++ b/src/app/components/textHeavyBlog/__tests__/textHeavyBlog.test.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 jest.mock('next/link', () => ({
   __esModule: true,

--- a/src/app/components/typography/__tests__/Typography.test.tsx
+++ b/src/app/components/typography/__tests__/Typography.test.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Typography, { TypographyVariant } from '../Typography';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: Record<string, unknown>) => <img {...props} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 describe('Typography', () => {
   it('renders children text', () => {

--- a/src/app/endorsements/__tests__/page.test.tsx
+++ b/src/app/endorsements/__tests__/page.test.tsx
@@ -1,65 +1,42 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: { alt?: string }) => <img alt={props.alt ?? ''} />,
-}));
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
-jest.mock('../../components/bannerStudents/HomeBanner', () => ({
-  __esModule: true,
-  default: () => <div data-testid='home-banner' />,
-}));
-
-jest.mock('../../components/teacherSection/Teacher', () => ({
-  __esModule: true,
-  default: () => <div data-testid='teacher' />,
-}));
-
-jest.mock('../../components/handbook', () => ({
-  __esModule: true,
-  default: () => <div data-testid='handbook' />,
-}));
-
-jest.mock('../../components/fact/Fact', () => ({
-  __esModule: true,
-  default: () => <div data-testid='fact' />,
-}));
-
-jest.mock('../../components/endorsements/EndorsementProcess', () => ({
-  __esModule: true,
-  default: () => <div data-testid='endorsement-process' />,
-}));
-
-jest.mock('../../components/partnerSection/Partner', () => ({
-  __esModule: true,
-  default: () => <div data-testid='partner' />,
-}));
-
-jest.mock('../../components/podcast/DisplayPodcast', () => ({
-  __esModule: true,
-  default: () => <div data-testid='podcast' />,
-}));
-
-jest.mock('../../components/articleList/articleList', () => ({
-  __esModule: true,
-  default: () => <div data-testid='article-list' />,
-}));
-
-jest.mock('../../components/subscribe/subscribe', () => ({
-  __esModule: true,
-  default: () => <div data-testid='subscribe' />,
-}));
-
-jest.mock('../../components/accordion/Accordian', () => ({
-  __esModule: true,
-  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
-    <div data-testid='accordion'>
-      <h3>{title}</h3>
-      {children}
-    </div>
-  ),
-}));
+jest.mock(
+  '../../components/bannerStudents/HomeBanner',
+  () => require('@/testUtils/mockPageSectionStubs').mockHomeBanner,
+);
+jest.mock(
+  '../../components/teacherSection/Teacher',
+  () => require('@/testUtils/mockPageSectionStubs').mockTeacher,
+);
+jest.mock(
+  '../../components/handbook',
+  () => require('@/testUtils/mockPageSectionStubs').mockHandbook,
+);
+jest.mock('../../components/fact/Fact', () => require('@/testUtils/mockPageSectionStubs').mockFact);
+jest.mock(
+  '../../components/endorsements/EndorsementProcess',
+  () => require('@/testUtils/mockPageSectionStubs').mockEndorsementProcess,
+);
+jest.mock(
+  '../../components/partnerSection/Partner',
+  () => require('@/testUtils/mockPageSectionStubs').mockPartner,
+);
+jest.mock(
+  '../../components/podcast/DisplayPodcast',
+  () => require('@/testUtils/mockPageSectionStubs').mockDisplayPodcast,
+);
+jest.mock(
+  '../../components/articleList/articleList',
+  () => require('@/testUtils/mockPageSectionStubs').mockArticleList,
+);
+jest.mock(
+  '../../components/subscribe/subscribe',
+  () => require('@/testUtils/mockPageSectionStubs').mockSubscribe,
+);
+jest.mock('../../components/accordion/Accordian', () => require('@/testUtils/mockAccordion'));
 
 import Page from '../page';
 

--- a/src/testUtils/createStubComponent.tsx
+++ b/src/testUtils/createStubComponent.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+/**
+ * Builds a minimal presentational stub for page/section components in tests.
+ */
+export function createStubComponent(testId: string): React.FC {
+  const Stub: React.FC = () => <div data-testid={testId} />;
+  Stub.displayName = `Stub(${testId})`;
+  return Stub;
+}
+
+/**
+ * Jest module shape for `jest.mock(path, () => require(...).mockX)`.
+ */
+export function createStubModule(testId: string): {
+  __esModule: true;
+  default: React.FC;
+} {
+  return {
+    __esModule: true,
+    default: createStubComponent(testId),
+  };
+}

--- a/src/testUtils/mockAccordion.tsx
+++ b/src/testUtils/mockAccordion.tsx
@@ -1,0 +1,20 @@
+/**
+ * Shared mock for Accordion.
+ * Usage:
+ *   jest.mock('@/app/components/accordion/Accordian', () => require('@/testUtils/mockAccordion'));
+ */
+import React from 'react';
+
+interface MockAccordionProps {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const MockAccordion = ({ title, children }: MockAccordionProps): React.ReactElement => (
+  <div data-testid='accordion'>
+    <div data-testid='accordion-title'>{title}</div>
+    <div>{children}</div>
+  </div>
+);
+
+export default MockAccordion;

--- a/src/testUtils/mockNextImage.tsx
+++ b/src/testUtils/mockNextImage.tsx
@@ -1,0 +1,72 @@
+/**
+ * Shared mock for next/image.
+ * Usage: jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
+ */
+import React from 'react';
+
+const NEXT_IMAGE_ONLY_PROPS = [
+  'fill',
+  'priority',
+  'quality',
+  'placeholder',
+  'blurDataURL',
+  'loader',
+  'unoptimized',
+  'onLoadingComplete',
+] as const;
+
+type NextImageOnlyProp = (typeof NEXT_IMAGE_ONLY_PROPS)[number];
+
+interface MockNextImageProps {
+  alt?: string;
+  src?: string | { src?: string } | null;
+  [key: string]: unknown;
+}
+
+interface GetImagePropsArgs {
+  src?: string | { src?: string };
+  alt?: string;
+  className?: string;
+}
+
+const resolveSrc = (src: MockNextImageProps['src']): string => {
+  if (typeof src === 'object' && src !== null) {
+    return src.src ?? '';
+  }
+  return String(src ?? '');
+};
+
+const omitNextOnlyProps = (props: MockNextImageProps): Record<string, unknown> => {
+  const rest: Record<string, unknown> = { ...props };
+  for (const key of NEXT_IMAGE_ONLY_PROPS) {
+    delete rest[key as NextImageOnlyProp];
+  }
+  delete rest.src;
+  delete rest.alt;
+  return rest;
+};
+
+const MockNextImage = ({ alt = '', src, ...rest }: MockNextImageProps): React.ReactElement => {
+  const imgProps = omitNextOnlyProps({ alt, src, ...rest });
+  // Test stub — next/image is not available in Jest.
+  // eslint-disable-next-line @next/next/no-img-element -- intentional Jest stub
+  return <img alt={alt} src={resolveSrc(src)} {...imgProps} />;
+};
+
+export const getImageProps = ({
+  src,
+  alt,
+  className,
+}: GetImagePropsArgs): { props: Record<string, string | undefined> } => {
+  const resolvedSrc = resolveSrc(src) || '/hero.webp';
+  return {
+    props: {
+      src: resolvedSrc,
+      srcSet: resolvedSrc,
+      alt: alt ?? '',
+      className,
+    },
+  };
+};
+
+export default MockNextImage;

--- a/src/testUtils/mockPageSectionStubs.tsx
+++ b/src/testUtils/mockPageSectionStubs.tsx
@@ -1,0 +1,19 @@
+/**
+ * Shared page/section stubs for composition tests (e.g. endorsements page).
+ *
+ * Usage:
+ *   jest.mock('../components/fact/Fact', () =>
+ *     require('@/testUtils/mockPageSectionStubs').mockFact,
+ *   );
+ */
+import { createStubModule } from './createStubComponent';
+
+export const mockHomeBanner = createStubModule('home-banner');
+export const mockTeacher = createStubModule('teacher');
+export const mockHandbook = createStubModule('handbook');
+export const mockFact = createStubModule('fact');
+export const mockEndorsementProcess = createStubModule('endorsement-process');
+export const mockPartner = createStubModule('partner');
+export const mockDisplayPodcast = createStubModule('podcast');
+export const mockArticleList = createStubModule('article-list');
+export const mockSubscribe = createStubModule('subscribe');


### PR DESCRIPTION
## Summary
- Adds shared `src/testUtils` mocks for `next/image`, Accordion, stub components, and endorsements page sections
- Migrates all inline `next/image` test mocks (and Accordion duplicates) to the shared modules

## Test plan
- [x] `npm run format:check` / `lint`
- [x] Spot-check key suites + full `test:ci` (auth/enrol flakes under parallel load still pass in isolation)
- [ ] Confirm Vercel/Netlify checks pass on this PR


Made with [Cursor](https://cursor.com)