### PR TITLE
feat(analytics): track live contact, subscribe, and handbook conversions

### DIFF
--- a/src/app/components/contactUs/ContactUsForm.tsx
+++ b/src/app/components/contactUs/ContactUsForm.tsx
@@ -18,6 +18,8 @@ import { registerContactData } from '@/app/utilities/register/registerContactDat
 import Form from '@/app/components/formElements/Form';
 import { FieldValues, UseFormReturn, useForm } from 'react-hook-form';
 import { notifyError, notifySuccess } from '@/app/utilities/common';
+import { sendContactSubmitEvent } from '@/app/utilities/gaTracking';
+import { sendMetaContactLeadEvent } from '@/app/utilities/metaPixelTracking';
 import LoaderWrapper from '../loader/LoaderWrapper';
 import ContactUsLeftBanner from './ContactUsLeftBanner';
 import classNames from 'classnames';
@@ -67,6 +69,8 @@ const ContactUsForm: React.FC = () => {
       )) as CRMCreateResponseInterface;
       if (outcome.id) {
         notifySuccess('Successfully sent');
+        sendContactSubmitEvent(hs_persona);
+        sendMetaContactLeadEvent();
       }
     } catch (error) {
       notifyError(error as object);

--- a/src/app/components/contactUs/__tests__/ContactUsForm.test.tsx
+++ b/src/app/components/contactUs/__tests__/ContactUsForm.test.tsx
@@ -12,13 +12,25 @@ jest.mock('@/app/utilities/common', () => ({
   notifySuccess: jest.fn(),
 }));
 
+jest.mock('@/app/utilities/gaTracking', () => ({
+  sendContactSubmitEvent: jest.fn(),
+}));
+
+jest.mock('@/app/utilities/metaPixelTracking', () => ({
+  sendMetaContactLeadEvent: jest.fn(),
+}));
+
 import { registerContactData } from '@/app/utilities/register/registerContactData';
 import { notifyError, notifySuccess } from '@/app/utilities/common';
+import { sendContactSubmitEvent } from '@/app/utilities/gaTracking';
+import { sendMetaContactLeadEvent } from '@/app/utilities/metaPixelTracking';
 import ContactUsForm from '../ContactUsForm';
 
 const mockRegisterContactData = registerContactData as jest.Mock;
 const mockNotifySuccess = notifySuccess as jest.Mock;
 const mockNotifyError = notifyError as jest.Mock;
+const mockSendContactSubmitEvent = sendContactSubmitEvent as jest.Mock;
+const mockSendMetaContactLeadEvent = sendMetaContactLeadEvent as jest.Mock;
 
 const selectPersona = (label: string) => {
   fireEvent.focus(screen.getByPlaceholderText('Select your role'));
@@ -91,10 +103,12 @@ describe('ContactUsForm', () => {
         hs_persona: 'persona_1',
       });
       expect(mockNotifySuccess).toHaveBeenCalledWith('Successfully sent');
+      expect(mockSendContactSubmitEvent).toHaveBeenCalledWith('persona_1');
+      expect(mockSendMetaContactLeadEvent).toHaveBeenCalled();
     });
   });
 
-  it('shows error notification when submission fails', async () => {
+  it('does not fire conversion events when submission fails', async () => {
     const error = new Error('Submission failed');
     mockRegisterContactData.mockRejectedValue(error);
     render(<ContactUsForm />);
@@ -106,6 +120,25 @@ describe('ContactUsForm', () => {
 
     await waitFor(() => {
       expect(mockNotifyError).toHaveBeenCalledWith(error);
+      expect(mockSendContactSubmitEvent).not.toHaveBeenCalled();
+      expect(mockSendMetaContactLeadEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not fire conversion events when response has no id', async () => {
+    mockRegisterContactData.mockResolvedValue({});
+    render(<ContactUsForm />);
+    fillRequiredContactFields();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Submit'));
+    });
+
+    await waitFor(() => {
+      expect(mockRegisterContactData).toHaveBeenCalled();
+      expect(mockNotifySuccess).not.toHaveBeenCalled();
+      expect(mockSendContactSubmitEvent).not.toHaveBeenCalled();
+      expect(mockSendMetaContactLeadEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/handbook/HandbookPopup.tsx
+++ b/src/app/components/handbook/HandbookPopup.tsx
@@ -14,6 +14,8 @@ import mailBoxLadySrc from '@/app/images/mailboxLady.png';
 import Typography, { TypographyVariant } from '../typography/Typography';
 import { registerSubscriptionData } from '@/app/utilities/register/registerSubscriptionData';
 import { notifyError } from '@/app/utilities/common';
+import { sendHandbookDownloadEvent } from '@/app/utilities/gaTracking';
+import { sendMetaHandbookDownloadEvent } from '@/app/utilities/metaPixelTracking';
 import Dropdown from '../formElements/Dropdown/Dropdown';
 import { HSPersona } from '@/app/interfaces/UserSubscriptionType';
 
@@ -48,6 +50,8 @@ export default function HandbookPopup({ open, onClose }: HandbookPopupProps) {
       });
 
       setIsDownloadComplete(true);
+      sendHandbookDownloadEvent(data.hs_persona);
+      sendMetaHandbookDownloadEvent();
     } catch (ex) {
       notifyError(ex as object);
     } finally {

--- a/src/app/components/handbook/__tests__/HandbookPopup.test.tsx
+++ b/src/app/components/handbook/__tests__/HandbookPopup.test.tsx
@@ -16,12 +16,24 @@ jest.mock('@/app/utilities/common', () => ({
   notifyError: jest.fn(),
 }));
 
+jest.mock('@/app/utilities/gaTracking', () => ({
+  sendHandbookDownloadEvent: jest.fn(),
+}));
+
+jest.mock('@/app/utilities/metaPixelTracking', () => ({
+  sendMetaHandbookDownloadEvent: jest.fn(),
+}));
+
 import { registerSubscriptionData } from '@/app/utilities/register/registerSubscriptionData';
 import { notifyError } from '@/app/utilities/common';
+import { sendHandbookDownloadEvent } from '@/app/utilities/gaTracking';
+import { sendMetaHandbookDownloadEvent } from '@/app/utilities/metaPixelTracking';
 import HandbookPopup from '../HandbookPopup';
 
 const mockRegisterSubscriptionData = registerSubscriptionData as jest.Mock;
 const mockNotifyError = notifyError as jest.Mock;
+const mockSendHandbookDownloadEvent = sendHandbookDownloadEvent as jest.Mock;
+const mockSendMetaHandbookDownloadEvent = sendMetaHandbookDownloadEvent as jest.Mock;
 
 const fillHandbookForm = () => {
   fireEvent.change(screen.getByPlaceholderText('Email address'), {
@@ -62,6 +74,8 @@ describe('HandbookPopup', () => {
         getHandbook: true,
       });
       expect(screen.getByText('Your file is ready to be downloaded...')).toBeInTheDocument();
+      expect(mockSendHandbookDownloadEvent).toHaveBeenCalledWith('persona_2');
+      expect(mockSendMetaHandbookDownloadEvent).toHaveBeenCalled();
     });
   });
 
@@ -84,6 +98,8 @@ describe('HandbookPopup', () => {
 
     await waitFor(() => {
       expect(mockNotifyError).toHaveBeenCalledWith(error);
+      expect(mockSendHandbookDownloadEvent).not.toHaveBeenCalled();
+      expect(mockSendMetaHandbookDownloadEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/subscribe/__tests__/subscribe.test.tsx
+++ b/src/app/components/subscribe/__tests__/subscribe.test.tsx
@@ -11,12 +11,24 @@ jest.mock('@/app/utilities/common', () => ({
   notifyError: jest.fn(),
 }));
 
+jest.mock('@/app/utilities/gaTracking', () => ({
+  sendNewsletterSubscribeEvent: jest.fn(),
+}));
+
+jest.mock('@/app/utilities/metaPixelTracking', () => ({
+  sendMetaNewsletterSubscribeEvent: jest.fn(),
+}));
+
 import { registerSubscriptionData } from '@/app/utilities/register/registerSubscriptionData';
 import { notifyError } from '@/app/utilities/common';
+import { sendNewsletterSubscribeEvent } from '@/app/utilities/gaTracking';
+import { sendMetaNewsletterSubscribeEvent } from '@/app/utilities/metaPixelTracking';
 import Subscribe from '../subscribe';
 
 const mockRegisterSubscriptionData = registerSubscriptionData as jest.Mock;
 const mockNotifyError = notifyError as jest.Mock;
+const mockSendNewsletterSubscribeEvent = sendNewsletterSubscribeEvent as jest.Mock;
+const mockSendMetaNewsletterSubscribeEvent = sendMetaNewsletterSubscribeEvent as jest.Mock;
 
 const fillSubscribeForm = () => {
   fireEvent.change(screen.getByPlaceholderText('Email address'), {
@@ -65,6 +77,8 @@ describe('Subscribe', () => {
       });
       expect(screen.getByText('Thank you for subscribing to')).toBeInTheDocument();
       expect(screen.getByText('Neurodiversity Academy!')).toBeInTheDocument();
+      expect(mockSendNewsletterSubscribeEvent).toHaveBeenCalledWith('persona_3');
+      expect(mockSendMetaNewsletterSubscribeEvent).toHaveBeenCalled();
     });
   });
 
@@ -80,6 +94,8 @@ describe('Subscribe', () => {
 
     await waitFor(() => {
       expect(mockNotifyError).toHaveBeenCalledWith(error);
+      expect(mockSendNewsletterSubscribeEvent).not.toHaveBeenCalled();
+      expect(mockSendMetaNewsletterSubscribeEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/components/subscribe/subscribe.tsx
+++ b/src/app/components/subscribe/subscribe.tsx
@@ -13,6 +13,8 @@ import Typography, { TypographyVariant } from '@/app/components/typography/Typog
 import { FieldValues, UseFormReturn, useForm } from 'react-hook-form';
 import Form from '@/app/components/formElements/Form';
 import { notifyError } from '@/app/utilities/common';
+import { sendNewsletterSubscribeEvent } from '@/app/utilities/gaTracking';
+import { sendMetaNewsletterSubscribeEvent } from '@/app/utilities/metaPixelTracking';
 import LoaderWrapper from '../loader/LoaderWrapper';
 import Dropdown from '../formElements/Dropdown/Dropdown';
 
@@ -43,6 +45,8 @@ export default function Subscribe() {
 
       if (outcome.id || !outcome) {
         setSubmissionSuccess(true);
+        sendNewsletterSubscribeEvent(data.hs_persona);
+        sendMetaNewsletterSubscribeEvent();
       }
     } catch (error) {
       notifyError(error as object);

--- a/src/app/utilities/__tests__/constants.test.ts
+++ b/src/app/utilities/__tests__/constants.test.ts
@@ -1,15 +1,18 @@
-import { GA_EVENTS } from '../constants';
+import { CONVERSION_FORM_NAMES, GA_EVENTS, META_EVENTS } from '../constants';
 
 describe('GA_EVENTS', () => {
-  it('has exactly 5 event definitions', () => {
+  it('has exactly 8 event definitions', () => {
     const keys = Object.keys(GA_EVENTS);
-    expect(keys).toHaveLength(5);
+    expect(keys).toHaveLength(8);
     expect(keys).toEqual([
       'SCROLL_DEPTH',
       'SECTION_VISIBLE',
       'TIME_ON_PAGE',
       'ACCORDION_TOGGLE',
       'ENDORSED_EXPLORE_CLICK',
+      'CONTACT_SUBMIT',
+      'NEWSLETTER_SUBSCRIBE',
+      'HANDBOOK_DOWNLOAD',
     ]);
   });
 
@@ -26,5 +29,24 @@ describe('GA_EVENTS', () => {
     expect(GA_EVENTS.TIME_ON_PAGE.eventName).toBe('time_on_page');
     expect(GA_EVENTS.ACCORDION_TOGGLE.eventName).toBe('accordion_toggle');
     expect(GA_EVENTS.ENDORSED_EXPLORE_CLICK.eventName).toBe('endorsed_explore_click');
+    expect(GA_EVENTS.CONTACT_SUBMIT.eventName).toBe('contact_submit');
+    expect(GA_EVENTS.NEWSLETTER_SUBSCRIBE.eventName).toBe('newsletter_subscribe');
+    expect(GA_EVENTS.HANDBOOK_DOWNLOAD.eventName).toBe('handbook_download');
+  });
+});
+
+describe('META_EVENTS', () => {
+  it('has expected Meta standard event names', () => {
+    expect(META_EVENTS.LEAD).toBe('Lead');
+    expect(META_EVENTS.SUBSCRIBE).toBe('Subscribe');
+    expect(META_EVENTS.COMPLETE_REGISTRATION).toBe('CompleteRegistration');
+  });
+});
+
+describe('CONVERSION_FORM_NAMES', () => {
+  it('has expected form name values', () => {
+    expect(CONVERSION_FORM_NAMES.CONTACT_US).toBe('contact_us');
+    expect(CONVERSION_FORM_NAMES.NEWSLETTER).toBe('newsletter');
+    expect(CONVERSION_FORM_NAMES.HANDBOOK).toBe('handbook');
   });
 });

--- a/src/app/utilities/__tests__/gaTracking.test.ts
+++ b/src/app/utilities/__tests__/gaTracking.test.ts
@@ -127,16 +127,12 @@ describe('gaTracking', () => {
     installTestPagePath('/contact');
     const mockGtag = installGtagMock();
     sendContactSubmitEvent('persona_1');
-    expect(mockGtag).toHaveBeenCalledWith(
-      GA_EVENT_COMMAND,
-      GA_EVENTS.CONTACT_SUBMIT.eventName,
-      {
-        category: GA_EVENTS.CONTACT_SUBMIT.category,
-        form_name: CONVERSION_FORM_NAMES.CONTACT_US,
-        persona: 'persona_1',
-        page_path: '/contact',
-      },
-    );
+    expect(mockGtag).toHaveBeenCalledWith(GA_EVENT_COMMAND, GA_EVENTS.CONTACT_SUBMIT.eventName, {
+      category: GA_EVENTS.CONTACT_SUBMIT.category,
+      form_name: CONVERSION_FORM_NAMES.CONTACT_US,
+      persona: 'persona_1',
+      page_path: '/contact',
+    });
   });
 
   it('sendNewsletterSubscribeEvent dispatches newsletter_subscribe', () => {
@@ -159,16 +155,12 @@ describe('gaTracking', () => {
     installTestPagePath('/handbook');
     const mockGtag = installGtagMock();
     sendHandbookDownloadEvent('persona_2');
-    expect(mockGtag).toHaveBeenCalledWith(
-      GA_EVENT_COMMAND,
-      GA_EVENTS.HANDBOOK_DOWNLOAD.eventName,
-      {
-        category: GA_EVENTS.HANDBOOK_DOWNLOAD.category,
-        form_name: CONVERSION_FORM_NAMES.HANDBOOK,
-        content_name: CONVERSION_FORM_NAMES.HANDBOOK,
-        persona: 'persona_2',
-        page_path: '/handbook',
-      },
-    );
+    expect(mockGtag).toHaveBeenCalledWith(GA_EVENT_COMMAND, GA_EVENTS.HANDBOOK_DOWNLOAD.eventName, {
+      category: GA_EVENTS.HANDBOOK_DOWNLOAD.category,
+      form_name: CONVERSION_FORM_NAMES.HANDBOOK,
+      content_name: CONVERSION_FORM_NAMES.HANDBOOK,
+      persona: 'persona_2',
+      page_path: '/handbook',
+    });
   });
 });

--- a/src/app/utilities/__tests__/gaTracking.test.ts
+++ b/src/app/utilities/__tests__/gaTracking.test.ts
@@ -3,14 +3,18 @@ import {
   GA_PARAM,
   ENDORSED_EXPLORE_LINK_TEXT,
   sendAccordionToggleEvent,
+  sendContactSubmitEvent,
   sendEndorsedExploreClickEvent,
   sendGaEvent,
+  sendHandbookDownloadEvent,
+  sendNewsletterSubscribeEvent,
   sendScrollDepthEvent,
   sendSectionVisibleEvent,
   sendTimeOnPageEvent,
   buildProviderScopedParams,
+  buildConversionScopedParams,
 } from '@/app/utilities/gaTracking';
-import { GA_EVENTS } from '@/app/utilities/constants';
+import { CONVERSION_FORM_NAMES, GA_EVENTS } from '@/app/utilities/constants';
 import { installGtagMock, installTestPagePath } from '@/app/utilities/__tests__/gaTestHelpers';
 
 describe('gaTracking', () => {
@@ -104,6 +108,66 @@ describe('gaTracking', () => {
         provider_slug: 'collarts',
         link_text: ENDORSED_EXPLORE_LINK_TEXT,
         category: GA_EVENTS.ENDORSED_EXPLORE_CLICK.category,
+      },
+    );
+  });
+
+  it('buildConversionScopedParams includes page path only', () => {
+    installTestPagePath('/contact');
+    const params = buildConversionScopedParams({
+      [GA_PARAM.CATEGORY]: 'Conversion',
+    });
+    expect(params).toEqual({
+      category: 'Conversion',
+      page_path: '/contact',
+    });
+  });
+
+  it('sendContactSubmitEvent dispatches contact_submit without PII', () => {
+    installTestPagePath('/contact');
+    const mockGtag = installGtagMock();
+    sendContactSubmitEvent('persona_1');
+    expect(mockGtag).toHaveBeenCalledWith(
+      GA_EVENT_COMMAND,
+      GA_EVENTS.CONTACT_SUBMIT.eventName,
+      {
+        category: GA_EVENTS.CONTACT_SUBMIT.category,
+        form_name: CONVERSION_FORM_NAMES.CONTACT_US,
+        persona: 'persona_1',
+        page_path: '/contact',
+      },
+    );
+  });
+
+  it('sendNewsletterSubscribeEvent dispatches newsletter_subscribe', () => {
+    installTestPagePath('/');
+    const mockGtag = installGtagMock();
+    sendNewsletterSubscribeEvent('persona_3');
+    expect(mockGtag).toHaveBeenCalledWith(
+      GA_EVENT_COMMAND,
+      GA_EVENTS.NEWSLETTER_SUBSCRIBE.eventName,
+      {
+        category: GA_EVENTS.NEWSLETTER_SUBSCRIBE.category,
+        form_name: CONVERSION_FORM_NAMES.NEWSLETTER,
+        persona: 'persona_3',
+        page_path: '/',
+      },
+    );
+  });
+
+  it('sendHandbookDownloadEvent dispatches handbook_download', () => {
+    installTestPagePath('/handbook');
+    const mockGtag = installGtagMock();
+    sendHandbookDownloadEvent('persona_2');
+    expect(mockGtag).toHaveBeenCalledWith(
+      GA_EVENT_COMMAND,
+      GA_EVENTS.HANDBOOK_DOWNLOAD.eventName,
+      {
+        category: GA_EVENTS.HANDBOOK_DOWNLOAD.category,
+        form_name: CONVERSION_FORM_NAMES.HANDBOOK,
+        content_name: CONVERSION_FORM_NAMES.HANDBOOK,
+        persona: 'persona_2',
+        page_path: '/handbook',
       },
     );
   });

--- a/src/app/utilities/__tests__/metaPixelTracking.test.ts
+++ b/src/app/utilities/__tests__/metaPixelTracking.test.ts
@@ -1,0 +1,64 @@
+import { CONVERSION_FORM_NAMES, META_EVENTS } from '@/app/utilities/constants';
+import {
+  sendMetaContactLeadEvent,
+  sendMetaEvent,
+  sendMetaHandbookDownloadEvent,
+  sendMetaNewsletterSubscribeEvent,
+} from '@/app/utilities/metaPixelTracking';
+
+interface FbqTestWindow extends Window {
+  fbq?: jest.Mock;
+}
+
+function installFbqMock(): jest.Mock {
+  const mockFbq = jest.fn();
+  (window as FbqTestWindow).fbq = mockFbq;
+  return mockFbq;
+}
+
+describe('metaPixelTracking', () => {
+  afterEach(() => {
+    delete (window as FbqTestWindow).fbq;
+  });
+
+  it('sendMetaEvent is a no-op when fbq is missing', () => {
+    delete (window as FbqTestWindow).fbq;
+    expect(() => sendMetaEvent(META_EVENTS.LEAD)).not.toThrow();
+  });
+
+  it('sendMetaEvent tracks event without params', () => {
+    const mockFbq = installFbqMock();
+    sendMetaEvent(META_EVENTS.SUBSCRIBE);
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.SUBSCRIBE);
+  });
+
+  it('sendMetaEvent tracks event with params', () => {
+    const mockFbq = installFbqMock();
+    sendMetaEvent(META_EVENTS.LEAD, { content_name: 'contact_us' });
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.LEAD, {
+      content_name: 'contact_us',
+    });
+  });
+
+  it('sendMetaContactLeadEvent tracks Lead with content_name', () => {
+    const mockFbq = installFbqMock();
+    sendMetaContactLeadEvent();
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.LEAD, {
+      content_name: CONVERSION_FORM_NAMES.CONTACT_US,
+    });
+  });
+
+  it('sendMetaNewsletterSubscribeEvent tracks Subscribe', () => {
+    const mockFbq = installFbqMock();
+    sendMetaNewsletterSubscribeEvent();
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.SUBSCRIBE);
+  });
+
+  it('sendMetaHandbookDownloadEvent tracks CompleteRegistration with handbook content_name', () => {
+    const mockFbq = installFbqMock();
+    sendMetaHandbookDownloadEvent();
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.COMPLETE_REGISTRATION, {
+      content_name: CONVERSION_FORM_NAMES.HANDBOOK,
+    });
+  });
+});

--- a/src/app/utilities/constants.ts
+++ b/src/app/utilities/constants.ts
@@ -100,4 +100,19 @@ export const GA_EVENTS = {
     eventName: 'endorsed_explore_click',
     category: 'Endorsed',
   },
+  CONTACT_SUBMIT: { eventName: 'contact_submit', category: 'Conversion' },
+  NEWSLETTER_SUBSCRIBE: { eventName: 'newsletter_subscribe', category: 'Conversion' },
+  HANDBOOK_DOWNLOAD: { eventName: 'handbook_download', category: 'Conversion' },
+} as const;
+
+export const CONVERSION_FORM_NAMES = {
+  CONTACT_US: 'contact_us',
+  NEWSLETTER: 'newsletter',
+  HANDBOOK: 'handbook',
+} as const;
+
+export const META_EVENTS = {
+  LEAD: 'Lead',
+  SUBSCRIBE: 'Subscribe',
+  COMPLETE_REGISTRATION: 'CompleteRegistration',
 } as const;

--- a/src/app/utilities/gaTracking.ts
+++ b/src/app/utilities/gaTracking.ts
@@ -1,4 +1,4 @@
-import { GA_EVENTS } from '@/app/utilities/constants';
+import { CONVERSION_FORM_NAMES, GA_EVENTS } from '@/app/utilities/constants';
 
 export const GA_EVENT_COMMAND = 'event' as const;
 
@@ -12,6 +12,9 @@ export const GA_PARAM = {
   ACCORDION_TITLE: 'accordion_title',
   DESTINATION_URL: 'destination_url',
   LINK_TEXT: 'link_text',
+  FORM_NAME: 'form_name',
+  PERSONA: 'persona',
+  CONTENT_NAME: 'content_name',
 } as const;
 
 export const ENDORSED_EXPLORE_LINK_TEXT = 'Explore' as const;
@@ -110,6 +113,47 @@ export function sendEndorsedExploreClickEvent(providerSlug: string, destinationU
       [GA_PARAM.DESTINATION_URL]: destinationUrl,
       [GA_PARAM.LINK_TEXT]: ENDORSED_EXPLORE_LINK_TEXT,
       [GA_PARAM.CATEGORY]: GA_EVENTS.ENDORSED_EXPLORE_CLICK.category,
+    }),
+  );
+}
+
+export function buildConversionScopedParams(extra: GaEventParams): GaEventParams {
+  return {
+    ...extra,
+    [GA_PARAM.PAGE_PATH]: window.location.pathname,
+  };
+}
+
+export function sendContactSubmitEvent(persona: string): void {
+  sendGaEvent(
+    GA_EVENTS.CONTACT_SUBMIT.eventName,
+    buildConversionScopedParams({
+      [GA_PARAM.CATEGORY]: GA_EVENTS.CONTACT_SUBMIT.category,
+      [GA_PARAM.FORM_NAME]: CONVERSION_FORM_NAMES.CONTACT_US,
+      [GA_PARAM.PERSONA]: persona,
+    }),
+  );
+}
+
+export function sendNewsletterSubscribeEvent(persona: string): void {
+  sendGaEvent(
+    GA_EVENTS.NEWSLETTER_SUBSCRIBE.eventName,
+    buildConversionScopedParams({
+      [GA_PARAM.CATEGORY]: GA_EVENTS.NEWSLETTER_SUBSCRIBE.category,
+      [GA_PARAM.FORM_NAME]: CONVERSION_FORM_NAMES.NEWSLETTER,
+      [GA_PARAM.PERSONA]: persona,
+    }),
+  );
+}
+
+export function sendHandbookDownloadEvent(persona: string): void {
+  sendGaEvent(
+    GA_EVENTS.HANDBOOK_DOWNLOAD.eventName,
+    buildConversionScopedParams({
+      [GA_PARAM.CATEGORY]: GA_EVENTS.HANDBOOK_DOWNLOAD.category,
+      [GA_PARAM.FORM_NAME]: CONVERSION_FORM_NAMES.HANDBOOK,
+      [GA_PARAM.CONTENT_NAME]: CONVERSION_FORM_NAMES.HANDBOOK,
+      [GA_PARAM.PERSONA]: persona,
     }),
   );
 }

--- a/src/app/utilities/metaPixelTracking.ts
+++ b/src/app/utilities/metaPixelTracking.ts
@@ -1,0 +1,45 @@
+import { CONVERSION_FORM_NAMES, META_EVENTS } from '@/app/utilities/constants';
+
+export type MetaEventParams = Record<string, string>;
+
+type FbqFn = (...args: Array<string | MetaEventParams>) => void;
+
+interface FbqWindow extends Window {
+  fbq?: FbqFn;
+}
+
+function resolveFbq(): FbqFn | null {
+  const candidate = (window as FbqWindow).fbq;
+  if (typeof candidate === 'function') {
+    return candidate;
+  }
+  return null;
+}
+
+export function sendMetaEvent(eventName: string, params?: MetaEventParams): void {
+  const fbq = resolveFbq();
+  if (fbq === null) {
+    return;
+  }
+
+  if (params === undefined) {
+    fbq('track', eventName);
+    return;
+  }
+
+  fbq('track', eventName, params);
+}
+
+export function sendMetaContactLeadEvent(): void {
+  sendMetaEvent(META_EVENTS.LEAD, { content_name: CONVERSION_FORM_NAMES.CONTACT_US });
+}
+
+export function sendMetaNewsletterSubscribeEvent(): void {
+  sendMetaEvent(META_EVENTS.SUBSCRIBE);
+}
+
+export function sendMetaHandbookDownloadEvent(): void {
+  sendMetaEvent(META_EVENTS.COMPLETE_REGISTRATION, {
+    content_name: CONVERSION_FORM_NAMES.HANDBOOK,
+  });
+}


### PR DESCRIPTION
## Summary
- Add GA conversion events (`contact_submit`, `newsletter_subscribe`, `handbook_download`) fired only on successful live form submissions
- Add safe Meta Pixel helpers (`Lead`, `Subscribe`, `CompleteRegistration`) via `window.fbq` with no-op when pixel is unavailable
- Instrument ContactUsForm, Subscribe, and HandbookPopup; no course/checkout/Stripe changes

## Test plan
- [x] `npm test -- --testPathPatterns="gaTracking|metaPixelTracking|constants.test|ContactUsForm|subscribe.test|HandbookPopup"`
- [ ] Verify contact form success fires GA + Meta in browser (no email/name in event params)
- [ ] Verify newsletter subscribe success fires GA + Meta
- [ ] Verify handbook download gate success fires GA + Meta CompleteRegistration with `content_name: handbook`
- [ ] Confirm no events on submission failure paths


Made with [Cursor](https://cursor.com)