### PR TITLE
seo: expand sitemap and noindex auth/dev routes

### DIFF
--- a/src/app/components/layout.tsx
+++ b/src/app/components/layout.tsx
@@ -3,8 +3,8 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Neurodiversity Components',
   robots: {
-    index: true,
-    follow: true,
+    index: false,
+    follow: false,
   },
 };
 

--- a/src/app/forgotpassword/page.tsx
+++ b/src/app/forgotpassword/page.tsx
@@ -4,7 +4,9 @@ import { Metadata } from 'next';
 import { META_KEY } from '@/app/utilities/constants';
 import { createMetadata } from '@/app/utilities/common';
 
-export const metadata: Metadata = createMetadata(META_KEY.FORGOT_PASSWORD);
+export const metadata: Metadata = createMetadata(META_KEY.FORGOT_PASSWORD, {
+  robots: { index: false, follow: false },
+});
 
 const Page = () => {
   return <ForgotPassword />;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,7 +5,9 @@ import { Metadata } from 'next';
 import { META_KEY } from '@/app/utilities/constants';
 import { createMetadata } from '@/app/utilities/common';
 
-export const metadata: Metadata = createMetadata(META_KEY.LOGIN);
+export const metadata: Metadata = createMetadata(META_KEY.LOGIN, {
+  robots: { index: false, follow: false },
+});
 
 const Page = () => {
   return (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -6,7 +6,9 @@ import { createMetadata } from '@/app/utilities/common';
 import ProfileContainer from '../components/profile/ProfileContainer';
 import ProfileProvider from '../utilities/profile/ProfileProvider';
 
-export const metadata: Metadata = createMetadata(META_KEY.PROFILE);
+export const metadata: Metadata = createMetadata(META_KEY.PROFILE, {
+  robots: { index: false, follow: false },
+});
 
 const Page = async () => {
   return (

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -5,7 +5,9 @@ import { Metadata } from 'next';
 import { META_KEY } from '@/app/utilities/constants';
 import { createMetadata } from '@/app/utilities/common';
 
-export const metadata: Metadata = createMetadata(META_KEY.SIGNUP);
+export const metadata: Metadata = createMetadata(META_KEY.SIGNUP, {
+  robots: { index: false, follow: false },
+});
 
 const Page = () => {
   return (

--- a/src/app/sitemap.xml/__tests__/buildSitemapUrls.test.ts
+++ b/src/app/sitemap.xml/__tests__/buildSitemapUrls.test.ts
@@ -4,11 +4,7 @@ import blogData from '@/app/blogs/blogData.json';
 import articleData from '@/app/articles/articleData.json';
 import courseData from '@/app/courses/courseData.json';
 import { slugify } from '@/app/utilities/common';
-import {
-  buildSitemapUrls,
-  buildSitemapXml,
-  SITEMAP_STATIC_PAGES,
-} from '../buildSitemapUrls';
+import { buildSitemapUrls, buildSitemapXml, SITEMAP_STATIC_PAGES } from '../buildSitemapUrls';
 
 const BASE_URL = 'https://neurodiversityacademy.com';
 

--- a/src/app/sitemap.xml/__tests__/buildSitemapUrls.test.ts
+++ b/src/app/sitemap.xml/__tests__/buildSitemapUrls.test.ts
@@ -1,0 +1,78 @@
+import { ENDORSED_LIVE_SLUGS } from '@/app/components/endorsedProviders/endorsedProviderPageData';
+import emergingInstitutions from '@/app/components/emergingInstitutions/emergingInstitutions.json';
+import blogData from '@/app/blogs/blogData.json';
+import articleData from '@/app/articles/articleData.json';
+import courseData from '@/app/courses/courseData.json';
+import { slugify } from '@/app/utilities/common';
+import {
+  buildSitemapUrls,
+  buildSitemapXml,
+  SITEMAP_STATIC_PAGES,
+} from '../buildSitemapUrls';
+
+const BASE_URL = 'https://neurodiversityacademy.com';
+
+describe('buildSitemapUrls', () => {
+  it('includes marketing static pages and excludes auth routes', () => {
+    const urls = buildSitemapUrls({ baseUrl: BASE_URL });
+
+    SITEMAP_STATIC_PAGES.forEach((page) => {
+      expect(urls).toContain(`${BASE_URL}${page}`);
+    });
+
+    expect(urls).not.toContain(`${BASE_URL}/login`);
+    expect(urls).not.toContain(`${BASE_URL}/signup`);
+  });
+
+  it('includes live endorsed provider detail pages', () => {
+    const urls = buildSitemapUrls({ baseUrl: BASE_URL });
+
+    ENDORSED_LIVE_SLUGS.forEach((slug) => {
+      expect(urls).toContain(`${BASE_URL}/endorsedproviders/${slug}`);
+    });
+  });
+
+  it('includes emerging provider detail pages', () => {
+    const urls = buildSitemapUrls({ baseUrl: BASE_URL });
+
+    emergingInstitutions.forEach((institution) => {
+      expect(urls).toContain(`${BASE_URL}/emergingproviders/${slugify(institution.name)}`);
+    });
+  });
+
+  it('includes course listing and course detail pages from local data', () => {
+    const urls = buildSitemapUrls({ baseUrl: BASE_URL });
+
+    expect(urls).toContain(`${BASE_URL}/courses`);
+
+    courseData.courses
+      .filter((course) => course.CourseId)
+      .forEach((course) => {
+        expect(urls).toContain(`${BASE_URL}/courses/${course.CourseId}`);
+      });
+  });
+
+  it('includes article and blog detail pages', () => {
+    const urls = buildSitemapUrls({ baseUrl: BASE_URL });
+
+    articleData.articles.forEach((article) => {
+      expect(urls).toContain(`${BASE_URL}/articles/${slugify(article.title)}`);
+    });
+
+    blogData.blogs.forEach((blog) => {
+      expect(urls).toContain(`${BASE_URL}/blogs/${slugify(blog.title)}`);
+    });
+  });
+});
+
+describe('buildSitemapXml', () => {
+  it('returns valid sitemap XML with lastmod entries', () => {
+    const lastmod = '2026-07-19T00:00:00.000Z';
+    const xml = buildSitemapXml([`${BASE_URL}/courses`], lastmod);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain(`<loc>${BASE_URL}/courses</loc>`);
+    expect(xml).toContain(`<lastmod>${lastmod}</lastmod>`);
+  });
+});

--- a/src/app/sitemap.xml/buildSitemapUrls.ts
+++ b/src/app/sitemap.xml/buildSitemapUrls.ts
@@ -1,0 +1,66 @@
+import { ENDORSED_LIVE_SLUGS } from '@/app/components/endorsedProviders/endorsedProviderPageData';
+import emergingInstitutions from '@/app/components/emergingInstitutions/emergingInstitutions.json';
+import blogData from '@/app/blogs/blogData.json';
+import articleData from '@/app/articles/articleData.json';
+import courseData from '@/app/courses/courseData.json';
+import { slugify } from '@/app/utilities/common';
+
+export const SITEMAP_STATIC_PAGES = [
+  '/',
+  '/endorsements',
+  '/contact',
+  '/about',
+  '/neurodivergentmates',
+  '/articles',
+  '/blogs',
+  '/courses',
+] as const;
+
+interface BuildSitemapUrlsParams {
+  baseUrl: string;
+}
+
+export const buildSitemapUrls = ({ baseUrl }: BuildSitemapUrlsParams): string[] => {
+  const staticUrls = SITEMAP_STATIC_PAGES.map((page) => `${baseUrl}${page}`);
+
+  const endorsedProviderUrls = ENDORSED_LIVE_SLUGS.map(
+    (slug) => `${baseUrl}/endorsedproviders/${slug}`,
+  );
+
+  const emergingProviderUrls = emergingInstitutions.map(
+    (institution) => `${baseUrl}/emergingproviders/${slugify(institution.name)}`,
+  );
+
+  const courseUrls = courseData.courses
+    .filter((course) => course.CourseId)
+    .map((course) => `${baseUrl}/courses/${course.CourseId}`);
+
+  const articleUrls = articleData.articles.map(
+    (article) => `${baseUrl}/articles/${slugify(article.title)}`,
+  );
+
+  const blogUrls = blogData.blogs.map((blog) => `${baseUrl}/blogs/${slugify(blog.title)}`);
+
+  return [
+    ...staticUrls,
+    ...endorsedProviderUrls,
+    ...emergingProviderUrls,
+    ...courseUrls,
+    ...articleUrls,
+    ...blogUrls,
+  ];
+};
+
+export const buildSitemapXml = (urls: string[], lastmod: string): string => {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls
+  .map(
+    (url) => `<url>
+  <loc>${url}</loc>
+  <lastmod>${lastmod}</lastmod>
+</url>`,
+  )
+  .join('\n')}
+</urlset>`;
+};

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,50 +1,11 @@
-/* eslint-disable */
-/* tslint:disable */
 import { type NextRequest } from 'next/server';
-import { slugify } from '@/app/utilities/common';
-import blogData from '@/app/blogs/blogData.json';
-import articleData from '@/app/articles/articleData.json';
+import { buildSitemapUrls, buildSitemapXml } from './buildSitemapUrls';
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   const baseUrl = 'https://neurodiversityacademy.com';
-
-  const staticPages = [
-    '/',
-    '/endorsements',
-    '/contact',
-    '/about',
-    '/neurodivergentmates',
-    '/login',
-    '/signup',
-    '/articles',
-    '/blogs',
-  ];
-
-  const staticUrls = staticPages.map((page) => `${baseUrl}${page}`);
-
-  const articleUrls = articleData.articles.map((article) => {
-    return `${baseUrl}/articles/${slugify(article.title)}`;
-  });
-
-  const blogUrls = blogData.blogs.map((blog) => {
-    return `${baseUrl}/blogs/${slugify(blog.title)}`;
-  });
-
-  const urls = [...staticUrls, ...articleUrls, ...blogUrls];
-
+  const urls = buildSitemapUrls({ baseUrl });
   const lastmod = new Date().toISOString();
-
-  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls
-  .map(
-    (url) => `<url>
-  <loc>${url}</loc>
-  <lastmod>${lastmod}</lastmod>
-</url>`,
-  )
-  .join('\n')}
-</urlset>`;
+  const sitemap = buildSitemapXml(urls, lastmod);
 
   return new Response(sitemap, {
     headers: {


### PR DESCRIPTION
## Summary
- Expand `/sitemap.xml` to include `/courses`, live endorsed provider pages, emerging provider pages, and course detail URLs from local JSON; remove `/login` and `/signup`.
- Extract pure `buildSitemapUrls` / `buildSitemapXml` helpers with unit tests.
- Set `robots: { index: false, follow: false }` on login, signup, profile, forgot-password, and the component playground layout.

## Test plan
- [x] `npm test -- --testPathPatterns=buildSitemapUrls`
- [x] `npm run lint`
- [ ] Verify `/sitemap.xml` excludes auth URLs and includes `/courses`, provider pages, and articles/blogs
- [ ] Confirm login/signup/profile/forgot-password and `/components` emit noindex meta tags


Made with [Cursor](https://cursor.com)