### PR TITLE
seo: add generateMetadata for emerging provider pages

### DIFF
--- a/src/app/emergingproviders/[name-of-the-institute]/page.tsx
+++ b/src/app/emergingproviders/[name-of-the-institute]/page.tsx
@@ -1,48 +1,41 @@
 import { notFound } from 'next/navigation';
-import cardData from '@/app/components/emergingInstitutions/emergingInstitutions.json';
+import type { Metadata } from 'next';
 import EmergingProviderHero from '@/app/components/emergingInstitutions/EmergingProviderHero';
 import EmergingProviderStudentSuitability from '@/app/components/emergingInstitutions/EmergingProviderStudentSuitability';
 import EmergingProviderStats from '@/app/components/emergingInstitutions/EmergingProviderStats';
 import EmergingProvidersFAQs from '@/app/components/emergingInstitutions/EmergingProvidersFAQs';
-import { slugify } from '@/app/utilities/common';
 import {
-  HERO_DETAILS_BY_SLUG,
-  STATS_BY_SLUG,
-} from '@/app/components/emergingInstitutions/emergingProviderPageData';
+  buildEmergingProviderMetadata,
+  resolveEmergingProviderForSlug,
+} from '@/app/emergingproviders/emergingProviderMetadata';
 import pageStyles from './emergingProviderPage.module.css';
-
-type InstitutionCard = {
-  name: string;
-};
 
 type RouteParams = {
   'name-of-the-institute': string;
 };
 
-export default async function EmergingProviderPage({ params }: { params: Promise<RouteParams> }) {
+interface PageProps {
+  params: Promise<RouteParams>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const resolvedParams = await params;
-  const institutions = cardData as InstitutionCard[];
-  const institution = institutions.find(
-    (item) => slugify(item.name) === resolvedParams['name-of-the-institute'],
-  );
+  return buildEmergingProviderMetadata(resolvedParams['name-of-the-institute']);
+}
 
-  if (!institution) {
-    notFound();
-  }
+export default async function EmergingProviderPage({ params }: PageProps) {
+  const resolvedParams = await params;
+  const provider = resolveEmergingProviderForSlug(resolvedParams['name-of-the-institute']);
 
-  const institutionSlug = resolvedParams['name-of-the-institute'];
-  const heroInfoItems = HERO_DETAILS_BY_SLUG[institutionSlug];
-  const providerStats = STATS_BY_SLUG[institutionSlug];
-
-  if (!heroInfoItems || !providerStats) {
+  if (!provider) {
     notFound();
   }
 
   return (
     <main className={pageStyles.pageMain}>
-      <EmergingProviderHero title={institution.name} heroInfoItems={heroInfoItems} />
-      <EmergingProviderStudentSuitability instituteSlug={institutionSlug} />
-      <EmergingProviderStats stats={providerStats} />
+      <EmergingProviderHero title={provider.name} heroInfoItems={provider.heroInfoItems} />
+      <EmergingProviderStudentSuitability instituteSlug={provider.slug} />
+      <EmergingProviderStats stats={provider.providerStats} />
       <EmergingProvidersFAQs />
     </main>
   );

--- a/src/app/emergingproviders/__tests__/emergingProviderMetadata.test.ts
+++ b/src/app/emergingproviders/__tests__/emergingProviderMetadata.test.ts
@@ -1,0 +1,78 @@
+import cardData from '@/app/components/emergingInstitutions/emergingInstitutions.json';
+import {
+  buildEmergingProviderDetailHref,
+  buildEmergingProviderMetadata,
+  resolveEmergingProviderForSlug,
+} from '../emergingProviderMetadata';
+import { slugify } from '@/app/utilities/common';
+import { HOST_URL } from '@/app/utilities/constants';
+
+describe('buildEmergingProviderDetailHref', () => {
+  it('returns the detail path for a slug', () => {
+    expect(buildEmergingProviderDetailHref('bond-university')).toBe(
+      '/emergingproviders/bond-university',
+    );
+  });
+
+  it('returns empty string for an empty slug', () => {
+    expect(buildEmergingProviderDetailHref('')).toBe('');
+  });
+});
+
+describe('resolveEmergingProviderForSlug', () => {
+  it('resolves a known emerging provider slug', () => {
+    const provider = resolveEmergingProviderForSlug('bond-university');
+
+    expect(provider).toEqual(
+      expect.objectContaining({
+        slug: 'bond-university',
+        name: 'Bond University',
+      }),
+    );
+    expect(provider?.heroInfoItems.length).toBeGreaterThan(0);
+    expect(provider?.providerStats.length).toBeGreaterThan(0);
+  });
+
+  it('returns null for an unknown slug', () => {
+    expect(resolveEmergingProviderForSlug('unknown-institute')).toBeNull();
+  });
+});
+
+describe('buildEmergingProviderMetadata', () => {
+  it('returns SEO metadata for a valid emerging provider', () => {
+    const slug = 'griffith-university';
+    const metadata = buildEmergingProviderMetadata(slug);
+    const canonical = `${HOST_URL}/emergingproviders/${slug}`;
+
+    expect(metadata).toEqual({
+      title: 'Griffith University | NDA Emerging Provider',
+      description:
+        'Explore student experience insights and neuro-inclusive profile for Griffith University.',
+      alternates: { canonical },
+      openGraph: {
+        title: 'Griffith University | NDA Emerging Provider',
+        description:
+          'Explore student experience insights and neuro-inclusive profile for Griffith University.',
+        url: canonical,
+      },
+    });
+  });
+
+  it('returns not-found metadata for an unknown slug', () => {
+    expect(buildEmergingProviderMetadata('does-not-exist')).toEqual({ title: 'Not found' });
+  });
+
+  it('builds unique metadata for every listed emerging institution', () => {
+    for (const { name } of cardData) {
+      const metadata = buildEmergingProviderMetadata(slugify(name));
+
+      expect(metadata).toEqual(
+        expect.objectContaining({
+          title: `${name} | NDA Emerging Provider`,
+          description: `Explore student experience insights and neuro-inclusive profile for ${name}.`,
+        }),
+      );
+      expect(metadata.alternates?.canonical).toBe(`${HOST_URL}/emergingproviders/${slugify(name)}`);
+    }
+  });
+});

--- a/src/app/emergingproviders/emergingProviderMetadata.ts
+++ b/src/app/emergingproviders/emergingProviderMetadata.ts
@@ -1,0 +1,77 @@
+import type { Metadata } from 'next';
+import cardData from '@/app/components/emergingInstitutions/emergingInstitutions.json';
+import type { HeroInfoItem } from '@/app/components/emergingInstitutions/InstitutionHero';
+import type { ProviderStatItem } from '@/app/components/emergingInstitutions/EmergingProviderStats';
+import {
+  HERO_DETAILS_BY_SLUG,
+  STATS_BY_SLUG,
+} from '@/app/components/emergingInstitutions/emergingProviderPageData';
+import { HOST_URL } from '@/app/utilities/constants';
+import { slugify } from '@/app/utilities/common';
+
+export const EMERGING_PROVIDERS_BASE_PATH = '/emergingproviders' as const;
+
+type InstitutionCard = {
+  name: string;
+};
+
+export interface ResolvedEmergingProvider {
+  slug: string;
+  name: string;
+  heroInfoItems: HeroInfoItem[];
+  providerStats: ProviderStatItem[];
+}
+
+export function buildEmergingProviderDetailHref(slug: string): string {
+  if (slug === '') {
+    return '';
+  }
+
+  return `${EMERGING_PROVIDERS_BASE_PATH}/${slug}`;
+}
+
+export function resolveEmergingProviderForSlug(slug: string): ResolvedEmergingProvider | null {
+  const institutions = cardData as InstitutionCard[];
+  const institution = institutions.find((item) => slugify(item.name) === slug);
+
+  if (!institution) {
+    return null;
+  }
+
+  const heroInfoItems = HERO_DETAILS_BY_SLUG[slug];
+  const providerStats = STATS_BY_SLUG[slug];
+
+  if (!heroInfoItems || !providerStats) {
+    return null;
+  }
+
+  return {
+    slug,
+    name: institution.name,
+    heroInfoItems,
+    providerStats,
+  };
+}
+
+export function buildEmergingProviderMetadata(slug: string): Metadata {
+  const provider = resolveEmergingProviderForSlug(slug);
+
+  if (!provider) {
+    return { title: 'Not found' };
+  }
+
+  const title = `${provider.name} | NDA Emerging Provider`;
+  const description = `Explore student experience insights and neuro-inclusive profile for ${provider.name}.`;
+  const canonical = `${HOST_URL}${buildEmergingProviderDetailHref(slug)}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `generateMetadata` to emerging provider detail pages (`/emergingproviders/[name-of-the-institute]`)
- Extract shared helpers for slug resolution, canonical URLs, and metadata construction
- Return endorsed-style not-found metadata for unknown slugs without throwing

## Test plan
- [x] `npx jest --testPathPatterns=emergingProviderMetadata --no-coverage` (7 tests)
- [ ] Verify a valid slug (e.g. `/emergingproviders/bond-university`) renders unique title/description in page source
- [ ] Verify an unknown slug returns `{ title: 'Not found' }` metadata and 404 page
- [ ] Confirm canonical URLs use `HOST_URL` + `/emergingproviders/{slug}`


Made with [Cursor](https://cursor.com)