### PR TITLE
feat(analytics): engagement tracking on emerging provider pages

### DIFF
--- a/src/app/components/endorsedProviders/__tests__/PageEngagementTracker.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/PageEngagementTracker.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import PageEngagementTracker from '../PageEngagementTracker';
+import { EMERGING_PAGE_SECTION } from '@/app/utilities/emergingPageSections';
 import { ENDORSED_PAGE_SECTION } from '@/app/utilities/endorsedPageSections';
 import { DATA_SECTION_ATTRIBUTE } from '@/app/utilities/gaTracking';
 import {
@@ -115,6 +116,38 @@ describe('PageEngagementTracker', () => {
         section: ENDORSED_PAGE_SECTION.FAQS,
         provider_slug: 'collarts',
         page_path: '/endorsedproviders/collarts',
+        category: 'Engagement',
+      }),
+    );
+  });
+
+  it('fires section_visible for emerging provider section ids', () => {
+    const mockGtag = installGtagMock();
+    installTestPagePath('/emergingproviders/bond-university');
+
+    render(
+      <PageEngagementTracker providerSlug='bond-university'>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.HERO }}>Hero</div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.SUITABILITY }}>
+          Suitability
+        </div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.STATS }}>Stats</div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.FAQS }}>FAQs</div>
+      </PageEngagementTracker>,
+    );
+
+    const heroTarget = document.querySelector(
+      `[${DATA_SECTION_ATTRIBUTE}="${EMERGING_PAGE_SECTION.HERO}"]`,
+    ) as HTMLElement;
+    fireIntersection(heroTarget);
+
+    expect(mockGtag).toHaveBeenCalledWith(
+      GA_EVENT_COMMAND,
+      'section_visible',
+      expect.objectContaining({
+        section: EMERGING_PAGE_SECTION.HERO,
+        provider_slug: 'bond-university',
+        page_path: '/emergingproviders/bond-university',
         category: 'Engagement',
       }),
     );

--- a/src/app/components/endorsedProviders/__tests__/PageEngagementTracker.test.tsx
+++ b/src/app/components/endorsedProviders/__tests__/PageEngagementTracker.test.tsx
@@ -128,9 +128,7 @@ describe('PageEngagementTracker', () => {
     render(
       <PageEngagementTracker providerSlug='bond-university'>
         <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.HERO }}>Hero</div>
-        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.SUITABILITY }}>
-          Suitability
-        </div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.SUITABILITY }}>Suitability</div>
         <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.STATS }}>Stats</div>
         <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.FAQS }}>FAQs</div>
       </PageEngagementTracker>,

--- a/src/app/emergingproviders/[name-of-the-institute]/page.tsx
+++ b/src/app/emergingproviders/[name-of-the-institute]/page.tsx
@@ -4,11 +4,14 @@ import EmergingProviderHero from '@/app/components/emergingInstitutions/Emerging
 import EmergingProviderStudentSuitability from '@/app/components/emergingInstitutions/EmergingProviderStudentSuitability';
 import EmergingProviderStats from '@/app/components/emergingInstitutions/EmergingProviderStats';
 import EmergingProvidersFAQs from '@/app/components/emergingInstitutions/EmergingProvidersFAQs';
+import PageEngagementTracker from '@/app/components/endorsedProviders/PageEngagementTracker';
 import { slugify } from '@/app/utilities/common';
 import {
   HERO_DETAILS_BY_SLUG,
   STATS_BY_SLUG,
 } from '@/app/components/emergingInstitutions/emergingProviderPageData';
+import { EMERGING_PAGE_SECTION } from '@/app/utilities/emergingPageSections';
+import { DATA_SECTION_ATTRIBUTE } from '@/app/utilities/gaTracking';
 import pageStyles from './emergingProviderPage.module.css';
 
 type InstitutionCard = {
@@ -39,11 +42,21 @@ export default async function EmergingProviderPage({ params }: { params: Promise
   }
 
   return (
-    <main className={pageStyles.pageMain}>
-      <EmergingProviderHero title={institution.name} heroInfoItems={heroInfoItems} />
-      <EmergingProviderStudentSuitability instituteSlug={institutionSlug} />
-      <EmergingProviderStats stats={providerStats} />
-      <EmergingProvidersFAQs />
-    </main>
+    <PageEngagementTracker providerSlug={institutionSlug}>
+      <main className={pageStyles.pageMain}>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.HERO }}>
+          <EmergingProviderHero title={institution.name} heroInfoItems={heroInfoItems} />
+        </div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.SUITABILITY }}>
+          <EmergingProviderStudentSuitability instituteSlug={institutionSlug} />
+        </div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.STATS }}>
+          <EmergingProviderStats stats={providerStats} />
+        </div>
+        <div {...{ [DATA_SECTION_ATTRIBUTE]: EMERGING_PAGE_SECTION.FAQS }}>
+          <EmergingProvidersFAQs />
+        </div>
+      </main>
+    </PageEngagementTracker>
   );
 }

--- a/src/app/utilities/__tests__/emergingPageSections.test.ts
+++ b/src/app/utilities/__tests__/emergingPageSections.test.ts
@@ -1,0 +1,10 @@
+import { EMERGING_PAGE_SECTION } from '@/app/utilities/emergingPageSections';
+
+describe('emergingPageSections', () => {
+  it('defines stable section ids for emerging provider detail pages', () => {
+    expect(EMERGING_PAGE_SECTION.HERO).toBe('hero');
+    expect(EMERGING_PAGE_SECTION.SUITABILITY).toBe('suitability');
+    expect(EMERGING_PAGE_SECTION.STATS).toBe('stats');
+    expect(EMERGING_PAGE_SECTION.FAQS).toBe('faqs');
+  });
+});

--- a/src/app/utilities/emergingPageSections.ts
+++ b/src/app/utilities/emergingPageSections.ts
@@ -1,0 +1,9 @@
+export const EMERGING_PAGE_SECTION = {
+  HERO: 'hero',
+  SUITABILITY: 'suitability',
+  STATS: 'stats',
+  FAQS: 'faqs',
+} as const;
+
+export type EmergingPageSectionId =
+  (typeof EMERGING_PAGE_SECTION)[keyof typeof EMERGING_PAGE_SECTION];


### PR DESCRIPTION
## Summary
- Mount the existing `PageEngagementTracker` on live emerging provider detail pages (valid institutions only, after `notFound` guards).
- Add `data-section` markers for hero, suitability, stats, and FAQs via `EMERGING_PAGE_SECTION` constants.
- Extend engagement unit tests to cover emerging section IDs and page path scoping.

## Events fired
| Event | Category | Params |
|-------|----------|--------|
| `scroll_depth` | Engagement | `percent`, `provider_slug`, `page_path` |
| `section_visible` | Engagement | `section` (`hero`, `suitability`, `stats`, `faqs`), `provider_slug`, `page_path` |
| `time_on_page` | Engagement | `seconds`, `provider_slug`, `page_path` |

## Test plan
- [x] `PageEngagementTracker` tests pass (endorsed + emerging section IDs)
- [x] `emergingPageSections` unit test passes
- [ ] CI green


Made with [Cursor](https://cursor.com)