### PR TITLE
fix(metadata): live-page SERP and share metadata sweep (Blitz #5)

### DIFF
--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -21,17 +21,6 @@ export const metadata: Metadata = {
       'max-snippet': -1,
     },
   },
-  title: 'Articles - Neurodiversity Academy',
-  description: 'Explore articles on neurodiversity, education',
-  keywords: [
-    'Neurodiversity Academy',
-    'Blogs',
-    'Neurodiversity',
-    'Education',
-    'Neurodiverse Individuals',
-    'Neurodivergent Mates',
-    'Neurodiversity in vocational education',
-  ],
 };
 
 const CardList: React.FC = () => {

--- a/src/app/endorsements/layout.tsx
+++ b/src/app/endorsements/layout.tsx
@@ -15,19 +15,6 @@ export const metadata: Metadata = {
       'max-snippet': -1,
     },
   },
-  title: 'Endorsements - Neurodiversity Academy',
-  description:
-    'Endorsement ensures that learning organisations meet the\
-              Neurodiversity Academy/’s (NDA) neuro-inclusion standards. Only\
-              endorsed providers are eligible to appear on our platform, giving\
-              students confidence that these organisations are prepared to\
-              support neurodivergent learners effectively.',
-  keywords: [
-    'neurodiverse',
-    'neurodiverse meaning',
-    'Neurodiversity Academy',
-    // ...rest of your keywords...
-  ],
 };
 
 export default function Layout({ children }: { children: React.ReactNode }) {

--- a/src/app/utilities/__tests__/common.test.ts
+++ b/src/app/utilities/__tests__/common.test.ts
@@ -274,6 +274,48 @@ describe('createMetadata', () => {
     const result = createMetadata(META_KEY.HOME);
     expect(result.keywords).toBe(metadata[META_KEY.HOME].keywords);
   });
+
+  it('includes summary_large_image twitter card with title and description', () => {
+    const result = createMetadata(META_KEY.HOME);
+    const homeData = metadata[META_KEY.HOME];
+
+    expect(result.twitter).toEqual(
+      expect.objectContaining({
+        card: 'summary_large_image',
+        title: homeData.title,
+        description: homeData.description,
+      }),
+    );
+  });
+
+  it('includes twitter images when custom images are provided', () => {
+    const imageUrl = 'https://example.com/share.jpg';
+    const result = createMetadata(META_KEY.HOME, {
+      images: [{ url: imageUrl, width: 1200, height: 630 }],
+    });
+
+    expect(result.twitter).toEqual(
+      expect.objectContaining({
+        card: 'summary_large_image',
+        images: [imageUrl],
+      }),
+    );
+  });
+
+  it('registers endorsements metadata with canonical /endorsements', () => {
+    const endorsementsData = metadata[META_KEY.ENDORSEMENTS];
+
+    expect(endorsementsData).toEqual(
+      expect.objectContaining({
+        title: 'Endorsements - Neurodiversity Academy',
+        canonical: expect.stringMatching(/\/endorsements$/),
+      }),
+    );
+
+    const result = createMetadata(META_KEY.ENDORSEMENTS);
+    expect(result.alternates?.canonical).toBe(endorsementsData.canonical);
+    expect(result.title).toBe('Endorsements - Neurodiversity Academy');
+  });
 });
 
 describe('notifyError', () => {

--- a/src/app/utilities/common.ts
+++ b/src/app/utilities/common.ts
@@ -102,19 +102,13 @@ export const pickSeeded = <T>(items: readonly T[], count: number, seed: string):
   return copy.slice(0, count);
 };
 
-const getTwitterImages = (
-  ogImages: MetadataParams['images'],
-): string | string[] | undefined => {
+const getTwitterImages = (ogImages: MetadataParams['images']): string | string[] | undefined => {
   if (!ogImages) {
     return undefined;
   }
 
   const toUrl = (image: string | URL | { url: string | URL }): string =>
-    typeof image === 'string'
-      ? image
-      : image instanceof URL
-        ? image.toString()
-        : String(image.url);
+    typeof image === 'string' ? image : image instanceof URL ? image.toString() : String(image.url);
 
   return Array.isArray(ogImages) ? ogImages.map(toUrl) : toUrl(ogImages);
 };

--- a/src/app/utilities/common.ts
+++ b/src/app/utilities/common.ts
@@ -102,6 +102,23 @@ export const pickSeeded = <T>(items: readonly T[], count: number, seed: string):
   return copy.slice(0, count);
 };
 
+const getTwitterImages = (
+  ogImages: MetadataParams['images'],
+): string | string[] | undefined => {
+  if (!ogImages) {
+    return undefined;
+  }
+
+  const toUrl = (image: string | URL | { url: string | URL }): string =>
+    typeof image === 'string'
+      ? image
+      : image instanceof URL
+        ? image.toString()
+        : String(image.url);
+
+  return Array.isArray(ogImages) ? ogImages.map(toUrl) : toUrl(ogImages);
+};
+
 export const createMetadata = (
   key: META_KEY,
   customMetadata?: Partial<MetadataParams>,
@@ -110,6 +127,7 @@ export const createMetadata = (
     ...metadata[key],
     ...customMetadata,
   };
+  const twitterImages = getTwitterImages(images);
 
   return {
     alternates: {
@@ -124,6 +142,12 @@ export const createMetadata = (
       ...(type && { type }),
       siteName: SITE_NAME,
       locale: LOCALE,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: rest.title || undefined,
+      description: rest.description || undefined,
+      ...(twitterImages && { images: twitterImages }),
     },
     ...rest,
   };

--- a/src/app/utilities/constants.ts
+++ b/src/app/utilities/constants.ts
@@ -40,11 +40,6 @@ export enum META_TYPE {
 export enum META_KEY {
   HOME = 'home',
   NEURODIVERGENT_MATES = 'neurodivergentmates',
-  NEURODIVERSITY_TRAINING = 'neurodiversitytraining',
-  ADVISORY_CONSULTING = 'advisoryconsulting',
-  NETWORKING = 'networking',
-  COACHING = 'coaching',
-  PLACEMENTS = 'placements',
   ABOUT = 'about',
   CONTACT = 'contact',
   ARTICLES = 'articles',

--- a/src/app/utilities/metadata/keywords.ts
+++ b/src/app/utilities/metadata/keywords.ts
@@ -3,20 +3,6 @@ export const KEYWORDS_HOME =
 
 export const KEYWORDS_NEURODIVERGENT_MATES = 'neurodivergentmates, neurodivergent mates, ';
 
-export const KEYWORDS_NEURODIVERSITY_TRAINING =
-  'Neurodiversity Learning/Training Partnerships, Neurodiversity Learning, Learning/Training Partnerships, Neurodiversity Training, ';
-
-export const KEYWORDS_ADVISORY_CONSULTING =
-  'Advisory Neurodiversity Consulting, advisoryneurodiversityconsulting, ';
-
-export const KEYWORDS_NETWORKING =
-  'Host Neurodiversity Workshops & Networking, Neurodiversity Workshops, Neurodiversity Networking, ';
-
-export const KEYWORDS_COACHING =
-  'Neurodiversity Coaching & Placements, Neurodiversity Coaching, Career coaching, ';
-
-export const KEYWORDS_PLACEMENTS = 'Training Partnerships, placements, ';
-
 export const KEYWORDS_ABOUT =
   'About, about us, neurodiversity, neurodiversityacademy, neurodiversity academy, ';
 
@@ -43,3 +29,6 @@ export const KEYWORDS_PROFILE =
 
 export const KEYWORDS_COURSES =
   'course, courses, search, neurodiversity, neurodiversityacademy, neurodiversity academy';
+
+export const KEYWORDS_ENDORSEMENTS =
+  'endorsements, endorsed providers, neuro-inclusion standards, neurodiverse, neurodiverse meaning, neurodiversity, neurodiversityacademy, neurodiversity academy, ';

--- a/src/app/utilities/metadata/metadata.ts
+++ b/src/app/utilities/metadata/metadata.ts
@@ -1,17 +1,13 @@
 import { HOST_URL, META_KEY, META_TYPE } from '../constants';
 import {
   KEYWORDS_ABOUT,
-  KEYWORDS_ADVISORY_CONSULTING,
   KEYWORDS_ARTICLES,
   KEYWORDS_BLOGS,
-  KEYWORDS_COACHING,
   KEYWORDS_CONTACT,
+  KEYWORDS_ENDORSEMENTS,
   KEYWORDS_HOME,
   KEYWORDS_LOGIN,
-  KEYWORDS_NETWORKING,
   KEYWORDS_NEURODIVERGENT_MATES,
-  KEYWORDS_NEURODIVERSITY_TRAINING,
-  KEYWORDS_PLACEMENTS,
   KEYWORDS_SIGNUP,
   KEYWORDS_FORGOT_PASSWORD,
   KEYWORDS_PROFILE,
@@ -35,42 +31,6 @@ export const metadata: Record<string, Partial<MetadataParams>> = {
       'Neurodivergent Mates is two neurodivergent mates from Australia who get together with different members of the community to talk and have in-depth conversations',
     keywords: KEYWORDS_HOME + KEYWORDS_NEURODIVERGENT_MATES,
     canonical: `${HOST_URL}/neurodivergentmates`,
-    type: META_TYPE.WEBSITE,
-  },
-  [META_KEY.NEURODIVERSITY_TRAINING]: {
-    title: 'Learning/Training Partnerships',
-    description: 'Learning/Training Partnerships services from Neurodiversity Academy',
-    keywords: KEYWORDS_HOME + KEYWORDS_NEURODIVERGENT_MATES + KEYWORDS_NEURODIVERSITY_TRAINING,
-    canonical: `${HOST_URL}/services/neurodiversitytraining`,
-    type: META_TYPE.WEBSITE,
-  },
-  [META_KEY.ADVISORY_CONSULTING]: {
-    title: 'Advisory Neurodiversity Consulting',
-    description: 'Advisory Neurodiversity Consulting services from Neurodiversity Academy',
-    keywords: KEYWORDS_HOME + KEYWORDS_NEURODIVERGENT_MATES + KEYWORDS_ADVISORY_CONSULTING,
-    canonical: `${HOST_URL}/services/advisoryconsulting`,
-    type: META_TYPE.WEBSITE,
-  },
-  [META_KEY.NETWORKING]: {
-    title: 'Host Neurodiversity Workshops & Networking (Awareness/Education)',
-    description:
-      'Hosting Neurodiversity Workshops & Networking services from Neurodiversity Academy',
-    keywords: KEYWORDS_HOME + KEYWORDS_NEURODIVERGENT_MATES + KEYWORDS_NETWORKING,
-    canonical: `${HOST_URL}/services/networking`,
-    type: META_TYPE.WEBSITE,
-  },
-  [META_KEY.COACHING]: {
-    title: 'Career Coaching',
-    description: 'Neurodiversity Career Coaching from Neurodiversity Academy',
-    keywords: KEYWORDS_HOME + KEYWORDS_NEURODIVERGENT_MATES + KEYWORDS_COACHING,
-    canonical: `${HOST_URL}/services/coaching`,
-    type: META_TYPE.WEBSITE,
-  },
-  [META_KEY.PLACEMENTS]: {
-    title: 'Placements (Internships/Employment)',
-    description: 'Placements (Internships/Employment) services from Neurodiversity Academy',
-    keywords: KEYWORDS_HOME + KEYWORDS_NEURODIVERGENT_MATES + KEYWORDS_PLACEMENTS,
-    canonical: `${HOST_URL}/services/placements`,
     type: META_TYPE.WEBSITE,
   },
   [META_KEY.ABOUT]: {
@@ -148,6 +108,14 @@ export const metadata: Record<string, Partial<MetadataParams>> = {
     description: 'Search courses associated with Neurodiversity Academy',
     keywords: KEYWORDS_COURSES,
     canonical: META_COURSES_DEFAULT_CANONICAL_URL,
+    type: META_TYPE.WEBSITE,
+  },
+  [META_KEY.ENDORSEMENTS]: {
+    title: 'Endorsements - Neurodiversity Academy',
+    description:
+      "Endorsement ensures that learning organisations meet the Neurodiversity Academy's (NDA) neuro-inclusion standards. Only endorsed providers are eligible to appear on our platform, giving students confidence that these organisations are prepared to support neurodivergent learners effectively.",
+    keywords: KEYWORDS_ENDORSEMENTS,
+    canonical: `${HOST_URL}/endorsements`,
     type: META_TYPE.WEBSITE,
   },
 };


### PR DESCRIPTION
## Summary
- Fix `/blogs` listing title override that incorrectly showed "Articles"
- Register `META_KEY.ENDORSEMENTS` in the metadata registry and simplify the endorsements layout
- Add `twitter:summary_large_image` cards globally via `createMetadata`
- Remove dead `/services/*` metadata entries with no matching live routes

## Test plan
- [x] `npm test -- --testPathPatterns=common.test`
- [ ] Verify `/blogs` `<title>` is "Blogs" (not "Articles")
- [ ] Verify `/endorsements` meta title, description, and canonical
- [ ] Spot-check Twitter card tags on a page with share images (e.g. home)


Made with [Cursor](https://cursor.com)