### PR TITLE
Blitz #7: Internal linking pack for live marketing pages

### DIFF
--- a/src/app/about/__tests__/page.test.tsx
+++ b/src/app/about/__tests__/page.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock('../../components/aboutJourney/Journey', () => ({
+  __esModule: true,
+  default: () => <div>Journey</div>,
+}));
+jest.mock('../../components/aboutValues/Values', () => ({
+  __esModule: true,
+  default: () => <div>Values</div>,
+}));
+jest.mock('../../components/aboutVision/Vision', () => ({
+  __esModule: true,
+  default: () => <div>Vision</div>,
+}));
+jest.mock('../../components/aboutMission/Mission', () => ({
+  __esModule: true,
+  default: () => <div>Mission</div>,
+}));
+jest.mock('../../components/aboutFounders/Founders', () => ({
+  __esModule: true,
+  default: () => <div>Founders</div>,
+}));
+jest.mock('../../components/aboutAdvisors/Advisors', () => ({
+  __esModule: true,
+  default: () => <div>Advisors</div>,
+}));
+
+import Page from '../page';
+
+describe('About page', () => {
+  it('links to endorsements and contact', () => {
+    render(<Page />);
+
+    expect(screen.getByRole('link', { name: 'endorsement program' })).toHaveAttribute(
+      'href',
+      '/endorsements',
+    );
+    expect(screen.getByRole('link', { name: 'contact us' })).toHaveAttribute('href', '/contact');
+  });
+});

--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -43,3 +43,19 @@
     margin-top: 30vh;
   }
 }
+
+.pageLinks {
+  padding: 48px 24px 64px;
+  text-align: center;
+}
+
+.pageLink {
+  color: var(--cherryPie);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.pageLink:hover {
+  color: var(--cherryPieVariant);
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import styles from './about.module.css';
 import Typography, { TypographyVariant } from '../components/typography/Typography';
 import Journey from '../components/aboutJourney/Journey';
@@ -56,6 +57,19 @@ export default function Page() {
       </div>
       <div id='advisors'>
         <Advisors />
+      </div>
+      <div className={styles.pageLinks}>
+        <Typography variant={TypographyVariant.Body1} color='var(--BondBlackVariant)'>
+          Explore our{' '}
+          <Link href='/endorsements' className={styles.pageLink}>
+            endorsement program
+          </Link>{' '}
+          or{' '}
+          <Link href='/contact' className={styles.pageLink}>
+            contact us
+          </Link>
+          .
+        </Typography>
       </div>
     </div>
   );

--- a/src/app/components/course/CourseSearch/CourseSearchEmpty.tsx
+++ b/src/app/components/course/CourseSearch/CourseSearchEmpty.tsx
@@ -2,6 +2,7 @@
 
 import noCoursesSrc from '@/app/images/no_courses.jpg';
 import Image from 'next/image';
+import Link from 'next/link';
 import styles from './courseSearchEmpty.module.css';
 
 export default function CourseSearchEmpty(): React.ReactNode {
@@ -11,6 +12,17 @@ export default function CourseSearchEmpty(): React.ReactNode {
       <div role='alert' className={styles.text} aria-atomic>
         Sorry, there are no results for the applied filter(s).
       </div>
+      <p className={styles.helpText}>
+        Need help finding a course?{' '}
+        <Link href='/contact' className={styles.helpLink}>
+          Contact us
+        </Link>{' '}
+        or explore{' '}
+        <Link href='/endorsements' className={styles.helpLink}>
+          endorsed providers
+        </Link>
+        .
+      </p>
     </div>
   );
 }

--- a/src/app/components/course/CourseSearch/courseSearchEmpty.module.css
+++ b/src/app/components/course/CourseSearch/courseSearchEmpty.module.css
@@ -12,3 +12,22 @@
   text-align: center;
   color: var(--bond-black-light);
 }
+
+.helpText {
+  margin-top: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  text-align: center;
+  color: var(--bond-black-light);
+}
+
+.helpLink {
+  color: var(--cherryPie);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.helpLink:hover {
+  color: var(--cherryPieVariant);
+}

--- a/src/app/components/course/__tests__/course.test.tsx
+++ b/src/app/components/course/__tests__/course.test.tsx
@@ -341,6 +341,15 @@ describe('CourseSearchEmpty', () => {
     render(<CourseSearchEmpty />);
     expect(screen.getByAltText('No courses found.')).toBeInTheDocument();
   });
+
+  it('links to contact and endorsements from help text', () => {
+    render(<CourseSearchEmpty />);
+    expect(screen.getByRole('link', { name: 'Contact us' })).toHaveAttribute('href', '/contact');
+    expect(screen.getByRole('link', { name: 'endorsed providers' })).toHaveAttribute(
+      'href',
+      '/endorsements',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/app/components/howItWorks/HowItWorks.tsx
+++ b/src/app/components/howItWorks/HowItWorks.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from 'next/link';
 import styles from './howItWorks.module.css';
 import Image from 'next/image';
 import explore from '../../images/stepsExplore.svg';
@@ -101,6 +102,21 @@ export default function HowItWorks() {
           </div>
         </div>
       </div>
+      <Typography
+        variant={TypographyVariant.Body1}
+        color={TypographyColorToken.BondBlackVariant}
+        className={styles.exploreLinks}
+      >
+        <Link href='/endorsements' className={styles.exploreLink}>
+          Browse endorsed providers
+        </Link>
+        <span className={styles.exploreLinkDivider} aria-hidden='true'>
+          ·
+        </span>
+        <Link href='/courses' className={styles.exploreLink}>
+          Find neuroinclusive courses
+        </Link>
+      </Typography>
     </div>
   );
 }

--- a/src/app/components/howItWorks/__tests__/HowItWorks.test.tsx
+++ b/src/app/components/howItWorks/__tests__/HowItWorks.test.tsx
@@ -3,6 +3,23 @@ import { render, screen } from '@testing-library/react';
 
 jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 import HowItWorks from '../HowItWorks';
 
 describe('HowItWorks', () => {
@@ -43,5 +60,17 @@ describe('HowItWorks', () => {
     expect(screen.getByAltText('profile')).toBeInTheDocument();
     expect(screen.getByAltText('quality')).toBeInTheDocument();
     expect(screen.getByAltText('guide')).toBeInTheDocument();
+  });
+
+  it('links to endorsements and courses', () => {
+    render(<HowItWorks />);
+    expect(screen.getByRole('link', { name: 'Browse endorsed providers' })).toHaveAttribute(
+      'href',
+      '/endorsements',
+    );
+    expect(screen.getByRole('link', { name: 'Find neuroinclusive courses' })).toHaveAttribute(
+      'href',
+      '/courses',
+    );
   });
 });

--- a/src/app/components/howItWorks/howItWorks.module.css
+++ b/src/app/components/howItWorks/howItWorks.module.css
@@ -96,3 +96,29 @@
     background-image: url('../../images/stepsline1MobileOnLight.svg');
   }
 }
+
+.exploreLinks {
+  margin: 0 30px 80px;
+}
+
+.exploreLink {
+  color: var(--cherryPie);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.exploreLink:hover {
+  color: var(--cherryPieVariant);
+}
+
+.exploreLinkDivider {
+  margin: 0 0.35em;
+}
+
+@media (max-width: 480px) {
+  .exploreLinks {
+    margin: 0 3vw 48px;
+    text-align: center;
+  }
+}

--- a/src/app/components/textHeavyArticle/TextHeavyArticle.tsx
+++ b/src/app/components/textHeavyArticle/TextHeavyArticle.tsx
@@ -60,6 +60,13 @@ export default function TextHeavyArticle({
           />
         </div>
       )}
+      <Typography variant={TypographyVariant.Body2} className={styles.relatedCta}>
+        Ready to explore options?{' '}
+        <Link href='/courses' className={styles.relatedLink}>
+          Browse neuroinclusive courses
+        </Link>
+        .
+      </Typography>
     </div>
   );
 }

--- a/src/app/components/textHeavyArticle/__tests__/TextHeavyArticle.test.tsx
+++ b/src/app/components/textHeavyArticle/__tests__/TextHeavyArticle.test.tsx
@@ -85,4 +85,12 @@ describe('TextHeavyArticle', () => {
     render(<TextHeavyArticle {...defaultProps} />);
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
   });
+
+  it('links to courses from the related CTA', () => {
+    render(<TextHeavyArticle {...defaultProps} />);
+    expect(screen.getByRole('link', { name: 'Browse neuroinclusive courses' })).toHaveAttribute(
+      'href',
+      '/courses',
+    );
+  });
 });

--- a/src/app/components/textHeavyArticle/textHeavyArticle.module.css
+++ b/src/app/components/textHeavyArticle/textHeavyArticle.module.css
@@ -43,6 +43,21 @@
   object-fit: cover;
 }
 
+.relatedCta {
+  margin-top: 2rem;
+}
+
+.relatedLink {
+  color: var(--cherryPie);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.relatedLink:hover {
+  color: var(--cherryPieVariant);
+}
+
 @media (max-width: 1024px) and (min-width: 480px) {
   .imageWrapper {
     height: 400px;

--- a/src/app/components/textHeavyBlog/__tests__/textHeavyBlog.test.tsx
+++ b/src/app/components/textHeavyBlog/__tests__/textHeavyBlog.test.tsx
@@ -70,4 +70,12 @@ describe('TextHeavyBlog', () => {
     render(<TextHeavyBlog {...defaultProps} />);
     expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
   });
+
+  it('links to endorsements from the related CTA', () => {
+    render(<TextHeavyBlog {...defaultProps} />);
+    expect(screen.getByRole('link', { name: 'endorsed providers' })).toHaveAttribute(
+      'href',
+      '/endorsements',
+    );
+  });
 });

--- a/src/app/components/textHeavyBlog/textHeavyBlog.module.css
+++ b/src/app/components/textHeavyBlog/textHeavyBlog.module.css
@@ -26,6 +26,21 @@
   font-size: var(--Body1);
 }
 
+.relatedCta {
+  margin-top: 2rem;
+}
+
+.relatedLink {
+  color: var(--cherryPie);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.relatedLink:hover {
+  color: var(--cherryPieVariant);
+}
+
 @media (max-width: 1024px) and (min-width: 480px) {
   .imageWrapper {
     height: 400px;

--- a/src/app/components/textHeavyBlog/textHeavyBlog.tsx
+++ b/src/app/components/textHeavyBlog/textHeavyBlog.tsx
@@ -47,6 +47,13 @@ export default function TextHeavyBlog({
         </div>
       </div>
       <div className={styles.blogText}>{paragraphs}</div>
+      <Typography variant={TypographyVariant.Body2} className={styles.relatedCta}>
+        Learn about our{' '}
+        <Link href='/endorsements' className={styles.relatedLink}>
+          endorsed providers
+        </Link>
+        .
+      </Typography>
     </div>
   );
 }

--- a/src/app/emergingproviders/[name-of-the-institute]/__tests__/page.test.tsx
+++ b/src/app/emergingproviders/[name-of-the-institute]/__tests__/page.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock('@/app/components/emergingInstitutions/EmergingProviderHero', () => ({
+  __esModule: true,
+  default: () => <div>Hero</div>,
+}));
+jest.mock('@/app/components/emergingInstitutions/EmergingProviderStudentSuitability', () => ({
+  __esModule: true,
+  default: () => <div>Suitability</div>,
+}));
+jest.mock('@/app/components/emergingInstitutions/EmergingProviderStats', () => ({
+  __esModule: true,
+  default: () => <div>Stats</div>,
+}));
+jest.mock('@/app/components/emergingInstitutions/EmergingProvidersFAQs', () => ({
+  __esModule: true,
+  default: () => <div>FAQs</div>,
+}));
+
+import EmergingProviderPage from '../page';
+
+describe('Emerging provider page', () => {
+  it('links back to endorsements and home', async () => {
+    const page = await EmergingProviderPage({
+      params: Promise.resolve({ 'name-of-the-institute': 'bond-university' }),
+    });
+
+    render(page);
+
+    expect(screen.getByRole('navigation', { name: 'Related pages' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'NDA endorsements' })).toHaveAttribute(
+      'href',
+      '/endorsements',
+    );
+    expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('href', '/');
+  });
+});

--- a/src/app/emergingproviders/[name-of-the-institute]/emergingProviderPage.module.css
+++ b/src/app/emergingproviders/[name-of-the-institute]/emergingProviderPage.module.css
@@ -4,8 +4,33 @@
   gap: 30px;
 }
 
+.pageLinks {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px 24px;
+  padding: 0 24px 48px;
+}
+
+.pageLink {
+  color: var(--cherryPie);
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.5;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.pageLink:hover {
+  color: var(--cherryPieVariant);
+}
+
 @media (max-width: 767px) {
   .pageMain {
     gap: 5px;
+  }
+
+  .pageLinks {
+    padding: 0 12px 36px;
   }
 }

--- a/src/app/emergingproviders/[name-of-the-institute]/page.tsx
+++ b/src/app/emergingproviders/[name-of-the-institute]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import cardData from '@/app/components/emergingInstitutions/emergingInstitutions.json';
 import EmergingProviderHero from '@/app/components/emergingInstitutions/EmergingProviderHero';
 import EmergingProviderStudentSuitability from '@/app/components/emergingInstitutions/EmergingProviderStudentSuitability';
@@ -44,6 +45,14 @@ export default async function EmergingProviderPage({ params }: { params: Promise
       <EmergingProviderStudentSuitability instituteSlug={institutionSlug} />
       <EmergingProviderStats stats={providerStats} />
       <EmergingProvidersFAQs />
+      <nav className={pageStyles.pageLinks} aria-label='Related pages'>
+        <Link href='/endorsements' className={pageStyles.pageLink}>
+          NDA endorsements
+        </Link>
+        <Link href='/' className={pageStyles.pageLink}>
+          Home
+        </Link>
+      </nav>
     </main>
   );
 }

--- a/src/app/endorsements/__tests__/page.test.tsx
+++ b/src/app/endorsements/__tests__/page.test.tsx
@@ -47,4 +47,13 @@ describe('Endorsements page', () => {
     expect(screen.getByText('NDA Endorsed Providers')).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'Explore More' })).toHaveLength(4);
   });
+
+  it('links to courses from the endorsements hub', () => {
+    render(<Page />);
+
+    expect(screen.getByRole('link', { name: 'Browse neuroinclusive courses' })).toHaveAttribute(
+      'href',
+      '/courses',
+    );
+  });
 });

--- a/src/app/endorsements/endorsements.module.css
+++ b/src/app/endorsements/endorsements.module.css
@@ -234,3 +234,19 @@
     margin-bottom: 1em;
   }
 }
+
+.coursesPrompt {
+  margin: 0 24px 48px;
+  text-align: center;
+}
+
+.inlineLink {
+  color: var(--cherryPie);
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.inlineLink:hover {
+  color: var(--cherryPieVariant);
+}

--- a/src/app/endorsements/page.tsx
+++ b/src/app/endorsements/page.tsx
@@ -30,6 +30,17 @@ export default function Page() {
       <Fact />
       <EndorsementProcess />
       <EndorsedProviders />
+      <Typography
+        variant={TypographyVariant.Body1}
+        color='var(--BondBlackVariant)'
+        className={styles.coursesPrompt}
+      >
+        Looking for study options?{' '}
+        <Link href='/courses' className={styles.inlineLink}>
+          Browse neuroinclusive courses
+        </Link>
+        .
+      </Typography>
       <Partner />
       <DisplayPodcast
         scriptSrc='https://www.buzzsprout.com/2132579.js?container_id=buzzsprout-large-player&player=large'


### PR DESCRIPTION
## Summary
- Adds lightweight, text-only internal links across live marketing pages to improve SEO crawl paths and user discovery — no hero redesigns or new card UI.
- Covers home (How it works footer), endorsements hub, about, emerging provider detail, article/blog detail footers, and courses empty state.
- Skips placements where clear links already exist (endorsed provider cards → detail pages; endorsements `/contact` CTA).

## Links added (from → to)
| From | To | Copy |
|------|-----|------|
| Home (`HowItWorks`) | `/endorsements` | Browse endorsed providers |
| Home (`HowItWorks`) | `/courses` | Find neuroinclusive courses |
| Endorsements hub | `/courses` | Browse neuroinclusive courses |
| About | `/endorsements` | endorsement program |
| About | `/contact` | contact us |
| Emerging provider detail | `/endorsements` | NDA endorsements |
| Emerging provider detail | `/` | Home |
| Article detail | `/courses` | Browse neuroinclusive courses |
| Blog detail | `/endorsements` | endorsed providers |
| Courses empty state | `/contact` | Contact us |
| Courses empty state | `/endorsements` | endorsed providers |

## Skipped (already present)
- Endorsements hub → endorsed provider detail pages (card CTAs already link via `InstitutionProviderCard`)
- Endorsements hub → `/contact` (existing “Contact us for endorsement” button)
- Home hero → `/endorsements` (navbar + footer already link; avoided hero clutter)

## Critique 1 — CSS duplication
Inline link styling (cherry underline) is repeated across several co-located CSS modules rather than a shared primitive. This keeps the diff minimal and avoids a new “related links” subsystem, but a future follow-up could extract a single `.marketingInlineLink` utility if more pages need the same pattern.

## Critique 2 — Home placement
Links live under **How it works** instead of the hero banner so we don’t add hero clutter or fight the existing search/filter layout. Trade-off: slightly less prominence than a hero CTA, but better fit with existing design and still crawlable in main content.

## Critique 3 — Endorsements hub coverage
Provider cards and contact CTA already cover detail + contact paths. Added only a `/courses` cross-link to connect the two primary discovery funnels without duplicating card links or FAQ noise.

## Test plan
- [x] `npx jest` on affected suites (HowItWorks, TextHeavyArticle/Blog, CourseSearchEmpty, endorsements/about/emerging page tests)
- [ ] CI green
- [ ] Spot-check linked routes in browser

## Files
- `src/app/components/howItWorks/HowItWorks.tsx` + module CSS + test
- `src/app/endorsements/page.tsx` + module CSS + test
- `src/app/about/page.tsx` + module CSS + new page test
- `src/app/emergingproviders/[name-of-the-institute]/page.tsx` + module CSS + new page test
- `src/app/components/textHeavyArticle/TextHeavyArticle.tsx` + module CSS + test
- `src/app/components/textHeavyBlog/textHeavyBlog.tsx` + module CSS + test
- `src/app/components/course/CourseSearch/CourseSearchEmpty.tsx` + module CSS + test


Made with [Cursor](https://cursor.com)