### PR TITLE
Blitz #8: Endorsements CTA polish + click tracking

### DIFF
--- a/src/app/components/endorsements/EndorsementsContactCta.tsx
+++ b/src/app/components/endorsements/EndorsementsContactCta.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import ActionButton from '../buttons/ActionButton';
+import { BUTTON_STYLE, ENDORSEMENTS_CTA_LABELS } from '@/app/utilities/constants';
+import { sendContactCtaClickEvent } from '@/app/utilities/gaTracking';
+import { sendMetaContactCtaLeadEvent } from '@/app/utilities/metaPixelTracking';
+import styles from '../../endorsements/endorsements.module.css';
+
+const CONTACT_PATH = '/contact';
+const CONTACT_CTA_SECTION = 'endorsements_faq';
+
+interface EndorsementsContactCtaProps {
+  className?: string;
+}
+
+export default function EndorsementsContactCta({ className }: EndorsementsContactCtaProps) {
+  const handleContactClick = () => {
+    sendContactCtaClickEvent(CONTACT_PATH, CONTACT_CTA_SECTION);
+    sendMetaContactCtaLeadEvent();
+  };
+
+  return (
+    <ActionButton
+      style={BUTTON_STYLE.Primary}
+      label={ENDORSEMENTS_CTA_LABELS.CONTACT}
+      className={className ?? styles.enrolBtn}
+      to={CONTACT_PATH}
+      onClick={handleContactClick}
+    />
+  );
+}

--- a/src/app/components/endorsements/__tests__/EndorsementsContactCta.test.tsx
+++ b/src/app/components/endorsements/__tests__/EndorsementsContactCta.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.mock('@/app/utilities/gaTracking', () => ({
+  sendContactCtaClickEvent: jest.fn(),
+}));
+
+jest.mock('@/app/utilities/metaPixelTracking', () => ({
+  sendMetaContactCtaLeadEvent: jest.fn(),
+}));
+
+import EndorsementsContactCta from '../EndorsementsContactCta';
+import { sendContactCtaClickEvent } from '@/app/utilities/gaTracking';
+import { sendMetaContactCtaLeadEvent } from '@/app/utilities/metaPixelTracking';
+import { ENDORSEMENTS_CTA_LABELS } from '@/app/utilities/constants';
+
+const mockSendContactCtaClickEvent = sendContactCtaClickEvent as jest.Mock;
+const mockSendMetaContactCtaLeadEvent = sendMetaContactCtaLeadEvent as jest.Mock;
+
+describe('EndorsementsContactCta', () => {
+  beforeEach(() => {
+    mockSendContactCtaClickEvent.mockClear();
+    mockSendMetaContactCtaLeadEvent.mockClear();
+  });
+
+  it('renders contact CTA label', () => {
+    render(<EndorsementsContactCta />);
+    expect(screen.getByText(ENDORSEMENTS_CTA_LABELS.CONTACT)).toBeInTheDocument();
+  });
+
+  it('tracks GA and Meta Lead on click', () => {
+    render(<EndorsementsContactCta />);
+    fireEvent.click(screen.getByText(ENDORSEMENTS_CTA_LABELS.CONTACT));
+    expect(mockSendContactCtaClickEvent).toHaveBeenCalledWith('/contact', 'endorsements_faq');
+    expect(mockSendMetaContactCtaLeadEvent).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/handbook/__tests__/Handbook.test.tsx
+++ b/src/app/components/handbook/__tests__/Handbook.test.tsx
@@ -16,14 +16,33 @@ jest.mock('@/app/utilities/common', () => ({
   notifyError: jest.fn(),
 }));
 
+jest.mock('@/app/utilities/gaTracking', () => ({
+  sendHandbookCtaClickEvent: jest.fn(),
+}));
+
+jest.mock('@/app/utilities/metaPixelTracking', () => ({
+  sendMetaHandbookCtaLeadEvent: jest.fn(),
+}));
+
 import Handbook from '../index';
+import { ENDORSEMENTS_CTA_LABELS } from '@/app/utilities/constants';
+import { sendHandbookCtaClickEvent } from '@/app/utilities/gaTracking';
+import { sendMetaHandbookCtaLeadEvent } from '@/app/utilities/metaPixelTracking';
+
+const mockSendHandbookCtaClickEvent = sendHandbookCtaClickEvent as jest.Mock;
+const mockSendMetaHandbookCtaLeadEvent = sendMetaHandbookCtaLeadEvent as jest.Mock;
 
 describe('Handbook', () => {
+  beforeEach(() => {
+    mockSendHandbookCtaClickEvent.mockClear();
+    mockSendMetaHandbookCtaLeadEvent.mockClear();
+  });
+
   it('renders handbook heading and description', () => {
     render(<Handbook />);
     expect(screen.getByText('Neuro-Inclusion in Vocational Education')).toBeInTheDocument();
     expect(
-      screen.getByText(/Explore key strategies for building neuro-inclusive/),
+      screen.getByText(/Download our free handbook for practical strategies/),
     ).toBeInTheDocument();
   });
 
@@ -33,9 +52,11 @@ describe('Handbook', () => {
     expect(screen.getByAltText('Handbook Mobile Screenshot')).toBeInTheDocument();
   });
 
-  it('opens popup when Free Download is clicked', () => {
+  it('opens popup and tracks CTA click when handbook button is clicked', () => {
     render(<Handbook />);
-    fireEvent.click(screen.getByText('Free Download'));
+    fireEvent.click(screen.getByText(ENDORSEMENTS_CTA_LABELS.HANDBOOK));
+    expect(mockSendHandbookCtaClickEvent).toHaveBeenCalledWith('handbook');
+    expect(mockSendMetaHandbookCtaLeadEvent).toHaveBeenCalled();
     expect(screen.getByText('Subscribe to our Newsletter!')).toBeInTheDocument();
   });
 

--- a/src/app/components/handbook/index.tsx
+++ b/src/app/components/handbook/index.tsx
@@ -7,13 +7,23 @@ import handbookMobileSrc from '@/app/images/handbook-mobile.png';
 import Image from 'next/image';
 import Typography, { TypographyVariant } from '../typography/Typography';
 import ActionButton from '../buttons/ActionButton';
-import { BUTTON_STYLE } from '@/app/utilities/constants';
+import { BUTTON_STYLE, ENDORSEMENTS_CTA_LABELS } from '@/app/utilities/constants';
+import { sendHandbookCtaClickEvent } from '@/app/utilities/gaTracking';
+import { sendMetaHandbookCtaLeadEvent } from '@/app/utilities/metaPixelTracking';
 import HandbookPopup from './HandbookPopup';
+
+const HANDBOOK_CTA_SECTION = 'handbook';
 
 const Handbook: React.FC = () => {
   const [popupOpen, setPopupOpen] = useState(false);
   const onPopupClose = () => {
     setPopupOpen(false);
+  };
+
+  const handleHandbookClick = () => {
+    sendHandbookCtaClickEvent(HANDBOOK_CTA_SECTION);
+    sendMetaHandbookCtaLeadEvent();
+    setPopupOpen(true);
   };
 
   return (
@@ -26,14 +36,14 @@ const Handbook: React.FC = () => {
               Neuro-Inclusion in Vocational Education
             </Typography>
             <Typography variant={TypographyVariant.Body3} className={styles.subtext}>
-              Explore key strategies for building neuro-inclusive vocational education organizations
-              in our <b>free</b> handbook.
+              Download our free handbook for practical strategies to build neuro-inclusive
+              vocational education organisations.
             </Typography>
           </div>
           <ActionButton
-            label='Free Download'
+            label={ENDORSEMENTS_CTA_LABELS.HANDBOOK}
             style={BUTTON_STYLE.Primary}
-            onClick={() => setPopupOpen(true)}
+            onClick={handleHandbookClick}
           />
         </div>
       </div>

--- a/src/app/endorsements/__tests__/page.test.tsx
+++ b/src/app/endorsements/__tests__/page.test.tsx
@@ -38,7 +38,16 @@ jest.mock(
 );
 jest.mock('../../components/accordion/Accordian', () => require('@/testUtils/mockAccordion'));
 
+jest.mock('../../components/endorsements/EndorsementsContactCta', () => ({
+  __esModule: true,
+  default: () => {
+    const { ENDORSEMENTS_CTA_LABELS } = require('@/app/utilities/constants');
+    return <a href='/contact'>{ENDORSEMENTS_CTA_LABELS.CONTACT}</a>;
+  },
+}));
+
 import Page from '../page';
+import { ENDORSEMENTS_CTA_LABELS } from '@/app/utilities/constants';
 
 describe('Endorsements page', () => {
   it('renders live endorsed organisations', () => {
@@ -46,5 +55,14 @@ describe('Endorsements page', () => {
 
     expect(screen.getByText('NDA Endorsed Providers')).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'Explore More' })).toHaveLength(4);
+  });
+
+  it('renders tracked contact CTA below FAQs', () => {
+    render(<Page />);
+
+    expect(screen.getByRole('link', { name: ENDORSEMENTS_CTA_LABELS.CONTACT })).toHaveAttribute(
+      'href',
+      '/contact',
+    );
   });
 });

--- a/src/app/endorsements/page.tsx
+++ b/src/app/endorsements/page.tsx
@@ -15,16 +15,19 @@ import Image from 'next/image';
 import bronzeBadge from '../images/bronzeBadge.svg';
 import silverBadge from '../images/silverBadge.svg';
 import goldBadge from '../images/goldBadge.svg';
-import ActionButton from '../components/buttons/ActionButton';
-import { BUTTON_STYLE } from '../utilities/constants';
-import Link from 'next/link';
 import Accordion from '../components/accordion/Accordian';
+import EndorsementsContactCta from '../components/endorsements/EndorsementsContactCta';
 import { ACCORDION_TRACKING_DISABLED } from '@/app/utilities/accordionActions';
+import { ENDORSEMENTS_HERO_SUBTITLE } from '@/app/utilities/constants';
 
 export default function Page() {
   return (
     <div className={styles.container}>
-      <HomeBanner displayBadges={true} displayFilter={false} />
+      <HomeBanner
+        displayBadges={true}
+        displayFilter={false}
+        subtitle={ENDORSEMENTS_HERO_SUBTITLE}
+      />
       <Teacher />
       <Handbook />
       <Fact />
@@ -169,13 +172,7 @@ export default function Page() {
             </Accordion>
           </div>
         </div>
-        <Link href='/contact'>
-          <ActionButton
-            style={BUTTON_STYLE.Primary}
-            label='Contact us for endorsement'
-            className={styles.enrolBtn}
-          />
-        </Link>
+        <EndorsementsContactCta />
       </div>
     </div>
   );

--- a/src/app/utilities/__tests__/constants.test.ts
+++ b/src/app/utilities/__tests__/constants.test.ts
@@ -1,15 +1,22 @@
-import { GA_EVENTS } from '../constants';
+import {
+  CONVERSION_CTA_NAMES,
+  ENDORSEMENTS_CTA_LABELS,
+  GA_EVENTS,
+  META_EVENTS,
+} from '../constants';
 
 describe('GA_EVENTS', () => {
-  it('has exactly 5 event definitions', () => {
+  it('has exactly 7 event definitions', () => {
     const keys = Object.keys(GA_EVENTS);
-    expect(keys).toHaveLength(5);
+    expect(keys).toHaveLength(7);
     expect(keys).toEqual([
       'SCROLL_DEPTH',
       'SECTION_VISIBLE',
       'TIME_ON_PAGE',
       'ACCORDION_TOGGLE',
       'ENDORSED_EXPLORE_CLICK',
+      'HANDBOOK_CTA_CLICK',
+      'CONTACT_CTA_CLICK',
     ]);
   });
 
@@ -26,5 +33,23 @@ describe('GA_EVENTS', () => {
     expect(GA_EVENTS.TIME_ON_PAGE.eventName).toBe('time_on_page');
     expect(GA_EVENTS.ACCORDION_TOGGLE.eventName).toBe('accordion_toggle');
     expect(GA_EVENTS.ENDORSED_EXPLORE_CLICK.eventName).toBe('endorsed_explore_click');
+    expect(GA_EVENTS.HANDBOOK_CTA_CLICK.eventName).toBe('handbook_cta_click');
+    expect(GA_EVENTS.CONTACT_CTA_CLICK.eventName).toBe('contact_cta_click');
+  });
+});
+
+describe('conversion CTA constants', () => {
+  it('exposes endorsement CTA labels', () => {
+    expect(ENDORSEMENTS_CTA_LABELS.HANDBOOK).toBe('Get the free handbook');
+    expect(ENDORSEMENTS_CTA_LABELS.CONTACT).toBe('Contact us about endorsement');
+  });
+
+  it('exposes conversion CTA names for Meta content_name', () => {
+    expect(CONVERSION_CTA_NAMES.HANDBOOK).toBe('handbook');
+    expect(CONVERSION_CTA_NAMES.CONTACT).toBe('contact_us');
+  });
+
+  it('exposes Meta Lead event name', () => {
+    expect(META_EVENTS.LEAD).toBe('Lead');
   });
 });

--- a/src/app/utilities/__tests__/gaTracking.test.ts
+++ b/src/app/utilities/__tests__/gaTracking.test.ts
@@ -3,19 +3,22 @@ import {
   GA_PARAM,
   ENDORSED_EXPLORE_LINK_TEXT,
   sendAccordionToggleEvent,
+  sendContactCtaClickEvent,
   sendEndorsedExploreClickEvent,
   sendGaEvent,
+  sendHandbookCtaClickEvent,
   sendScrollDepthEvent,
   sendSectionVisibleEvent,
   sendTimeOnPageEvent,
   buildProviderScopedParams,
+  buildPageScopedParams,
 } from '@/app/utilities/gaTracking';
-import { GA_EVENTS } from '@/app/utilities/constants';
+import { ENDORSEMENTS_CTA_LABELS, GA_EVENTS } from '@/app/utilities/constants';
 import { installGtagMock, installTestPagePath } from '@/app/utilities/__tests__/gaTestHelpers';
 
 describe('gaTracking', () => {
   beforeEach(() => {
-    installTestPagePath('/endorsedproviders/collarts');
+    installTestPagePath('/endorsements');
   });
 
   it('sendGaEvent is a no-op when gtag is missing', () => {
@@ -24,6 +27,7 @@ describe('gaTracking', () => {
   });
 
   it('buildProviderScopedParams includes slug and page path', () => {
+    installTestPagePath('/endorsedproviders/collarts');
     const params = buildProviderScopedParams('collarts', {
       [GA_PARAM.CATEGORY]: 'Engagement',
     });
@@ -35,6 +39,7 @@ describe('gaTracking', () => {
   });
 
   it('sendScrollDepthEvent dispatches scroll_depth', () => {
+    installTestPagePath('/endorsedproviders/collarts');
     const mockGtag = installGtagMock();
     sendScrollDepthEvent('collarts', 50);
     expect(mockGtag).toHaveBeenCalledWith(
@@ -50,6 +55,7 @@ describe('gaTracking', () => {
   });
 
   it('sendSectionVisibleEvent dispatches section_visible', () => {
+    installTestPagePath('/endorsedproviders/collarts');
     const mockGtag = installGtagMock();
     sendSectionVisibleEvent('collarts', 'faqs');
     expect(mockGtag).toHaveBeenCalledWith(
@@ -64,6 +70,7 @@ describe('gaTracking', () => {
   });
 
   it('sendTimeOnPageEvent dispatches time_on_page', () => {
+    installTestPagePath('/endorsedproviders/collarts');
     const mockGtag = installGtagMock();
     sendTimeOnPageEvent('collarts', 42);
     expect(mockGtag).toHaveBeenCalledWith(
@@ -78,6 +85,7 @@ describe('gaTracking', () => {
   });
 
   it('sendAccordionToggleEvent dispatches accordion_toggle params', () => {
+    installTestPagePath('/endorsedproviders/collarts');
     const mockGtag = installGtagMock();
     sendAccordionToggleEvent(
       GA_EVENTS.ACCORDION_TOGGLE.eventName,
@@ -92,6 +100,7 @@ describe('gaTracking', () => {
   });
 
   it('sendEndorsedExploreClickEvent dispatches endorsed_explore_click', () => {
+    installTestPagePath('/endorsedproviders/collarts');
     const mockGtag = installGtagMock();
     const destinationUrl = 'https://example.com/courses';
     sendEndorsedExploreClickEvent('collarts', destinationUrl);
@@ -104,6 +113,45 @@ describe('gaTracking', () => {
         provider_slug: 'collarts',
         link_text: ENDORSED_EXPLORE_LINK_TEXT,
         category: GA_EVENTS.ENDORSED_EXPLORE_CLICK.category,
+      },
+    );
+  });
+
+  it('buildPageScopedParams includes page path', () => {
+    const params = buildPageScopedParams({ [GA_PARAM.CATEGORY]: 'Conversion' });
+    expect(params).toEqual({
+      category: 'Conversion',
+      page_path: '/endorsements',
+    });
+  });
+
+  it('sendHandbookCtaClickEvent dispatches handbook_cta_click', () => {
+    const mockGtag = installGtagMock();
+    sendHandbookCtaClickEvent('handbook');
+    expect(mockGtag).toHaveBeenCalledWith(
+      GA_EVENT_COMMAND,
+      GA_EVENTS.HANDBOOK_CTA_CLICK.eventName,
+      {
+        category: GA_EVENTS.HANDBOOK_CTA_CLICK.category,
+        link_text: ENDORSEMENTS_CTA_LABELS.HANDBOOK,
+        page_path: '/endorsements',
+        section: 'handbook',
+      },
+    );
+  });
+
+  it('sendContactCtaClickEvent dispatches contact_cta_click', () => {
+    const mockGtag = installGtagMock();
+    sendContactCtaClickEvent('/contact', 'endorsements_faq');
+    expect(mockGtag).toHaveBeenCalledWith(
+      GA_EVENT_COMMAND,
+      GA_EVENTS.CONTACT_CTA_CLICK.eventName,
+      {
+        category: GA_EVENTS.CONTACT_CTA_CLICK.category,
+        link_text: ENDORSEMENTS_CTA_LABELS.CONTACT,
+        destination_url: '/contact',
+        page_path: '/endorsements',
+        section: 'endorsements_faq',
       },
     );
   });

--- a/src/app/utilities/__tests__/gaTracking.test.ts
+++ b/src/app/utilities/__tests__/gaTracking.test.ts
@@ -143,16 +143,12 @@ describe('gaTracking', () => {
   it('sendContactCtaClickEvent dispatches contact_cta_click', () => {
     const mockGtag = installGtagMock();
     sendContactCtaClickEvent('/contact', 'endorsements_faq');
-    expect(mockGtag).toHaveBeenCalledWith(
-      GA_EVENT_COMMAND,
-      GA_EVENTS.CONTACT_CTA_CLICK.eventName,
-      {
-        category: GA_EVENTS.CONTACT_CTA_CLICK.category,
-        link_text: ENDORSEMENTS_CTA_LABELS.CONTACT,
-        destination_url: '/contact',
-        page_path: '/endorsements',
-        section: 'endorsements_faq',
-      },
-    );
+    expect(mockGtag).toHaveBeenCalledWith(GA_EVENT_COMMAND, GA_EVENTS.CONTACT_CTA_CLICK.eventName, {
+      category: GA_EVENTS.CONTACT_CTA_CLICK.category,
+      link_text: ENDORSEMENTS_CTA_LABELS.CONTACT,
+      destination_url: '/contact',
+      page_path: '/endorsements',
+      section: 'endorsements_faq',
+    });
   });
 });

--- a/src/app/utilities/__tests__/metaPixelTracking.test.ts
+++ b/src/app/utilities/__tests__/metaPixelTracking.test.ts
@@ -1,0 +1,42 @@
+import {
+  sendMetaContactCtaLeadEvent,
+  sendMetaEvent,
+  sendMetaHandbookCtaLeadEvent,
+} from '@/app/utilities/metaPixelTracking';
+import { CONVERSION_CTA_NAMES, META_EVENTS } from '@/app/utilities/constants';
+
+type FbqTestWindow = Window & {
+  fbq?: jest.Mock;
+};
+
+describe('metaPixelTracking', () => {
+  const mockFbq = jest.fn();
+
+  beforeEach(() => {
+    mockFbq.mockClear();
+    (window as FbqTestWindow).fbq = mockFbq;
+  });
+
+  afterEach(() => {
+    delete (window as FbqTestWindow).fbq;
+  });
+
+  it('sendMetaEvent is a no-op when fbq is missing', () => {
+    delete (window as FbqTestWindow).fbq;
+    expect(() => sendMetaEvent(META_EVENTS.LEAD)).not.toThrow();
+  });
+
+  it('sendMetaHandbookCtaLeadEvent tracks Lead with handbook cta content_name', () => {
+    sendMetaHandbookCtaLeadEvent();
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.LEAD, {
+      content_name: `${CONVERSION_CTA_NAMES.HANDBOOK}_cta`,
+    });
+  });
+
+  it('sendMetaContactCtaLeadEvent tracks Lead with contact cta content_name', () => {
+    sendMetaContactCtaLeadEvent();
+    expect(mockFbq).toHaveBeenCalledWith('track', META_EVENTS.LEAD, {
+      content_name: `${CONVERSION_CTA_NAMES.CONTACT}_cta`,
+    });
+  });
+});

--- a/src/app/utilities/constants.ts
+++ b/src/app/utilities/constants.ts
@@ -100,4 +100,23 @@ export const GA_EVENTS = {
     eventName: 'endorsed_explore_click',
     category: 'Endorsed',
   },
+  HANDBOOK_CTA_CLICK: { eventName: 'handbook_cta_click', category: 'Conversion' },
+  CONTACT_CTA_CLICK: { eventName: 'contact_cta_click', category: 'Conversion' },
+} as const;
+
+export const CONVERSION_CTA_NAMES = {
+  HANDBOOK: 'handbook',
+  CONTACT: 'contact_us',
+} as const;
+
+export const ENDORSEMENTS_CTA_LABELS = {
+  HANDBOOK: 'Get the free handbook',
+  CONTACT: 'Contact us about endorsement',
+} as const;
+
+export const ENDORSEMENTS_HERO_SUBTITLE =
+  'Download our free handbook or contact us to start your organisation’s endorsement journey.' as const;
+
+export const META_EVENTS = {
+  LEAD: 'Lead',
 } as const;

--- a/src/app/utilities/gaTracking.ts
+++ b/src/app/utilities/gaTracking.ts
@@ -1,4 +1,4 @@
-import { GA_EVENTS } from '@/app/utilities/constants';
+import { ENDORSEMENTS_CTA_LABELS, GA_EVENTS } from '@/app/utilities/constants';
 
 export const GA_EVENT_COMMAND = 'event' as const;
 
@@ -110,6 +110,36 @@ export function sendEndorsedExploreClickEvent(providerSlug: string, destinationU
       [GA_PARAM.DESTINATION_URL]: destinationUrl,
       [GA_PARAM.LINK_TEXT]: ENDORSED_EXPLORE_LINK_TEXT,
       [GA_PARAM.CATEGORY]: GA_EVENTS.ENDORSED_EXPLORE_CLICK.category,
+    }),
+  );
+}
+
+export function buildPageScopedParams(extra: GaEventParams): GaEventParams {
+  return {
+    ...extra,
+    [GA_PARAM.PAGE_PATH]: window.location.pathname,
+  };
+}
+
+export function sendHandbookCtaClickEvent(section: string): void {
+  sendGaEvent(
+    GA_EVENTS.HANDBOOK_CTA_CLICK.eventName,
+    buildPageScopedParams({
+      [GA_PARAM.CATEGORY]: GA_EVENTS.HANDBOOK_CTA_CLICK.category,
+      [GA_PARAM.LINK_TEXT]: ENDORSEMENTS_CTA_LABELS.HANDBOOK,
+      [GA_PARAM.SECTION]: section,
+    }),
+  );
+}
+
+export function sendContactCtaClickEvent(destinationUrl: string, section: string): void {
+  sendGaEvent(
+    GA_EVENTS.CONTACT_CTA_CLICK.eventName,
+    buildPageScopedParams({
+      [GA_PARAM.CATEGORY]: GA_EVENTS.CONTACT_CTA_CLICK.category,
+      [GA_PARAM.LINK_TEXT]: ENDORSEMENTS_CTA_LABELS.CONTACT,
+      [GA_PARAM.DESTINATION_URL]: destinationUrl,
+      [GA_PARAM.SECTION]: section,
     }),
   );
 }

--- a/src/app/utilities/metaPixelTracking.ts
+++ b/src/app/utilities/metaPixelTracking.ts
@@ -1,0 +1,39 @@
+import { CONVERSION_CTA_NAMES, META_EVENTS } from '@/app/utilities/constants';
+
+export type MetaEventParams = Record<string, string>;
+
+type FbqFn = (...args: Array<string | MetaEventParams>) => void;
+
+interface FbqWindow extends Window {
+  fbq?: FbqFn;
+}
+
+function resolveFbq(): FbqFn | null {
+  const candidate = (window as FbqWindow).fbq;
+  if (typeof candidate === 'function') {
+    return candidate;
+  }
+  return null;
+}
+
+export function sendMetaEvent(eventName: string, params?: MetaEventParams): void {
+  const fbq = resolveFbq();
+  if (fbq === null) {
+    return;
+  }
+
+  if (params === undefined) {
+    fbq('track', eventName);
+    return;
+  }
+
+  fbq('track', eventName, params);
+}
+
+export function sendMetaHandbookCtaLeadEvent(): void {
+  sendMetaEvent(META_EVENTS.LEAD, { content_name: `${CONVERSION_CTA_NAMES.HANDBOOK}_cta` });
+}
+
+export function sendMetaContactCtaLeadEvent(): void {
+  sendMetaEvent(META_EVENTS.LEAD, { content_name: `${CONVERSION_CTA_NAMES.CONTACT}_cta` });
+}


### PR DESCRIPTION
## Summary
- Clarify `/endorsements` lead paths: hero subtitle, handbook copy/button label, and FAQ contact CTA copy
- Add GA click events (`handbook_cta_click`, `contact_cta_click`) for handbook popup open and contact navigation
- Mirror Meta Pixel `Lead` on those CTA clicks with `_cta` content_name suffix (distinct from form submit events in PR #290)
- Endorsed provider card clicks remain on existing `endorsed_cta_click`; FAQ accordion tracking left disabled (not one-liner safe)

## Test plan
- [x] Unit tests for constants, gaTracking, metaPixelTracking, Handbook, EndorsementsContactCta, endorsements page
- [ ] Manual: open `/endorsements`, click **Get the free handbook** — popup opens, GA/Meta fire on click (not submit)
- [ ] Manual: click **Contact us about endorsement** — navigates to `/contact`, GA/Meta fire on click
- [ ] Manual: endorsed card **Explore More** still fires existing `endorsed_cta_click`


Made with [Cursor](https://cursor.com)