### PR TITLE
feat(seo): JSON-LD structured data for live content pages

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -9,6 +9,9 @@ import Subscribe from '@/app/components/subscribe/subscribe';
 import { HOST_URL, META_KEY } from '@/app/utilities/constants';
 import { createMetadata, slugify } from '@/app/utilities/common';
 import VisitTrackerWrapper from '@/app/components/wrapper/VisitTrackerWrapper';
+import JsonLd from '@/app/components/seo/JsonLd';
+import { buildArticleSchema } from '@/app/components/seo/schemaBuilders';
+import { getSiteOrigin } from '@/app/components/seo/siteOrigin';
 
 interface Props {
   params: Promise<{
@@ -54,10 +57,22 @@ export default async function OneArticle({ params }: Props) {
     return <Typography variant={TypographyVariant.H1}>Article not found</Typography>;
   }
 
-  const { id, header, imageUrl, bodyText, authorName, authorImageUrl } = article;
+  const { id, header, title, description, imageUrl, bodyText, authorName, authorImageUrl } =
+    article;
+  const siteOrigin = getSiteOrigin();
+  const canonical = `${siteOrigin}/articles/${slug}`;
 
   return (
     <div className={styles.container}>
+      <JsonLd
+        data={buildArticleSchema(siteOrigin, {
+          headline: header ?? title,
+          description,
+          url: canonical,
+          imageUrl,
+          authorName,
+        })}
+      />
       <VisitTrackerWrapper id={id} type='article' />
       <TextHeavyArticle
         id={id}

--- a/src/app/blogs/[slug]/page.tsx
+++ b/src/app/blogs/[slug]/page.tsx
@@ -9,6 +9,9 @@ import { Metadata } from 'next';
 import { HOST_URL, META_KEY } from '@/app/utilities/constants';
 import { createMetadata, slugify } from '@/app/utilities/common';
 import VisitTrackerWrapper from '@/app/components/wrapper/VisitTrackerWrapper';
+import JsonLd from '@/app/components/seo/JsonLd';
+import { buildBlogPostingSchema } from '@/app/components/seo/schemaBuilders';
+import { getSiteOrigin } from '@/app/components/seo/siteOrigin';
 import BlogList from '@/app/components/blogList/blogList';
 
 interface Props {
@@ -47,9 +50,20 @@ export default async function OneBlog({ params }: Props) {
   if (!blog) {
     return <Typography variant={TypographyVariant.H1}>Blog not found</Typography>;
   }
-  const { id, header, imageUrl, bodyText, scriptSrc, containerId } = blog;
+  const { id, title, description, header, imageUrl, bodyText, scriptSrc, containerId } = blog;
+  const siteOrigin = getSiteOrigin();
+  const canonical = `${siteOrigin}/blogs/${slug}`;
+
   return (
     <div className={styles.container}>
+      <JsonLd
+        data={buildBlogPostingSchema(siteOrigin, {
+          headline: header ?? title,
+          description,
+          url: canonical,
+          imageUrl,
+        })}
+      />
       <VisitTrackerWrapper id={id} type='blog' />
       <TextHeavyBlog id={id} header={header} imageUrl={imageUrl} bodyText={bodyText} />{' '}
       {scriptSrc !== '' && containerId !== '' && (

--- a/src/app/components/seo/JsonLd.tsx
+++ b/src/app/components/seo/JsonLd.tsx
@@ -1,0 +1,10 @@
+interface JsonLdProps {
+  data: Record<string, unknown>;
+}
+
+/** Renders JSON-LD; `JSON.stringify` plus `<` escape prevents script-breakout XSS. */
+export default function JsonLd({ data }: JsonLdProps) {
+  const json = JSON.stringify(data).replace(/</g, '\\u003c');
+
+  return <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: json }} />;
+}

--- a/src/app/components/seo/__tests__/JsonLd.test.tsx
+++ b/src/app/components/seo/__tests__/JsonLd.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import JsonLd from '../JsonLd';
+
+describe('JsonLd', () => {
+  it('renders application/ld+json script with stringified data', () => {
+    const { container } = render(
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          name: 'Neurodiversity Academy',
+        }}
+      />,
+    );
+
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script).not.toBeNull();
+    expect(script?.textContent).toContain('"@type":"Organization"');
+    expect(script?.textContent).toContain('Neurodiversity Academy');
+  });
+
+  it('escapes less-than characters in JSON output', () => {
+    const { container } = render(
+      <JsonLd
+        data={{
+          '@context': 'https://schema.org',
+          description: 'Use <script> safely',
+        }}
+      />,
+    );
+
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script?.textContent).toContain('\\u003cscript');
+    expect(script?.textContent).not.toContain('<script');
+  });
+});

--- a/src/app/components/seo/__tests__/schemaBuilders.test.ts
+++ b/src/app/components/seo/__tests__/schemaBuilders.test.ts
@@ -1,0 +1,98 @@
+import {
+  buildArticleSchema,
+  buildBlogPostingSchema,
+  buildEducationalOrganizationSchema,
+  buildFaqPageSchema,
+  buildSiteGraphSchema,
+  organizationIdForOrigin,
+  websiteIdForOrigin,
+} from '../schemaBuilders';
+
+const ORIGIN = 'https://neurodiversityacademy.com';
+
+describe('buildSiteGraphSchema', () => {
+  it('returns Organization and WebSite linked by @id', () => {
+    const schema = buildSiteGraphSchema(ORIGIN);
+    const graph = schema['@graph'] as Record<string, unknown>[];
+
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(graph).toHaveLength(2);
+
+    const organization = graph[0] as Record<string, unknown>;
+    const website = graph[1] as Record<string, unknown>;
+
+    expect(organization['@type']).toBe('Organization');
+    expect(organization['@id']).toBe(organizationIdForOrigin(ORIGIN));
+    expect(organization.name).toBe('Neurodiversity Academy');
+
+    expect(website['@type']).toBe('WebSite');
+    expect(website['@id']).toBe(websiteIdForOrigin(ORIGIN));
+    expect(website.publisher).toEqual({ '@id': organizationIdForOrigin(ORIGIN) });
+  });
+});
+
+describe('buildArticleSchema', () => {
+  it('includes headline, publisher, and optional author and image', () => {
+    const schema = buildArticleSchema(ORIGIN, {
+      headline: 'Test headline',
+      description: 'Test description',
+      url: `${ORIGIN}/articles/test`,
+      imageUrl: `${ORIGIN}/image.jpg`,
+      authorName: 'Jane Doe',
+    });
+
+    expect(schema['@type']).toBe('Article');
+    expect(schema.headline).toBe('Test headline');
+    expect(schema.image).toBe(`${ORIGIN}/image.jpg`);
+    expect(schema.author).toEqual({ '@type': 'Person', name: 'Jane Doe' });
+    expect(schema.publisher).toEqual({ '@id': organizationIdForOrigin(ORIGIN) });
+  });
+});
+
+describe('buildBlogPostingSchema', () => {
+  it('uses BlogPosting type', () => {
+    const schema = buildBlogPostingSchema(ORIGIN, {
+      headline: 'Blog headline',
+      description: 'Blog description',
+      url: `${ORIGIN}/blogs/test`,
+    });
+
+    expect(schema['@type']).toBe('BlogPosting');
+  });
+});
+
+describe('buildEducationalOrganizationSchema', () => {
+  it('returns thin EducationalOrganization payload', () => {
+    const schema = buildEducationalOrganizationSchema({
+      name: 'Health Science Hub',
+      url: `${ORIGIN}/endorsedproviders/hsh`,
+    });
+
+    expect(schema['@type']).toBe('EducationalOrganization');
+    expect(schema.name).toBe('Health Science Hub');
+    expect(schema.url).toBe(`${ORIGIN}/endorsedproviders/hsh`);
+  });
+});
+
+describe('buildFaqPageSchema', () => {
+  it('flattens FAQ sections into Question entities', () => {
+    const schema = buildFaqPageSchema({
+      pageUrl: `${ORIGIN}/endorsedproviders/hsh`,
+      sections: [
+        {
+          sectionTitle: 'About',
+          items: [
+            { question: 'Q1?', answer: 'A1.' },
+            { question: 'Q2?', answer: 'A2.' },
+          ],
+        },
+      ],
+    });
+
+    const mainEntity = schema.mainEntity as Record<string, unknown>[];
+    expect(schema['@type']).toBe('FAQPage');
+    expect(mainEntity).toHaveLength(2);
+    expect(mainEntity[0]?.name).toBe('Q1?');
+    expect(mainEntity[0]?.acceptedAnswer).toEqual({ '@type': 'Answer', text: 'A1.' });
+  });
+});

--- a/src/app/components/seo/__tests__/siteOrigin.test.ts
+++ b/src/app/components/seo/__tests__/siteOrigin.test.ts
@@ -1,0 +1,26 @@
+describe('getSiteOrigin', () => {
+  const originalHostUrl = process.env.NEXT_PUBLIC_HOST_URL;
+
+  afterEach(() => {
+    if (originalHostUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_HOST_URL;
+    } else {
+      process.env.NEXT_PUBLIC_HOST_URL = originalHostUrl;
+    }
+    jest.resetModules();
+  });
+
+  it('returns production origin when HOST_URL is localhost', async () => {
+    process.env.NEXT_PUBLIC_HOST_URL = 'http://localhost:3000';
+    jest.resetModules();
+    const { getSiteOrigin: getOrigin } = await import('../siteOrigin');
+    expect(getOrigin()).toBe('https://neurodiversityacademy.com');
+  });
+
+  it('returns HOST_URL when not localhost', async () => {
+    process.env.NEXT_PUBLIC_HOST_URL = 'https://neurodiversityacademy.com';
+    jest.resetModules();
+    const { getSiteOrigin: getOrigin } = await import('../siteOrigin');
+    expect(getOrigin()).toBe('https://neurodiversityacademy.com');
+  });
+});

--- a/src/app/components/seo/schemaBuilders.ts
+++ b/src/app/components/seo/schemaBuilders.ts
@@ -1,0 +1,134 @@
+import { SITE_NAME } from '@/app/utilities/constants';
+import type { EndorsedFaqSection } from '@/app/components/endorsedProviders/endorsedProviderPageData';
+
+const SCHEMA_CONTEXT = 'https://schema.org';
+
+export interface ArticleSchemaParams {
+  headline: string;
+  description: string;
+  url: string;
+  imageUrl?: string;
+  authorName?: string;
+}
+
+export interface BlogPostingSchemaParams extends ArticleSchemaParams {}
+
+export interface EducationalOrganizationSchemaParams {
+  name: string;
+  url: string;
+}
+
+export interface FaqPageSchemaParams {
+  pageUrl: string;
+  sections: EndorsedFaqSection[];
+}
+
+export function organizationIdForOrigin(origin: string): string {
+  return `${origin}/#organization`;
+}
+
+export function websiteIdForOrigin(origin: string): string {
+  return `${origin}/#website`;
+}
+
+export function buildSiteGraphSchema(origin: string): Record<string, unknown> {
+  const organizationId = organizationIdForOrigin(origin);
+  const websiteId = websiteIdForOrigin(origin);
+
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@graph': [
+      {
+        '@type': 'Organization',
+        '@id': organizationId,
+        name: SITE_NAME,
+        url: origin,
+      },
+      {
+        '@type': 'WebSite',
+        '@id': websiteId,
+        url: origin,
+        name: SITE_NAME,
+        publisher: { '@id': organizationId },
+      },
+    ],
+  };
+}
+
+function buildPublisher(origin: string): Record<string, unknown> {
+  return { '@id': organizationIdForOrigin(origin) };
+}
+
+function buildArticleLikeSchema(
+  type: 'Article' | 'BlogPosting',
+  origin: string,
+  params: ArticleSchemaParams,
+): Record<string, unknown> {
+  const schema: Record<string, unknown> = {
+    '@context': SCHEMA_CONTEXT,
+    '@type': type,
+    headline: params.headline,
+    description: params.description,
+    url: params.url,
+    mainEntityOfPage: params.url,
+    publisher: buildPublisher(origin),
+  };
+
+  if (params.imageUrl) {
+    schema.image = params.imageUrl;
+  }
+
+  if (params.authorName) {
+    schema.author = {
+      '@type': 'Person',
+      name: params.authorName,
+    };
+  }
+
+  return schema;
+}
+
+export function buildArticleSchema(
+  origin: string,
+  params: ArticleSchemaParams,
+): Record<string, unknown> {
+  return buildArticleLikeSchema('Article', origin, params);
+}
+
+export function buildBlogPostingSchema(
+  origin: string,
+  params: BlogPostingSchemaParams,
+): Record<string, unknown> {
+  return buildArticleLikeSchema('BlogPosting', origin, params);
+}
+
+export function buildEducationalOrganizationSchema(
+  params: EducationalOrganizationSchemaParams,
+): Record<string, unknown> {
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'EducationalOrganization',
+    name: params.name,
+    url: params.url,
+  };
+}
+
+export function buildFaqPageSchema(params: FaqPageSchemaParams): Record<string, unknown> {
+  const mainEntity = params.sections.flatMap((section) =>
+    section.items.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer,
+      },
+    })),
+  );
+
+  return {
+    '@context': SCHEMA_CONTEXT,
+    '@type': 'FAQPage',
+    mainEntityOfPage: params.pageUrl,
+    mainEntity,
+  };
+}

--- a/src/app/components/seo/siteOrigin.ts
+++ b/src/app/components/seo/siteOrigin.ts
@@ -1,0 +1,6 @@
+import { HOST_URL } from '@/app/utilities/constants';
+
+/** Canonical production origin; mirrors root layout `metadataBase` localhost handling. */
+export function getSiteOrigin(): string {
+  return HOST_URL.includes('localhost') ? 'https://neurodiversityacademy.com' : HOST_URL;
+}

--- a/src/app/emergingproviders/[name-of-the-institute]/page.tsx
+++ b/src/app/emergingproviders/[name-of-the-institute]/page.tsx
@@ -10,6 +10,9 @@ import {
   STATS_BY_SLUG,
 } from '@/app/components/emergingInstitutions/emergingProviderPageData';
 import pageStyles from './emergingProviderPage.module.css';
+import JsonLd from '@/app/components/seo/JsonLd';
+import { buildEducationalOrganizationSchema } from '@/app/components/seo/schemaBuilders';
+import { getSiteOrigin } from '@/app/components/seo/siteOrigin';
 
 type InstitutionCard = {
   name: string;
@@ -38,8 +41,17 @@ export default async function EmergingProviderPage({ params }: { params: Promise
     notFound();
   }
 
+  const siteOrigin = getSiteOrigin();
+  const canonical = `${siteOrigin}/emergingproviders/${institutionSlug}`;
+
   return (
     <main className={pageStyles.pageMain}>
+      <JsonLd
+        data={buildEducationalOrganizationSchema({
+          name: institution.name,
+          url: canonical,
+        })}
+      />
       <EmergingProviderHero title={institution.name} heroInfoItems={heroInfoItems} />
       <EmergingProviderStudentSuitability instituteSlug={institutionSlug} />
       <EmergingProviderStats stats={providerStats} />

--- a/src/app/endorsedproviders/[slug]/page.tsx
+++ b/src/app/endorsedproviders/[slug]/page.tsx
@@ -45,6 +45,12 @@ import {
 } from '@/app/utilities/endorsedPageSections';
 import { DATA_SECTION_ATTRIBUTE } from '@/app/utilities/gaTracking';
 import pageStyles from './endorsedProviderPage.module.css';
+import JsonLd from '@/app/components/seo/JsonLd';
+import {
+  buildEducationalOrganizationSchema,
+  buildFaqPageSchema,
+} from '@/app/components/seo/schemaBuilders';
+import { getSiteOrigin } from '@/app/components/seo/siteOrigin';
 
 type RouteParams = {
   slug: string;
@@ -122,9 +128,28 @@ export default async function EndorsedProviderDetailPage({ params, searchParams 
   const locationValue = findHeroInfoValueByLabel(heroInfoItems, HERO_INFO_LABEL_LOCATION);
   const studyModeValue = findHeroInfoValueByLabel(heroInfoItems, HERO_INFO_LABEL_STUDY_MODE);
   const typeValue = findHeroInfoValueByLabel(heroInfoItems, HERO_INFO_LABEL_TYPE);
+  const isLivePage = isLiveEndorsedSlug(internalSlug);
+  const siteOrigin = getSiteOrigin();
+  const liveCanonical = `${siteOrigin}${buildEndorsedLiveDetailHref(internalSlug)}`;
 
   return (
     <PageEngagementTracker providerSlug={internalSlug}>
+      {isLivePage ? (
+        <>
+          <JsonLd
+            data={buildEducationalOrganizationSchema({
+              name: displayName,
+              url: liveCanonical,
+            })}
+          />
+          <JsonLd
+            data={buildFaqPageSchema({
+              pageUrl: liveCanonical,
+              sections: faqSections,
+            })}
+          />
+        </>
+      ) : null}
       <main className={pageStyles.pageMain}>
         <EndorsedInstitutionCoverHero
           locationValue={locationValue}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,9 @@ import MetaPixel from './components/article/MetaPixel';
 import DeferredTabNavEmbed from './components/tabnav/DeferredTabNavEmbed';
 import DeferredGoogleAnalytics from './components/analytics/DeferredGoogleAnalytics';
 import DeferredVercelInsights from './components/analytics/DeferredVercelInsights';
+import JsonLd from './components/seo/JsonLd';
+import { buildSiteGraphSchema } from './components/seo/schemaBuilders';
+import { getSiteOrigin } from './components/seo/siteOrigin';
 
 const poppins = Poppins({
   subsets: ['latin'],
@@ -42,9 +45,12 @@ export const metadata: Metadata = {
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const siteOrigin = getSiteOrigin();
+
   return (
     <html lang='en' className={poppins.variable}>
       <head>
+        <JsonLd data={buildSiteGraphSchema(siteOrigin)} />
         <meta name='viewport' content='width=device-width, initial-scale=1.0, viewport-fit=cover' />
         <meta
           name='google-site-verification'


### PR DESCRIPTION
## Summary
- Add reusable `JsonLd` component and pure schema builders for Organization, WebSite, Article, BlogPosting, EducationalOrganization, and FAQPage.
- Wire site-wide Organization + WebSite graph in root layout; Article/BlogPosting on content slug pages; EducationalOrganization (+ FAQPage) on live endorsed and emerging provider pages.
- Unit tests cover schema builders, `JsonLd` XSS escaping, and canonical origin resolution.

## Test plan
- [x] `npm run verify:quality` (format, lint, typecheck, audit, test:ci)
- [x] SEO unit tests under `src/app/components/seo/__tests__/`
- [ ] Spot-check rendered `<script type="application/ld+json">` on home, an article, a blog, a live endorsed provider, and an emerging provider page

## Schemas added
| Page | Schema types |
|------|-------------|
| Root layout | Organization, WebSite (@graph) |
| `/articles/[slug]` | Article |
| `/blogs/[slug]` | BlogPosting |
| Live `/endorsedproviders/[slug]` | EducationalOrganization, FAQPage |
| `/emergingproviders/[name]` | EducationalOrganization |

## Out of scope (lite)
- No Course, Stripe/checkout, or Apply Now schemas
- No FAQPage on emerging providers (FAQ content is inline JSX)
- No `datePublished` (source JSON lacks dates)


Made with [Cursor](https://cursor.com)