### PR TITLE
Enable homepage study search (area + location)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,10 +6,10 @@ if (typeof globalThis.TextEncoder === 'undefined') {
   Object.defineProperty(globalThis, 'TextDecoder', { value: TextDecoder });
 }
 
-// Default analytics gate open in tests; suites that assert the prod-only gate override this.
-if (process.env.NEXT_PUBLIC_VERCEL_ENV === undefined) {
-  process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
-}
+// Default analytics gate open in tests. Vercel Preview sets NEXT_PUBLIC_VERCEL_ENV=preview
+// during `vercel:build`, which would no-op sendGaEvent and fail engagement suites.
+// Suites that assert the prod-only gate override this in beforeEach/afterEach.
+process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
 
 // RTL / React 19 require the test act environment. Jest scripts force NODE_ENV=test
 // so React.act is available even when the parent Vercel build uses NODE_ENV=production.

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -6,6 +6,11 @@ if (typeof globalThis.TextEncoder === 'undefined') {
   Object.defineProperty(globalThis, 'TextDecoder', { value: TextDecoder });
 }
 
+// Default analytics gate open in tests; suites that assert the prod-only gate override this.
+if (process.env.NEXT_PUBLIC_VERCEL_ENV === undefined) {
+  process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
+}
+
 // RTL / React 19 require the test act environment. Jest scripts force NODE_ENV=test
 // so React.act is available even when the parent Vercel build uses NODE_ENV=production.
 Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {

--- a/next.config.js
+++ b/next.config.js
@@ -225,6 +225,10 @@ const globalSecurityHeaders = [
 ];
 
 module.exports = {
+  env: {
+    // Expose Vercel deploy target to the client so analytics can gate on Production only.
+    NEXT_PUBLIC_VERCEL_ENV: process.env.VERCEL_ENV ?? process.env.NEXT_PUBLIC_VERCEL_ENV ?? '',
+  },
   experimental: {
     // Speeds repeat production builds when the Turbopack FS cache is warm.
     turbopackFileSystemCacheForBuild: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9840,9 +9840,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -10522,9 +10522,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10541,7 +10541,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "overrides": {
     "fast-xml-parser": "^5.10.1",
-    "postcss": "^8.5.10",
+    "nanoid": "^3.3.17",
+    "postcss": "^8.5.23",
     "sharp": "^0.35.3"
   }
 }

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import styles from './banner.module.css';
 import Typography, { TypographyVariant } from '../typography/Typography';
 import BadgeDisplay from '../badges/BadgeDisplay';
@@ -34,9 +35,11 @@ export default function HomeBanner({
   return (
     <div className={showSearch ? styles.bannerWithSearch : undefined}>
       <div
-        className={`home-hero-banner ${styles.bannerContainer}${
-          showSearch ? ` ${styles.bannerContainerWithSearch}` : ''
-        }`}
+        className={classNames(
+          'home-hero-banner',
+          styles.bannerContainer,
+          showSearch && styles.bannerContainerWithSearch,
+        )}
       >
         <div className={styles.bannerOverlay} aria-hidden='true' />
         <div className={styles.bannerTextAndBadge}>

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -35,16 +35,6 @@ export default function HomeBanner({
     <div className={showSearch ? styles.bannerWithSearch : undefined}>
       <div className={`home-hero-banner ${styles.bannerContainer}`}>
         <div className={styles.bannerOverlay} aria-hidden='true' />
-        {showSearch && (
-          <ProviderStudySearch
-            className={styles.form}
-            compact
-            surface='homepage'
-            interestAreaOptions={interestAreaOptions}
-            locationOptions={locationOptions}
-            searchDemo={searchDemo}
-          />
-        )}
         <div className={styles.bannerTextAndBadge}>
           <div className={styles.textContainer}>
             <Typography variant={TypographyVariant.H1} className='m-0' color='var(--GhostWhite)'>
@@ -68,6 +58,16 @@ export default function HomeBanner({
           </div>
           {displayBadges && <BadgeDisplay />}
         </div>
+        {showSearch && (
+          <ProviderStudySearch
+            className={styles.form}
+            compact
+            surface='homepage'
+            interestAreaOptions={interestAreaOptions}
+            locationOptions={locationOptions}
+            searchDemo={searchDemo}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -35,6 +35,16 @@ export default function HomeBanner({
     <div className={showSearch ? styles.bannerWithSearch : undefined}>
       <div className={`home-hero-banner ${styles.bannerContainer}`}>
         <div className={styles.bannerOverlay} aria-hidden='true' />
+        {showSearch && (
+          <ProviderStudySearch
+            className={styles.form}
+            compact
+            surface='homepage'
+            interestAreaOptions={interestAreaOptions}
+            locationOptions={locationOptions}
+            searchDemo={searchDemo}
+          />
+        )}
         <div className={styles.bannerTextAndBadge}>
           <div className={styles.textContainer}>
             <Typography variant={TypographyVariant.H1} className='m-0' color='var(--GhostWhite)'>
@@ -59,15 +69,6 @@ export default function HomeBanner({
           {displayBadges && <BadgeDisplay />}
         </div>
       </div>
-      {showSearch && (
-        <ProviderStudySearch
-          className={styles.form}
-          surface='homepage'
-          interestAreaOptions={interestAreaOptions}
-          locationOptions={locationOptions}
-          searchDemo={searchDemo}
-        />
-      )}
     </div>
   );
 }

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -33,7 +33,11 @@ export default function HomeBanner({
 
   return (
     <div className={showSearch ? styles.bannerWithSearch : undefined}>
-      <div className={`home-hero-banner ${styles.bannerContainer}`}>
+      <div
+        className={`home-hero-banner ${styles.bannerContainer}${
+          showSearch ? ` ${styles.bannerContainerWithSearch}` : ''
+        }`}
+      >
         <div className={styles.bannerOverlay} aria-hidden='true' />
         <div className={styles.bannerTextAndBadge}>
           <div className={styles.textContainer}>

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import styles from './banner.module.css';
 import Typography, { TypographyVariant } from '../typography/Typography';
 import BadgeDisplay from '../badges/BadgeDisplay';
-import CoursePrimaryFilter from '../course/CoursePrimaryFilter';
-import CourseProvider from '@/app/utilities/course/CourseProvider';
+import ProviderStudySearch from '../providerSearch/ProviderStudySearch';
 import { BUTTON_STYLE } from '@/app/utilities/constants';
 import ActionButton from '../buttons/ActionButton';
 
@@ -14,6 +13,9 @@ interface PropType {
   title?: string;
   subtitle?: string;
   showSearchBar?: boolean;
+  interestAreaOptions?: { label: string; value: string }[];
+  locationOptions?: { label: string; value: string }[];
+  searchDemo?: boolean;
 }
 
 export default function HomeBanner({
@@ -23,9 +25,14 @@ export default function HomeBanner({
   title,
   subtitle,
   showSearchBar = false,
+  interestAreaOptions = [],
+  locationOptions = [],
+  searchDemo = false,
 }: PropType) {
+  const showSearch = Boolean(showSearchBar && displayFilter);
+
   return (
-    <>
+    <div className={showSearch ? styles.bannerWithSearch : undefined}>
       <div className={`home-hero-banner ${styles.bannerContainer}`}>
         <div className={styles.bannerOverlay} aria-hidden='true' />
         <div className={styles.bannerTextAndBadge}>
@@ -51,17 +58,16 @@ export default function HomeBanner({
           </div>
           {displayBadges && <BadgeDisplay />}
         </div>
-        {showSearchBar && displayFilter && (
-          <CourseProvider redirectToSearchPage>
-            <CoursePrimaryFilter className={styles.form} />
-          </CourseProvider>
-        )}
       </div>
-      {showSearchBar && displayFilter && (
-        <CourseProvider redirectToSearchPage>
-          <CoursePrimaryFilter className={styles.formMobile} />
-        </CourseProvider>
+      {showSearch && (
+        <ProviderStudySearch
+          className={styles.form}
+          surface='homepage'
+          interestAreaOptions={interestAreaOptions}
+          locationOptions={locationOptions}
+          searchDemo={searchDemo}
+        />
       )}
-    </>
+    </div>
   );
 }

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -83,13 +83,7 @@ function BannerSearch({
   );
 }
 
-function BannerFrame({
-  showSearch,
-  children,
-}: {
-  showSearch: boolean;
-  children: React.ReactNode;
-}) {
+function BannerFrame({ showSearch, children }: { showSearch: boolean; children: React.ReactNode }) {
   return (
     <div className={showSearch ? styles.bannerWithSearch : undefined}>
       <div

--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -19,6 +19,92 @@ interface PropType {
   searchDemo?: boolean;
 }
 
+const DEFAULT_TITLE = 'We endorse Neuro-inclusion in tertiary education';
+const DEFAULT_SUBTITLE =
+  'Reach out to learn more about our endorsements and the \
+              impact we are creating for Neurodivergent students.';
+
+function BannerCopy({
+  title,
+  subtitle,
+  showButton,
+}: {
+  title?: string;
+  subtitle?: string;
+  showButton?: boolean;
+}) {
+  return (
+    <div className={styles.textContainer}>
+      <Typography variant={TypographyVariant.H1} className='m-0' color='var(--GhostWhite)'>
+        {title || DEFAULT_TITLE}
+      </Typography>
+      <Typography variant={TypographyVariant.H2} color='var(--GhostWhite)'>
+        {subtitle || DEFAULT_SUBTITLE}
+      </Typography>
+      {showButton ? (
+        <div className={styles.buttonContainer}>
+          <ActionButton
+            type='button'
+            label='Learn More'
+            style={BUTTON_STYLE.Tertiary}
+            to='/endorsements'
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function shouldShowSearch(showSearchBar: boolean, displayFilter?: boolean): boolean {
+  if (!showSearchBar) {
+    return false;
+  }
+  return Boolean(displayFilter);
+}
+
+function BannerSearch({
+  interestAreaOptions,
+  locationOptions,
+  searchDemo,
+}: {
+  interestAreaOptions: { label: string; value: string }[];
+  locationOptions: { label: string; value: string }[];
+  searchDemo: boolean;
+}) {
+  return (
+    <ProviderStudySearch
+      className={styles.form}
+      compact
+      surface='homepage'
+      interestAreaOptions={interestAreaOptions}
+      locationOptions={locationOptions}
+      searchDemo={searchDemo}
+    />
+  );
+}
+
+function BannerFrame({
+  showSearch,
+  children,
+}: {
+  showSearch: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={showSearch ? styles.bannerWithSearch : undefined}>
+      <div
+        className={classNames(
+          'home-hero-banner',
+          styles.bannerContainer,
+          showSearch ? styles.bannerContainerWithSearch : undefined,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export default function HomeBanner({
   displayBadges,
   displayFilter,
@@ -30,52 +116,22 @@ export default function HomeBanner({
   locationOptions = [],
   searchDemo = false,
 }: PropType) {
-  const showSearch = Boolean(showSearchBar && displayFilter);
+  const showSearch = shouldShowSearch(showSearchBar, displayFilter);
 
   return (
-    <div className={showSearch ? styles.bannerWithSearch : undefined}>
-      <div
-        className={classNames(
-          'home-hero-banner',
-          styles.bannerContainer,
-          showSearch && styles.bannerContainerWithSearch,
-        )}
-      >
-        <div className={styles.bannerOverlay} aria-hidden='true' />
-        <div className={styles.bannerTextAndBadge}>
-          <div className={styles.textContainer}>
-            <Typography variant={TypographyVariant.H1} className='m-0' color='var(--GhostWhite)'>
-              {title || 'We endorse Neuro-inclusion in tertiary education'}
-            </Typography>
-            <Typography variant={TypographyVariant.H2} color='var(--GhostWhite)'>
-              {subtitle ||
-                'Reach out to learn more about our endorsements and the \
-              impact we are creating for Neurodivergent students.'}
-            </Typography>
-            {showButton && (
-              <div className={styles.buttonContainer}>
-                <ActionButton
-                  type='button'
-                  label='Learn More'
-                  style={BUTTON_STYLE.Tertiary}
-                  to='/endorsements'
-                />
-              </div>
-            )}
-          </div>
-          {displayBadges && <BadgeDisplay />}
-        </div>
-        {showSearch && (
-          <ProviderStudySearch
-            className={styles.form}
-            compact
-            surface='homepage'
-            interestAreaOptions={interestAreaOptions}
-            locationOptions={locationOptions}
-            searchDemo={searchDemo}
-          />
-        )}
+    <BannerFrame showSearch={showSearch}>
+      <div className={styles.bannerOverlay} aria-hidden='true' />
+      <div className={styles.bannerTextAndBadge}>
+        <BannerCopy title={title} subtitle={subtitle} showButton={showButton} />
+        {displayBadges ? <BadgeDisplay /> : null}
       </div>
-    </div>
+      {showSearch ? (
+        <BannerSearch
+          interestAreaOptions={interestAreaOptions}
+          locationOptions={locationOptions}
+          searchDemo={searchDemo}
+        />
+      ) : null}
+    </BannerFrame>
   );
 }

--- a/src/app/components/banner/__tests__/HomeBanner.test.tsx
+++ b/src/app/components/banner/__tests__/HomeBanner.test.tsx
@@ -85,6 +85,17 @@ describe('HomeBanner', () => {
     expect(filters).toHaveLength(1);
   });
 
+  it('places provider search above the hero title when enabled', () => {
+    const { container } = render(<HomeBanner showSearchBar displayFilter title='Hero Title' />);
+    const search = screen.getByTestId('provider-study-search');
+    const title = screen.getByText('Hero Title');
+    const banner = container.querySelector('.home-hero-banner');
+    expect(banner?.contains(search)).toBe(true);
+    expect(Boolean(search.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(
+      true,
+    );
+  });
+
   it('does not render provider search when showSearchBar is false', () => {
     render(<HomeBanner showSearchBar={false} displayFilter />);
     expect(screen.queryByTestId('provider-study-search')).not.toBeInTheDocument();

--- a/src/app/components/banner/__tests__/HomeBanner.test.tsx
+++ b/src/app/components/banner/__tests__/HomeBanner.test.tsx
@@ -85,15 +85,17 @@ describe('HomeBanner', () => {
     expect(filters).toHaveLength(1);
   });
 
-  it('places provider search above the hero title when enabled', () => {
-    const { container } = render(<HomeBanner showSearchBar displayFilter title='Hero Title' />);
+  it('places provider search beneath the hero subtitle when enabled', () => {
+    const { container } = render(
+      <HomeBanner showSearchBar displayFilter title='Hero Title' subtitle='Hero Subtitle' />,
+    );
     const search = screen.getByTestId('provider-study-search');
-    const title = screen.getByText('Hero Title');
+    const subtitle = screen.getByText('Hero Subtitle');
     const banner = container.querySelector('.home-hero-banner');
     expect(banner?.contains(search)).toBe(true);
-    expect(Boolean(search.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(
-      true,
-    );
+    expect(
+      Boolean(subtitle.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING),
+    ).toBe(true);
   });
 
   it('does not render provider search when showSearchBar is false', () => {

--- a/src/app/components/banner/__tests__/HomeBanner.test.tsx
+++ b/src/app/components/banner/__tests__/HomeBanner.test.tsx
@@ -25,18 +25,13 @@ jest.mock('../../badges/BadgeDisplay', () => ({
   default: () => <div data-testid='badge-display'>Badges</div>,
 }));
 
-jest.mock('../../course/CoursePrimaryFilter', () => ({
+jest.mock('../../providerSearch/ProviderStudySearch', () => ({
   __esModule: true,
-  default: ({ className }: { className: string }) => (
-    <div data-testid='course-filter' className={className}>
-      Filter
+  default: ({ className }: { className?: string }) => (
+    <div data-testid='provider-study-search' className={className}>
+      Provider search
     </div>
   ),
-}));
-
-jest.mock('@/app/utilities/course/CourseProvider', () => ({
-  __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
 import HomeBanner from '../HomeBanner';
@@ -84,14 +79,14 @@ describe('HomeBanner', () => {
     expect(link).toHaveAttribute('href', '/endorsements');
   });
 
-  it('renders course filter when showSearchBar and displayFilter are true', () => {
+  it('renders a single provider search when showSearchBar and displayFilter are true', () => {
     render(<HomeBanner showSearchBar displayFilter />);
-    const filters = screen.getAllByTestId('course-filter');
-    expect(filters.length).toBeGreaterThanOrEqual(1);
+    const filters = screen.getAllByTestId('provider-study-search');
+    expect(filters).toHaveLength(1);
   });
 
-  it('does not render course filter when showSearchBar is false', () => {
+  it('does not render provider search when showSearchBar is false', () => {
     render(<HomeBanner showSearchBar={false} displayFilter />);
-    expect(screen.queryByTestId('course-filter')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('provider-study-search')).not.toBeInTheDocument();
   });
 });

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -1,3 +1,8 @@
+.bannerWithSearch {
+  width: 100%;
+  position: relative;
+}
+
 .bannerContainer {
   box-sizing: border-box;
   width: 100%;
@@ -8,9 +13,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  position: relative; /* allow absolutely positioned filter to sit inside the picture */
+  position: relative;
   overflow: hidden;
-  /* Fallback + mobile hero as CSS background so LCP can be text (faster CWV). */
   background-color: #4a2a8a;
   background-image: url('/images/hero-mobile.webp');
   background-size: cover;
@@ -53,14 +57,25 @@
 .form {
   position: relative;
   z-index: 2;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0 5vw 1.5rem;
+  box-sizing: border-box;
 }
 
-.form > :first-child {
-  flex: 1;
-}
+@media (min-width: 481px) {
+  .form {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 1.5rem;
+    padding-bottom: 0;
+  }
 
-.bannerContainer + .formMobile {
-  display: none;
+  .bannerWithSearch {
+    margin-bottom: 0;
+  }
 }
 
 .buttonContainer {
@@ -78,11 +93,7 @@
     flex-direction: column;
   }
 
-  .bannerContainer .form {
-    display: none;
-  }
-
-  .bannerContainer + .formMobile {
-    display: flex;
+  .form {
+    margin-top: 0.75rem;
   }
 }

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -11,7 +11,7 @@
   gap: 1vw;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
   position: relative;
   overflow: hidden;
@@ -48,6 +48,8 @@
   max-width: 100%;
   position: relative;
   z-index: 2;
+  flex: 1 1 auto;
+  align-items: center;
 }
 
 .textContainer {
@@ -58,24 +60,14 @@
   position: relative;
   z-index: 2;
   width: 100%;
+  max-height: 15vh;
+  flex: 0 0 auto;
   display: flex;
   justify-content: center;
-  padding: 0 5vw 1.5rem;
+  align-items: center;
+  padding: 0.5rem 0 0;
   box-sizing: border-box;
-}
-
-@media (min-width: 481px) {
-  .form {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 1.5rem;
-    padding-bottom: 0;
-  }
-
-  .bannerWithSearch {
-    margin-bottom: 0;
-  }
+  overflow: visible;
 }
 
 .buttonContainer {
@@ -87,6 +79,8 @@
 @media (max-width: 480px) {
   .bannerContainer {
     flex-direction: column;
+    height: auto;
+    min-height: 70vh;
   }
 
   .bannerTextAndBadge {
@@ -94,6 +88,8 @@
   }
 
   .form {
-    margin-top: 0.75rem;
+    max-height: none;
+    order: -1;
+    margin-bottom: 0.75rem;
   }
 }

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -76,6 +76,12 @@
   width: 100%;
 }
 
+@media (max-width: 768px) {
+  .form {
+    max-height: none;
+  }
+}
+
 @media (max-width: 480px) {
   .bannerContainer {
     flex-direction: column;
@@ -88,9 +94,9 @@
   }
 
   .form {
-    max-height: 15vh;
+    max-height: none;
     order: -1;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
     padding: 0;
   }
 }

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -1,6 +1,8 @@
 .bannerWithSearch {
   width: 100%;
   position: relative;
+  /* Keep open search dropdowns above the next homepage section */
+  z-index: 4;
 }
 
 .bannerContainer {
@@ -20,6 +22,11 @@
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+}
+
+/* Allow study/location menus to extend past the hero edge */
+.bannerContainerWithSearch {
+  overflow: visible;
 }
 
 @media (min-width: 769px) {
@@ -58,12 +65,12 @@
 
 .form {
   position: relative;
-  z-index: 2;
+  z-index: 3;
   width: 100%;
-  max-height: 15vh;
+  max-height: none;
   flex: 0 0 auto;
   display: flex;
-  justify-content: stretch;
+  justify-content: center;
   align-items: center;
   padding: 0.75rem 0 0;
   box-sizing: border-box;

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -63,7 +63,7 @@
   max-height: 15vh;
   flex: 0 0 auto;
   display: flex;
-  justify-content: center;
+  justify-content: stretch;
   align-items: center;
   padding: 0.5rem 0 0;
   box-sizing: border-box;

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -88,8 +88,9 @@
   }
 
   .form {
-    max-height: none;
+    max-height: 15vh;
     order: -1;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
+    padding: 0;
   }
 }

--- a/src/app/components/banner/banner.module.css
+++ b/src/app/components/banner/banner.module.css
@@ -65,7 +65,7 @@
   display: flex;
   justify-content: stretch;
   align-items: center;
-  padding: 0.5rem 0 0;
+  padding: 0.75rem 0 0;
   box-sizing: border-box;
   overflow: visible;
 }
@@ -95,8 +95,7 @@
 
   .form {
     max-height: none;
-    order: -1;
-    margin-bottom: 0.75rem;
+    margin-top: 0.75rem;
     padding: 0;
   }
 }

--- a/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
+++ b/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
@@ -20,6 +20,42 @@ type EmergingInstitutionCardProps = {
   ctaOpenInNewTab?: boolean;
 };
 
+function resolveEmergingCta(params: {
+  name: string;
+  state: AustralianState;
+  demo: boolean;
+  gaEventOverride?: InstitutionCtaAnalytics;
+}): {
+  href: string | undefined;
+  comingSoonLabel: string | undefined;
+  gaEvent: InstitutionCtaAnalytics | undefined;
+} {
+  const providerSlug = slugify(params.name);
+  const missingProfile = !hasEmergingProviderProfile(providerSlug);
+  const isComingSoon = params.demo || missingProfile;
+  if (isComingSoon) {
+    return {
+      href: undefined,
+      comingSoonLabel: 'Coming soon',
+      gaEvent: params.gaEventOverride,
+    };
+  }
+
+  const href = buildEmergingProviderDetailHref(providerSlug);
+  const defaultGaEvent = buildEmergingExploreMoreAnalytics({
+    providerName: params.name,
+    providerSlug,
+    state: params.state,
+    destinationPath: href,
+  });
+
+  return {
+    href,
+    comingSoonLabel: undefined,
+    gaEvent: params.gaEventOverride ?? defaultGaEvent,
+  };
+}
+
 export default function EmergingInstitutionCard({
   name,
   state,
@@ -27,26 +63,15 @@ export default function EmergingInstitutionCard({
   gaEvent: gaEventOverride,
   ctaOpenInNewTab = true,
 }: EmergingInstitutionCardProps) {
-  const providerSlug = slugify(name);
-  const isComingSoon = demo || !hasEmergingProviderProfile(providerSlug);
-  const href = isComingSoon ? undefined : buildEmergingProviderDetailHref(providerSlug);
-  const defaultGaEvent =
-    href === undefined
-      ? undefined
-      : buildEmergingExploreMoreAnalytics({
-          providerName: name,
-          providerSlug,
-          state,
-          destinationPath: href,
-        });
+  const cta = resolveEmergingCta({ name, state, demo, gaEventOverride });
 
   return (
     <InstitutionProviderCard
-      ctaHref={href}
+      ctaHref={cta.href}
       ctaOpenInNewTab={ctaOpenInNewTab}
       compact
-      comingSoonLabel={isComingSoon ? 'Coming soon' : undefined}
-      gaEvent={gaEventOverride ?? defaultGaEvent}
+      comingSoonLabel={cta.comingSoonLabel}
+      gaEvent={cta.gaEvent}
       header={{
         kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
         stateTint: state,

--- a/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
+++ b/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
@@ -2,27 +2,35 @@ import InstitutionProviderCard from '../institutionProviderCard/InstitutionProvi
 import { INSTITUTION_PROVIDER_HEADER_KIND } from '../institutionProviderCard/institutionProviderHeader';
 import styles from '../institutionProviderCard/institutionProviderCard.module.css';
 import Typography, { TypographyVariant } from '../typography/Typography';
+import { TypographyColorToken } from '../typography/typographyColorToken';
 import type { AustralianState } from './emergingInstitutionTypes';
 import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
 import { slugify } from '@/app/utilities/common';
 import { buildEmergingExploreMoreAnalytics } from './emergingProvidersGa';
 import { hasEmergingProviderProfile } from './emergingProviderProfileSlugs';
+import type { InstitutionCtaAnalytics } from './EmergingInstitutionCtaButton';
 
 type EmergingInstitutionCardProps = {
   name: string;
   state: AustralianState;
   demo?: boolean;
+  /** When set, replaces the default emerging-directory Explore More analytics. */
+  gaEvent?: InstitutionCtaAnalytics;
+  /** Open detail links in a new tab (directory default). Search results keep same-tab. */
+  ctaOpenInNewTab?: boolean;
 };
 
 export default function EmergingInstitutionCard({
   name,
   state,
   demo = false,
+  gaEvent: gaEventOverride,
+  ctaOpenInNewTab = true,
 }: EmergingInstitutionCardProps) {
   const providerSlug = slugify(name);
   const isComingSoon = demo || !hasEmergingProviderProfile(providerSlug);
   const href = isComingSoon ? undefined : buildEmergingProviderDetailHref(providerSlug);
-  const gaEvent =
+  const defaultGaEvent =
     href === undefined
       ? undefined
       : buildEmergingExploreMoreAnalytics({
@@ -31,23 +39,23 @@ export default function EmergingInstitutionCard({
           state,
           destinationPath: href,
         });
+  const resolvedGa = gaEventOverride ?? defaultGaEvent;
+  const gaEvent = resolvedGa
+    ? {
+        eventName: resolvedGa.eventName,
+        category: resolvedGa.category,
+        fileName: resolvedGa.fileName,
+        params: resolvedGa.params,
+      }
+    : undefined;
 
   return (
     <InstitutionProviderCard
       ctaHref={href}
-      ctaOpenInNewTab
+      ctaOpenInNewTab={ctaOpenInNewTab}
       compact
       comingSoonLabel={isComingSoon ? 'Coming soon' : undefined}
-      gaEvent={
-        gaEvent
-          ? {
-              eventName: gaEvent.eventName,
-              category: gaEvent.category,
-              fileName: gaEvent.fileName,
-              params: gaEvent.params,
-            }
-          : undefined
-      }
+      gaEvent={gaEvent}
       header={{
         kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
         stateTint: state,
@@ -56,7 +64,10 @@ export default function EmergingInstitutionCard({
         <div className={styles.nameWrap}>
           <div className={styles.nameStack}>
             <Typography variant={TypographyVariant.Body2}>{name}</Typography>
-            <Typography variant={TypographyVariant.Body3} color='var(--cherryPieVariant)'>
+            <Typography
+              variant={TypographyVariant.Body3}
+              color={TypographyColorToken.CherryPieVariant}
+            >
               {state}
             </Typography>
           </div>

--- a/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
+++ b/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
@@ -39,15 +39,6 @@ export default function EmergingInstitutionCard({
           state,
           destinationPath: href,
         });
-  const resolvedGa = gaEventOverride ?? defaultGaEvent;
-  const gaEvent = resolvedGa
-    ? {
-        eventName: resolvedGa.eventName,
-        category: resolvedGa.category,
-        fileName: resolvedGa.fileName,
-        params: resolvedGa.params,
-      }
-    : undefined;
 
   return (
     <InstitutionProviderCard
@@ -55,7 +46,7 @@ export default function EmergingInstitutionCard({
       ctaOpenInNewTab={ctaOpenInNewTab}
       compact
       comingSoonLabel={isComingSoon ? 'Coming soon' : undefined}
-      gaEvent={gaEvent}
+      gaEvent={gaEventOverride ?? defaultGaEvent}
       header={{
         kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
         stateTint: state,

--- a/src/app/components/emergingInstitutions/__tests__/EmergingInstitutionCard.test.tsx
+++ b/src/app/components/emergingInstitutions/__tests__/EmergingInstitutionCard.test.tsx
@@ -62,4 +62,10 @@ describe('EmergingInstitutionCard', () => {
     const { container } = render(<EmergingInstitutionCard name='Bond University' state='QLD' />);
     expect(container.querySelector('[data-state-tint="QLD"]')).toBeInTheDocument();
   });
+
+  it('allows search surfaces to keep same-tab navigation', () => {
+    render(<EmergingInstitutionCard name='Bond University' state='QLD' ctaOpenInNewTab={false} />);
+    const link = screen.getByRole('link', { name: 'Explore More' });
+    expect(link).not.toHaveAttribute('target');
+  });
 });

--- a/src/app/components/emergingInstitutions/emergingInstitutionTypes.ts
+++ b/src/app/components/emergingInstitutions/emergingInstitutionTypes.ts
@@ -5,6 +5,10 @@ export type EmergingInstitution = {
   state: AustralianState;
   /** Demo listings have no detail page yet — shown in teaser/directory only. */
   demo?: boolean;
+  /** Canonical study-search interest areas (verified subset only). */
+  interestAreas?: string[];
+  /** Optional city-level location tags; state is always searchable. */
+  locations?: string[];
 };
 
 /** Neutral geographic order — not a popularity rank. */

--- a/src/app/components/emergingInstitutions/emergingInstitutions.json
+++ b/src/app/components/emergingInstitutions/emergingInstitutions.json
@@ -5,7 +5,10 @@
   },
   {
     "name": "Australian College of Physical Education",
-    "state": "NSW"
+    "state": "NSW",
+    "interestAreas": [
+      "Sport and Exercise Science"
+    ]
   },
   {
     "name": "Flinders University",
@@ -17,7 +20,10 @@
   },
   {
     "name": "Jazz Music Institute",
-    "state": "QLD"
+    "state": "QLD",
+    "interestAreas": [
+      "Music"
+    ]
   },
   {
     "name": "Academies Australasia Polytechnic",
@@ -29,7 +35,10 @@
   },
   {
     "name": "Adelaide Central School of Art",
-    "state": "SA"
+    "state": "SA",
+    "interestAreas": [
+      "Fine Arts"
+    ]
   },
   {
     "name": "Adelaide University",

--- a/src/app/components/emergingInstitutions/emergingInstitutions.json
+++ b/src/app/components/emergingInstitutions/emergingInstitutions.json
@@ -6,9 +6,7 @@
   {
     "name": "Australian College of Physical Education",
     "state": "NSW",
-    "interestAreas": [
-      "Sport and Exercise Science"
-    ]
+    "interestAreas": ["Sport and Exercise Science"]
   },
   {
     "name": "Flinders University",
@@ -21,9 +19,7 @@
   {
     "name": "Jazz Music Institute",
     "state": "QLD",
-    "interestAreas": [
-      "Music"
-    ]
+    "interestAreas": ["Music"]
   },
   {
     "name": "Academies Australasia Polytechnic",
@@ -36,9 +32,7 @@
   {
     "name": "Adelaide Central School of Art",
     "state": "SA",
-    "interestAreas": [
-      "Fine Arts"
-    ]
+    "interestAreas": ["Fine Arts"]
   },
   {
     "name": "Adelaide University",

--- a/src/app/components/endorsedProviders/endorsedProviderPageData.ts
+++ b/src/app/components/endorsedProviders/endorsedProviderPageData.ts
@@ -1387,7 +1387,13 @@ export const SUPPORT_FRAMEWORK_BY_SLUG: Record<string, SupportFrameworkSection[]
   ],
 };
 
-type EndorsedJsonRow = {
+export type EndorsedPromotedCourse = {
+  id: string;
+  title: string;
+  interestAreas: string[];
+};
+
+export type EndorsedJsonRow = {
   id: string;
   /** When true, profile is public via slug URL and shown on the homepage. */
   live?: boolean;
@@ -1398,9 +1404,38 @@ type EndorsedJsonRow = {
   metaStripInstitutionIconSrc?: string;
   topBackgroundImage?: string;
   institutionCoursesUrl: string;
+  /** Canonical study-search interest areas (catalog values). */
+  interestAreas?: string[];
+  /** Canonical study-search location tokens (cities and/or AU states). */
+  locations?: string[];
+  /** Promoted courses for course-endorsed search tier. */
+  promotedCourses?: EndorsedPromotedCourse[];
 };
 
 const rows = endorsedData as EndorsedJsonRow[];
+
+export function getEndorsedJsonRows(): readonly EndorsedJsonRow[] {
+  return rows;
+}
+
+export function getPromotedCoursesForSlug(slug: string): EndorsedPromotedCourse[] {
+  const row = rows.find((item) => slugify(item.id) === slug);
+  return row?.promotedCourses ?? [];
+}
+
+export function hasPromotedCoursesForSlug(slug: string): boolean {
+  return getPromotedCoursesForSlug(slug).length > 0;
+}
+
+export function getEndorsedInterestAreasForSlug(slug: string): string[] {
+  const row = rows.find((item) => slugify(item.id) === slug);
+  return row?.interestAreas ?? [];
+}
+
+export function getEndorsedLocationsForSlug(slug: string): string[] {
+  const row = rows.find((item) => slugify(item.id) === slug);
+  return row?.locations ?? [];
+}
 
 const INSTITUTION_COURSES_URL_BY_SLUG: Record<string, string> = Object.fromEntries(
   rows.map((row) => [slugify(row.id), row.institutionCoursesUrl.trim()]),

--- a/src/app/components/endorsedProviders/endorsedProviders.json
+++ b/src/app/components/endorsedProviders/endorsedProviders.json
@@ -5,33 +5,43 @@
     "ndaCertified": true,
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/NepeanCover.webp",
-    "institutionCoursesUrl": "https://ncc.nsw.edu.au/our-courses/"
+    "institutionCoursesUrl": "https://ncc.nsw.edu.au/our-courses/",
+    "locations": ["Penrith", "Sydney", "NSW"],
+    "interestAreas": []
   },
   {
     "id": "HSH",
     "live": true,
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/HSHCover.webp",
-    "institutionCoursesUrl": "https://www.hsh.edu.au"
+    "institutionCoursesUrl": "https://www.hsh.edu.au",
+    "locations": ["Perth"],
+    "interestAreas": ["Nursing", "Education", "Public Health"]
   },
   {
     "id": "academia",
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/AcademiaCover.webp",
-    "institutionCoursesUrl": "https://www.studyacademia.edu.au"
+    "institutionCoursesUrl": "https://www.studyacademia.edu.au",
+    "locations": ["Brisbane"],
+    "interestAreas": []
   },
   {
     "id": "Blueprint Career Development",
     "live": true,
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/BlueprintCover.webp",
-    "institutionCoursesUrl": "https://www.blueprintcd.com.au/"
+    "institutionCoursesUrl": "https://www.blueprintcd.com.au/",
+    "locations": ["Brisbane"],
+    "interestAreas": ["Business Administration", "Sport and Exercise Science"]
   },
   {
     "id": "Collarts",
     "live": true,
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/CollartsCover.webp",
-    "institutionCoursesUrl": "https://www.collarts.edu.au/courses"
+    "institutionCoursesUrl": "https://www.collarts.edu.au/courses",
+    "locations": ["Melbourne", "Sydney"],
+    "interestAreas": ["Music", "Media and Communication", "Design", "Fine Arts"]
   }
 ]

--- a/src/app/components/formElements/Dropdown/DropdownComboboxView.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownComboboxView.tsx
@@ -19,13 +19,7 @@ function getComboboxAriaLabel(showLabel: boolean, label?: string): string | unde
   return label || undefined;
 }
 
-function CreateOptionItem({
-  inputValue,
-  onCreate,
-}: {
-  inputValue: string;
-  onCreate: () => void;
-}) {
+function CreateOptionItem({ inputValue, onCreate }: { inputValue: string; onCreate: () => void }) {
   return (
     <CheckBoxItem
       label={'Add "' + inputValue + '"'}
@@ -75,10 +69,7 @@ function DropdownOptionItems({
   ));
 }
 
-function showEmptyOptions(
-  hasCreateItem: boolean,
-  filteredCount: number,
-): boolean {
+function showEmptyOptions(hasCreateItem: boolean, filteredCount: number): boolean {
   if (hasCreateItem) {
     return false;
   }
@@ -212,9 +203,7 @@ function OptionalLabel({
   if (!showLabel) {
     return null;
   }
-  return (
-    <Label name={name} color={error ? 'red' : undefined} label={label} required={required} />
-  );
+  return <Label name={name} color={error ? 'red' : undefined} label={label} required={required} />;
 }
 
 function OptionalError({

--- a/src/app/components/formElements/Dropdown/DropdownComboboxView.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownComboboxView.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import { FocusEvent, Ref, useId } from 'react';
+import styles from './dropdown.module.css';
+import classNames from 'classnames';
+import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form';
+import CheckBoxItem from '../CheckBoxItem/CheckBoxItem';
+import Label from '../Label/Label';
+import ErrorBox from '../ErrorBox/ErrorBox';
+import HelperText from '../HelperText/HelperText';
+import { emptyFunc } from '@/app/utilities/common';
+import DropdownFieldControls from './DropdownFieldControls';
+import { type SelectValue } from './dropdownSelection';
+
+function getComboboxAriaLabel(showLabel: boolean, label?: string): string | undefined {
+  if (showLabel) {
+    return undefined;
+  }
+  return label || undefined;
+}
+
+function CreateOptionItem({
+  inputValue,
+  onCreate,
+}: {
+  inputValue: string;
+  onCreate: () => void;
+}) {
+  return (
+    <CheckBoxItem
+      label={'Add "' + inputValue + '"'}
+      checked={false}
+      onChange={onCreate}
+      type='pill'
+      role='option'
+    />
+  );
+}
+
+function NoOptionsItem() {
+  return (
+    <CheckBoxItem
+      type='pill'
+      label='No options'
+      checked={false}
+      role='option'
+      aria-disabled
+      onChange={emptyFunc}
+      className={styles.noOptionItem}
+      tabIndex={-1}
+    />
+  );
+}
+
+function DropdownOptionItems({
+  filteredOptions,
+  radioMode,
+  isSelected,
+  onToggleOption,
+}: {
+  filteredOptions: { label: string; value: SelectValue }[];
+  radioMode: boolean;
+  isSelected: (val: SelectValue) => boolean;
+  onToggleOption: (value: SelectValue, selected: boolean) => void;
+}) {
+  return filteredOptions.map(({ label, value }) => (
+    <CheckBoxItem
+      key={String(value)}
+      label={label}
+      checked={isSelected(value)}
+      role='option'
+      type={radioMode ? 'radio' : undefined}
+      onChange={(selected) => onToggleOption(value, selected)}
+    />
+  ));
+}
+
+function showEmptyOptions(
+  hasCreateItem: boolean,
+  filteredCount: number,
+): boolean {
+  if (hasCreateItem) {
+    return false;
+  }
+  return filteredCount === 0;
+}
+
+function DropdownList({
+  listId,
+  multiple,
+  radioMode,
+  isExpanded,
+  hasCreateItem,
+  inputValue,
+  filteredOptions,
+  isSelected,
+  onCreate,
+  onToggleOption,
+  onCollapseClearDraft,
+}: {
+  listId: string;
+  multiple: boolean;
+  radioMode: boolean;
+  isExpanded: boolean;
+  hasCreateItem: boolean;
+  inputValue: string;
+  filteredOptions: { label: string; value: SelectValue }[];
+  isSelected: (val: SelectValue) => boolean;
+  onCreate: () => void;
+  onToggleOption: (value: SelectValue, selected: boolean) => void;
+  onCollapseClearDraft: () => void;
+}) {
+  const showEmpty = showEmptyOptions(hasCreateItem, filteredOptions.length);
+
+  return (
+    <div className={styles.dropdownListContainer}>
+      <ul
+        className={styles.dropdownList}
+        id={listId}
+        role='listbox'
+        aria-multiselectable={multiple}
+        onTransitionEnd={(e) => {
+          if (e.target !== e.currentTarget) {
+            return;
+          }
+          if (isExpanded) {
+            return;
+          }
+          onCollapseClearDraft();
+        }}
+      >
+        {hasCreateItem ? <CreateOptionItem inputValue={inputValue} onCreate={onCreate} /> : null}
+        <DropdownOptionItems
+          filteredOptions={filteredOptions}
+          radioMode={radioMode}
+          isSelected={isSelected}
+          onToggleOption={onToggleOption}
+        />
+        {showEmpty ? <NoOptionsItem /> : null}
+      </ul>
+    </div>
+  );
+}
+
+function HiddenSelectedValues({
+  name,
+  multiple,
+  selectedOptions,
+}: {
+  name: string;
+  multiple: boolean;
+  selectedOptions: SelectValue[];
+}) {
+  if (multiple) {
+    return selectedOptions.map((option) => (
+      <input key={String(option)} type='hidden' name={name} value={String(option)} />
+    ));
+  }
+  if (!selectedOptions.length) {
+    return null;
+  }
+  return <input type='hidden' name={name} value={String(selectedOptions[0])} />;
+}
+
+function SelectedPillsRow({ name, pills }: { name: string; pills: React.ReactNode }) {
+  return (
+    <div className={styles.selectedPillsBelow} data-testid={`${name}-selected-pills`}>
+      {pills}
+    </div>
+  );
+}
+
+function containerClassName(cols: number | undefined, className: string | undefined): string {
+  return classNames(
+    styles.container,
+    'border-box-parent',
+    cols ? 'col-md-' + cols : undefined,
+    className,
+  );
+}
+
+function resolveErrorMessage(error: unknown, fallback?: string): string | undefined {
+  if (!error) {
+    return fallback;
+  }
+  if (typeof error !== 'object') {
+    return fallback;
+  }
+  if (!('message' in error)) {
+    return fallback;
+  }
+  const message = (error as { message?: unknown }).message;
+  if (message == null) {
+    return fallback;
+  }
+  return String(message);
+}
+
+function OptionalLabel({
+  showLabel,
+  name,
+  label,
+  required,
+  error,
+}: {
+  showLabel: boolean;
+  name: string;
+  label?: string;
+  required: boolean;
+  error: unknown;
+}) {
+  if (!showLabel) {
+    return null;
+  }
+  return (
+    <Label name={name} color={error ? 'red' : undefined} label={label} required={required} />
+  );
+}
+
+function OptionalError({
+  error,
+  label,
+  defaultErrorMessage,
+}: {
+  error: unknown;
+  label?: string;
+  defaultErrorMessage?: string;
+}) {
+  if (!error) {
+    return null;
+  }
+  return <ErrorBox message={resolveErrorMessage(error, defaultErrorMessage)} label={label} />;
+}
+
+function OptionalPillsBelow({
+  show,
+  name,
+  pills,
+}: {
+  show: boolean;
+  name: string;
+  pills: React.ReactNode;
+}) {
+  if (!show) {
+    return null;
+  }
+  return <SelectedPillsRow name={name} pills={pills} />;
+}
+
+export type DropdownComboboxViewProps<TFieldValues extends FieldValues> = {
+  name: Path<TFieldValues>;
+  label?: string;
+  showLabel: boolean;
+  placeholder?: string;
+  helperText?: React.ReactNode;
+  required: boolean;
+  className?: string;
+  clearable: boolean;
+  radioMode: boolean;
+  multiple: boolean;
+  pillsBelow: boolean;
+  showInputAsText: boolean;
+  searchable: boolean;
+  cols?: number;
+  defaultErrorMessage?: string;
+  methods: UseFormReturn<TFieldValues>;
+  error: unknown;
+  disabled?: boolean;
+  value: PathValue<TFieldValues, Path<TFieldValues>>;
+  selectedOptions: SelectValue[];
+  isSelected: (val: SelectValue) => boolean;
+  inputValue: string;
+  isExpanded: boolean;
+  filteredOptions: { label: string; value: SelectValue }[];
+  hasCreateItem: boolean;
+  selectedPills: React.ReactNode;
+  showBelowPills: boolean;
+  inlinePills: React.ReactNode;
+  showTextControl: boolean;
+  attachInputRef: (node: HTMLInputElement | HTMLSpanElement | null) => void;
+  expandIfEnabled: () => void;
+  collapseIfLeaving: (relatedTarget: EventTarget | null, currentTarget: EventTarget) => void;
+  onKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
+  focusInput: (e: React.MouseEvent<HTMLElement>) => void;
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onInputKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onClearDraft: () => void;
+  onToggleExpand: (e: React.MouseEvent) => void;
+  onClearNextFocus: () => void;
+  createFromInput: () => void;
+  toggleOption: (value: SelectValue, selected: boolean) => void;
+  clearDraftOnCollapse: () => void;
+};
+
+function hasInlinePills(pillsBelow: boolean, selectedCount: number): boolean {
+  if (pillsBelow) {
+    return false;
+  }
+  return selectedCount > 0;
+}
+
+function listRadioMode(multiple: boolean, radioMode: boolean): boolean {
+  if (multiple) {
+    return false;
+  }
+  return radioMode;
+}
+
+export default function DropdownComboboxView<TFieldValues extends FieldValues>(
+  props: DropdownComboboxViewProps<TFieldValues>,
+) {
+  const listId = useId();
+
+  return (
+    <div
+      className={containerClassName(props.cols, props.className)}
+      role='combobox'
+      aria-controls={listId}
+      aria-expanded={props.isExpanded}
+      aria-disabled={props.disabled}
+      aria-label={getComboboxAriaLabel(props.showLabel, props.label)}
+      onFocusCapture={props.expandIfEnabled}
+      onBlurCapture={(e: FocusEvent<HTMLDivElement, Element>) => {
+        props.collapseIfLeaving(e.relatedTarget, e.currentTarget);
+      }}
+      onKeyDown={props.onKeyDown}
+    >
+      <OptionalLabel
+        showLabel={props.showLabel}
+        name={props.name}
+        label={props.label}
+        required={props.required}
+        error={props.error}
+      />
+      <DropdownFieldControls
+        name={props.name}
+        value={props.value}
+        methods={props.methods}
+        error={Boolean(props.error)}
+        pillsBelow={props.pillsBelow}
+        hasInlinePills={hasInlinePills(props.pillsBelow, props.selectedOptions.length)}
+        clearable={props.clearable}
+        disabled={props.disabled}
+        searchable={props.searchable}
+        showInputAsText={props.showInputAsText}
+        showTextControl={props.showTextControl}
+        placeholder={props.placeholder}
+        inputValue={props.inputValue}
+        inlinePills={props.inlinePills}
+        inputRef={props.attachInputRef as Ref<HTMLInputElement | HTMLSpanElement>}
+        onBlurCapture={props.onClearNextFocus}
+        onMouseDown={props.focusInput}
+        onInputChange={props.onInputChange}
+        onInputKeyDown={props.onInputKeyDown}
+        onClearDraft={props.onClearDraft}
+        onToggleExpand={props.onToggleExpand}
+      />
+      <OptionalPillsBelow
+        show={props.showBelowPills}
+        name={props.name}
+        pills={props.selectedPills}
+      />
+      <DropdownList
+        listId={listId}
+        multiple={props.multiple}
+        radioMode={listRadioMode(props.multiple, props.radioMode)}
+        isExpanded={props.isExpanded}
+        hasCreateItem={props.hasCreateItem}
+        inputValue={props.inputValue}
+        filteredOptions={props.filteredOptions}
+        isSelected={props.isSelected}
+        onCreate={props.createFromInput}
+        onToggleOption={props.toggleOption}
+        onCollapseClearDraft={props.clearDraftOnCollapse}
+      />
+      <HelperText>{props.helperText}</HelperText>
+      <OptionalError
+        error={props.error}
+        label={props.label}
+        defaultErrorMessage={props.defaultErrorMessage}
+      />
+      <HiddenSelectedValues
+        name={props.name}
+        multiple={props.multiple}
+        selectedOptions={props.selectedOptions}
+      />
+    </div>
+  );
+}

--- a/src/app/components/formElements/Dropdown/DropdownFieldControls.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownFieldControls.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { ChangeEvent, KeyboardEvent, MouseEvent, Ref } from 'react';
+import classNames from 'classnames';
+import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form';
+import ClearButton from '../ClearButton/ClearButton';
+import ArrowDownIcon from '../../images/ArrowDown';
+import styles from './dropdown.module.css';
+
+type DropdownFieldControlsProps<TFieldValues extends FieldValues> = {
+  name: Path<TFieldValues>;
+  value: PathValue<TFieldValues, Path<TFieldValues>>;
+  methods: UseFormReturn<TFieldValues>;
+  error?: boolean;
+  pillsBelow: boolean;
+  hasInlinePills: boolean;
+  clearable: boolean;
+  disabled?: boolean;
+  searchable: boolean;
+  showInputAsText: boolean;
+  showTextControl: boolean;
+  placeholder?: string;
+  inputValue: string;
+  inlinePills: React.ReactNode;
+  inputRef: Ref<HTMLInputElement | HTMLSpanElement>;
+  onBlurCapture: () => void;
+  onMouseDown: (e: MouseEvent<HTMLElement>) => void;
+  onInputChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onInputKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  onClearDraft: () => void;
+  onToggleExpand: (e: MouseEvent) => void;
+};
+
+export default function DropdownFieldControls<TFieldValues extends FieldValues>({
+  name,
+  value,
+  methods,
+  error,
+  pillsBelow,
+  hasInlinePills,
+  clearable,
+  disabled,
+  searchable,
+  showInputAsText,
+  showTextControl,
+  placeholder,
+  inputValue,
+  inlinePills,
+  inputRef,
+  onBlurCapture,
+  onMouseDown,
+  onInputChange,
+  onInputKeyDown,
+  onClearDraft,
+  onToggleExpand,
+}: DropdownFieldControlsProps<TFieldValues>) {
+  return (
+    <div
+      className={classNames(
+        styles.inputWrapper,
+        error && styles.error,
+        pillsBelow && styles.inputWrapperPillsBelow,
+        // NOTE: Exposing for CSS Selectors
+        'dropdown-input-wrapper',
+      )}
+      onBlurCapture={onBlurCapture}
+      onMouseDown={onMouseDown}
+    >
+      <div
+        className={classNames(
+          styles.pillAndInput,
+          hasInlinePills && styles.hasValue,
+          pillsBelow && styles.pillAndInputSingleLine,
+        )}
+        onMouseDown={onMouseDown}
+      >
+        {inlinePills}
+        {showTextControl &&
+          (showInputAsText ? (
+            <span ref={inputRef} className={styles.inputAsText} tabIndex={0}>
+              {inputValue}
+            </span>
+          ) : (
+            <input
+              ref={inputRef as Ref<HTMLInputElement>}
+              type='text'
+              role={searchable ? 'searchbox' : undefined}
+              disabled={disabled}
+              placeholder={placeholder}
+              className={styles.input}
+              onChange={onInputChange}
+              value={inputValue}
+              onKeyDown={onInputKeyDown}
+              readOnly={!searchable}
+            />
+          ))}
+      </div>
+      {clearable && (
+        <ClearButton
+          name={name}
+          value={value}
+          methods={methods}
+          className={styles.clearBtn}
+          disabled={disabled}
+          onClick={onClearDraft}
+        />
+      )}
+      <ArrowDownIcon aria-hidden className={styles.expandIcon} onMouseDown={onToggleExpand} />
+    </div>
+  );
+}

--- a/src/app/components/formElements/Dropdown/DropdownFieldControls.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownFieldControls.tsx
@@ -31,6 +31,67 @@ type DropdownFieldControlsProps<TFieldValues extends FieldValues> = {
   onToggleExpand: (e: MouseEvent) => void;
 };
 
+function DropdownTextControl({
+  inputRef,
+  showInputAsText,
+  searchable,
+  disabled,
+  placeholder,
+  inputValue,
+  onInputChange,
+  onInputKeyDown,
+}: {
+  inputRef: Ref<HTMLInputElement | HTMLSpanElement>;
+  showInputAsText: boolean;
+  searchable: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+  inputValue: string;
+  onInputChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onInputKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+}) {
+  if (showInputAsText) {
+    return (
+      <span ref={inputRef} className={styles.inputAsText} tabIndex={0}>
+        {inputValue}
+      </span>
+    );
+  }
+
+  return (
+    <input
+      ref={inputRef as Ref<HTMLInputElement>}
+      type='text'
+      role={searchable ? 'searchbox' : undefined}
+      disabled={disabled}
+      placeholder={placeholder}
+      className={styles.input}
+      onChange={onInputChange}
+      value={inputValue}
+      onKeyDown={onInputKeyDown}
+      readOnly={!searchable}
+    />
+  );
+}
+
+function wrapperClassName(error?: boolean, pillsBelow?: boolean): string {
+  return classNames(
+    styles.inputWrapper,
+    error ? styles.error : undefined,
+    pillsBelow ? styles.inputWrapperPillsBelow : undefined,
+    // NOTE: Exposing for CSS Selectors
+    'dropdown-input-wrapper',
+  );
+}
+
+function pillRowClassName(hasInlinePills: boolean, pillsBelow: boolean): string {
+  return classNames(
+    styles.pillAndInput,
+    hasInlinePills ? styles.hasValue : undefined,
+    pillsBelow ? styles.pillAndInputSingleLine : undefined,
+  );
+}
+
 export default function DropdownFieldControls<TFieldValues extends FieldValues>({
   name,
   value,
@@ -56,46 +117,26 @@ export default function DropdownFieldControls<TFieldValues extends FieldValues>(
 }: DropdownFieldControlsProps<TFieldValues>) {
   return (
     <div
-      className={classNames(
-        styles.inputWrapper,
-        error && styles.error,
-        pillsBelow && styles.inputWrapperPillsBelow,
-        // NOTE: Exposing for CSS Selectors
-        'dropdown-input-wrapper',
-      )}
+      className={wrapperClassName(error, pillsBelow)}
       onBlurCapture={onBlurCapture}
       onMouseDown={onMouseDown}
     >
-      <div
-        className={classNames(
-          styles.pillAndInput,
-          hasInlinePills && styles.hasValue,
-          pillsBelow && styles.pillAndInputSingleLine,
-        )}
-        onMouseDown={onMouseDown}
-      >
+      <div className={pillRowClassName(hasInlinePills, pillsBelow)} onMouseDown={onMouseDown}>
         {inlinePills}
-        {showTextControl &&
-          (showInputAsText ? (
-            <span ref={inputRef} className={styles.inputAsText} tabIndex={0}>
-              {inputValue}
-            </span>
-          ) : (
-            <input
-              ref={inputRef as Ref<HTMLInputElement>}
-              type='text'
-              role={searchable ? 'searchbox' : undefined}
-              disabled={disabled}
-              placeholder={placeholder}
-              className={styles.input}
-              onChange={onInputChange}
-              value={inputValue}
-              onKeyDown={onInputKeyDown}
-              readOnly={!searchable}
-            />
-          ))}
+        {showTextControl ? (
+          <DropdownTextControl
+            inputRef={inputRef}
+            showInputAsText={showInputAsText}
+            searchable={searchable}
+            disabled={disabled}
+            placeholder={placeholder}
+            inputValue={inputValue}
+            onInputChange={onInputChange}
+            onInputKeyDown={onInputKeyDown}
+          />
+        ) : null}
       </div>
-      {clearable && (
+      {clearable ? (
         <ClearButton
           name={name}
           value={value}
@@ -104,7 +145,7 @@ export default function DropdownFieldControls<TFieldValues extends FieldValues>(
           disabled={disabled}
           onClick={onClearDraft}
         />
-      )}
+      ) : null}
       <ArrowDownIcon aria-hidden className={styles.expandIcon} onMouseDown={onToggleExpand} />
     </div>
   );

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -63,10 +63,12 @@ const DropdownInput = <TFieldValues extends FieldValues>({
   clearable = true,
   radioMode = false,
   multiple = false,
+  pillsBelow = false,
   closeOnSelect = false,
   showInputAsText = false,
   cols,
   defaultErrorMessage,
+  onDraftChange,
   methods,
 }: DropdownInputProps<TFieldValues>) => {
   const {
@@ -126,6 +128,11 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     return (val: SelectValue): boolean => String(val).toLowerCase() in obj;
   })();
 
+  const setDraftValue = (next: string) => {
+    setInputValue(next);
+    onDraftChange?.(next);
+  };
+
   const createItem = (val: string) => {
     if (!creatable) {
       return;
@@ -135,7 +142,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
       return;
     }
     const valLowerCase = trimmed.toLowerCase();
-    setInputValue('');
+    setDraftValue('');
     const option = selectedOptions.find((option) => String(option).toLowerCase() === valLowerCase);
     if (!option) {
       setSelectedOptions([...selectedOptions, trimmed]);
@@ -147,11 +154,25 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     if (!searchable) {
       return;
     }
-    setInputValue(e.target.value);
+    setDraftValue(e.target.value);
     if (!multiple && selectedOptions.length) {
       setSelectedOptions([]);
     }
   };
+
+  const renderSelectedPills = () =>
+    selectedOptions.map((option) => (
+      <Pill
+        key={String(option)}
+        label={getLabel(option)}
+        value={option}
+        selected
+        onClose={onRemove}
+        onFocus={onPillFocus}
+        disabled={disabled}
+        button-aria-label={BUTTON_ARIA_LABEL}
+      />
+    ));
 
   const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && hasCreateItem) {
@@ -241,6 +262,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
         className={classNames(
           styles.inputWrapper,
           error && styles.error,
+          pillsBelow && styles.inputWrapperPillsBelow,
           // NOTE: Exposing for CSS Selectors
           'dropdown-input-wrapper',
         )}
@@ -250,22 +272,14 @@ const DropdownInput = <TFieldValues extends FieldValues>({
         onMouseDown={focusInput}
       >
         <div
-          className={classNames(styles.pillAndInput, selectedOptions.length && styles.hasValue)}
+          className={classNames(
+            styles.pillAndInput,
+            !pillsBelow && selectedOptions.length && styles.hasValue,
+            pillsBelow && styles.pillAndInputSingleLine,
+          )}
           onMouseDown={focusInput}
         >
-          {multiple &&
-            selectedOptions.map((option) => (
-              <Pill
-                key={String(option)}
-                label={getLabel(option)}
-                value={option}
-                selected
-                onClose={onRemove}
-                onFocus={onPillFocus}
-                disabled={disabled}
-                button-aria-label={BUTTON_ARIA_LABEL}
-              />
-            ))}
+          {multiple && !pillsBelow && renderSelectedPills()}
           {(!disabled || !selectedOptions.length) &&
             (showInputAsText ? (
               <span ref={attachInputRef} className={styles.inputAsText} tabIndex={0}>
@@ -293,7 +307,11 @@ const DropdownInput = <TFieldValues extends FieldValues>({
             methods={methods}
             className={styles.clearBtn}
             disabled={disabled}
-            onClick={() => !multiple && setInputValue('')}
+            onClick={() => {
+              if (!multiple) {
+                setDraftValue('');
+              }
+            }}
           />
         )}
         <ArrowDownIcon
@@ -305,6 +323,11 @@ const DropdownInput = <TFieldValues extends FieldValues>({
           }}
         />
       </div>
+      {multiple && pillsBelow && selectedOptions.length > 0 && (
+        <div className={styles.selectedPillsBelow} data-testid={`${name}-selected-pills`}>
+          {renderSelectedPills()}
+        </div>
+      )}
       <div className={styles.dropdownListContainer}>
         <ul
           className={styles.dropdownList}
@@ -317,7 +340,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
               !isExpanded &&
               (multiple || !selectedOptions.length)
             ) {
-              setInputValue('');
+              setDraftValue('');
             }
           }}
         >

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -37,6 +37,15 @@ function getComboboxAriaLabel(showLabel: boolean, label?: string): string | unde
   return label || undefined;
 }
 
+/** Clear/deselect paths may store '' instead of []; never treat that as a selected value. */
+function toSelectedOptions(value: unknown): SelectValue[] {
+  if (value == null || value === '') {
+    return [];
+  }
+  const values = Array.isArray(value) ? value : [value];
+  return values.filter((item) => item != null && String(item).trim() !== '');
+}
+
 const DropdownInput = <TFieldValues extends FieldValues>({
   name,
   label,
@@ -70,10 +79,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
 
   const inputRef = useRef<HTMLInputElement | HTMLSpanElement | undefined>(undefined);
   const nextFocusElemRef = useRef<HTMLElement | undefined>(undefined);
-  const selectedOptions = useMemo(
-    () => (value != null ? (Array.isArray(value) ? value : [value]) : []),
-    [value],
-  );
+  const selectedOptions = useMemo(() => toSelectedOptions(value), [value]);
   const listId = useId();
   const [expanded, setExpanded] = useState(false);
 
@@ -86,15 +92,13 @@ const DropdownInput = <TFieldValues extends FieldValues>({
   });
 
   const setSelectedOptions = (val: SelectValue[]) => {
+    const cleaned = toSelectedOptions(val);
     if (multiple) {
-      const newValue = val.length ? val : '';
-      field.onChange(newValue);
+      field.onChange(cleaned);
     } else {
-      const newValue = val.length ? val[0] : '';
-      field.onChange(newValue);
+      field.onChange(cleaned.length ? cleaned[0] : '');
     }
-    // The external onChange prop might expect an array, so we pass the array `val`
-    onChange?.(val);
+    onChange?.(cleaned);
   };
 
   const { getLabel, exists } = (() => {

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -21,29 +21,121 @@ import { SelectOption, DropdownInputProps } from '@/app/interfaces/FormElements'
 import ErrorBox from '../ErrorBox/ErrorBox';
 import Pill from '../Pill/Pill';
 import HelperText from '../HelperText/HelperText';
-import ClearButton from '../ClearButton/ClearButton';
 import useDefaultValue from '@/app/hooks/useDefaultValue';
 import { emptyFunc } from '@/app/utilities/common';
-import ArrowDownIcon from '../../images/ArrowDown';
+import DropdownFieldControls from './DropdownFieldControls';
+import {
+  buildOptionLookup,
+  buildSelectedLookup,
+  canCreateOption,
+  fieldValueFromSelection,
+  filterSearchableOptions,
+  nextSelectedValues,
+  resolveDisplayInputValue,
+  toSelectedOptions,
+  type SelectValue,
+} from './dropdownSelection';
 
 const BUTTON_ARIA_LABEL = 'Clear';
 
-type SelectValue = SelectOption['value'];
-
 function getComboboxAriaLabel(showLabel: boolean, label?: string): string | undefined {
-  if (showLabel) {
-    return undefined;
-  }
-  return label || undefined;
+  return showLabel ? undefined : label || undefined;
 }
 
-/** Clear/deselect paths may store '' instead of []; never treat that as a selected value. */
-function toSelectedOptions(value: unknown): SelectValue[] {
-  if (value == null || value === '') {
-    return [];
+type DropdownListProps = {
+  listId: string;
+  multiple: boolean;
+  radioMode: boolean;
+  isExpanded: boolean;
+  hasCreateItem: boolean;
+  inputValue: string;
+  filteredOptions: SelectOption[];
+  isSelected: (val: SelectValue) => boolean;
+  onCreate: () => void;
+  onToggleOption: (value: SelectValue, selected: boolean) => void;
+  onCollapseClearDraft: () => void;
+};
+
+function DropdownList({
+  listId,
+  multiple,
+  radioMode,
+  isExpanded,
+  hasCreateItem,
+  inputValue,
+  filteredOptions,
+  isSelected,
+  onCreate,
+  onToggleOption,
+  onCollapseClearDraft,
+}: DropdownListProps) {
+  return (
+    <div className={styles.dropdownListContainer}>
+      <ul
+        className={styles.dropdownList}
+        id={listId}
+        role='listbox'
+        aria-multiselectable={multiple}
+        onTransitionEnd={(e) => {
+          if (e.target === e.currentTarget && !isExpanded) {
+            onCollapseClearDraft();
+          }
+        }}
+      >
+        {hasCreateItem && (
+          <CheckBoxItem
+            label={'Add "' + inputValue + '"'}
+            checked={false}
+            onChange={onCreate}
+            type='pill'
+            role='option'
+          />
+        )}
+        {filteredOptions.map(({ label, value }) => (
+          <CheckBoxItem
+            key={String(value)}
+            label={label}
+            checked={isSelected(value)}
+            role='option'
+            type={radioMode ? 'radio' : undefined}
+            onChange={(selected) => onToggleOption(value, selected)}
+          />
+        ))}
+        {!hasCreateItem && !filteredOptions.length && (
+          <CheckBoxItem
+            type='pill'
+            label='No options'
+            checked={false}
+            role='option'
+            aria-disabled
+            onChange={emptyFunc}
+            className={styles.noOptionItem}
+            tabIndex={-1}
+          />
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function HiddenSelectedValues({
+  name,
+  multiple,
+  selectedOptions,
+}: {
+  name: string;
+  multiple: boolean;
+  selectedOptions: SelectValue[];
+}) {
+  if (multiple) {
+    return selectedOptions.map((option) => (
+      <input key={String(option)} type='hidden' name={name} value={String(option)} />
+    ));
   }
-  const values = Array.isArray(value) ? value : [value];
-  return values.filter((item) => item != null && String(item).trim() !== '');
+  if (!selectedOptions.length) {
+    return null;
+  }
+  return <input type='hidden' name={name} value={String(selectedOptions[0])} />;
 }
 
 const DropdownInput = <TFieldValues extends FieldValues>({
@@ -76,16 +168,13 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     formState: { errors },
   } = renderProps;
   const error = errors[name];
-  const comboboxAriaLabel = getComboboxAriaLabel(showLabel, label);
   const { disabled, onBlur, value } = field;
-
   const inputRef = useRef<HTMLInputElement | HTMLSpanElement | undefined>(undefined);
   const nextFocusElemRef = useRef<HTMLElement | undefined>(undefined);
   const selectedOptions = useMemo(() => toSelectedOptions(value), [value]);
   const listId = useId();
   const [expanded, setExpanded] = useState(false);
-
-  radioMode = !multiple && radioMode;
+  const [_inputValue, setInputValue] = useState('');
 
   useDefaultValue<TFieldValues>({
     renderProps,
@@ -95,38 +184,13 @@ const DropdownInput = <TFieldValues extends FieldValues>({
 
   const setSelectedOptions = (val: SelectValue[]) => {
     const cleaned = toSelectedOptions(val);
-    if (multiple) {
-      field.onChange(cleaned);
-    } else {
-      field.onChange(cleaned.length ? cleaned[0] : '');
-    }
+    field.onChange(fieldValueFromSelection(cleaned, multiple));
     onChange?.(cleaned);
   };
 
-  const { getLabel, exists } = (() => {
-    const obj: Record<string, SelectOption> = {};
-    for (const item of options) {
-      obj[String(item.value)] = item;
-    }
-
-    return {
-      getLabel: (val: SelectValue): SelectOption['label'] => obj[String(val)]?.label || String(val),
-      exists: (val: SelectValue): boolean => String(val) in obj,
-    };
-  })();
-
-  const [_inputValue, setInputValue] = useState('');
-  const inputValue =
-    !multiple && selectedOptions.length ? getLabel(selectedOptions[0]) : _inputValue;
-
-  const isSelected = (() => {
-    const obj: Record<string, true> = {};
-    for (const item of selectedOptions) {
-      obj[String(item).toLowerCase()] = true;
-    }
-
-    return (val: SelectValue): boolean => String(val).toLowerCase() in obj;
-  })();
+  const { getLabel, exists } = useMemo(() => buildOptionLookup(options), [options]);
+  const isSelected = useMemo(() => buildSelectedLookup(selectedOptions), [selectedOptions]);
+  const inputValue = resolveDisplayInputValue(multiple, selectedOptions, _inputValue, getLabel);
 
   const setDraftValue = (next: string) => {
     setInputValue(next);
@@ -134,17 +198,12 @@ const DropdownInput = <TFieldValues extends FieldValues>({
   };
 
   const createItem = (val: string) => {
-    if (!creatable) {
-      return;
-    }
     const trimmed = val.trim();
-    if (!trimmed) {
+    if (!creatable || !trimmed) {
       return;
     }
-    const valLowerCase = trimmed.toLowerCase();
     setDraftValue('');
-    const option = selectedOptions.find((option) => String(option).toLowerCase() === valLowerCase);
-    if (!option) {
+    if (!isSelected(trimmed)) {
       setSelectedOptions([...selectedOptions, trimmed]);
     }
     inputRef.current?.focus();
@@ -160,19 +219,36 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     }
   };
 
-  const renderSelectedPills = () =>
-    selectedOptions.map((option) => (
-      <Pill
-        key={String(option)}
-        label={getLabel(option)}
-        value={option}
-        selected
-        onClose={onRemove}
-        onFocus={onPillFocus}
-        disabled={disabled}
-        button-aria-label={BUTTON_ARIA_LABEL}
-      />
-    ));
+  const onRemove = (val: SelectValue) => {
+    setSelectedOptions(selectedOptions.filter((item) => item !== val));
+  };
+
+  const onPillFocus: PillFocusEventHandler = ({ parent }) => {
+    if (parent) {
+      nextFocusElemRef.current = parent.nextElementSibling as HTMLElement;
+    }
+  };
+
+  const selectedPills = selectedOptions.map((option) => (
+    <Pill
+      key={String(option)}
+      label={getLabel(option)}
+      value={option}
+      selected
+      onClose={onRemove}
+      onFocus={onPillFocus}
+      disabled={disabled}
+      button-aria-label={BUTTON_ARIA_LABEL}
+    />
+  ));
+
+  const hasCreateItem = canCreateOption({
+    disabled,
+    creatable,
+    inputValue,
+    exists,
+    isSelected,
+  });
 
   const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && hasCreateItem) {
@@ -187,53 +263,36 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     }
   };
 
-  const onRemove = (val: SelectValue) => {
-    setSelectedOptions(selectedOptions.filter((item) => item !== val));
-  };
-
-  const onPillFocus: PillFocusEventHandler = ({ parent }) => {
-    if (parent) {
-      nextFocusElemRef.current = parent.nextElementSibling as HTMLElement;
-    }
-  };
-
   const attachInputRef = (node: HTMLInputElement | HTMLSpanElement | null) => {
     inputRef.current = node || undefined;
     field.ref(node);
   };
 
   const handleCloseOnSelect = () => {
-    if (closeOnSelect) {
-      setExpanded(false);
-      (document.activeElement as HTMLElement)?.blur();
+    if (!closeOnSelect) {
+      return;
     }
+    setExpanded(false);
+    (document.activeElement as HTMLElement)?.blur();
   };
 
   useLayoutEffect(() => {
     nextFocusElemRef.current?.focus();
   }, [selectedOptions]);
 
-  const isExpanded = !disabled && expanded;
-
-  const filteredOptions = searchable
-    ? options.filter((option) => {
-        const inputValueLC = inputValue.toLowerCase();
-        return option.label.toLowerCase().includes(inputValueLC);
-      })
-    : options;
+  const isExpanded = Boolean(!disabled && expanded);
+  const filteredOptions = filterSearchableOptions(options, inputValue, searchable);
 
   const focusInput = (e: React.MouseEvent<HTMLElement>) => {
-    if (e.currentTarget === e.target) {
-      if (document.activeElement === inputRef.current) {
-        e.preventDefault();
-      } else {
-        setTimeout(() => inputRef.current?.focus());
-      }
+    if (e.currentTarget !== e.target) {
+      return;
     }
+    if (document.activeElement === inputRef.current) {
+      e.preventDefault();
+      return;
+    }
+    setTimeout(() => inputRef.current?.focus());
   };
-
-  const hasCreateItem =
-    !disabled && creatable && inputValue.trim() && !exists(inputValue) && !isSelected(inputValue);
 
   return (
     <div
@@ -247,7 +306,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
       aria-controls={listId}
       aria-expanded={isExpanded}
       aria-disabled={disabled}
-      aria-label={comboboxAriaLabel}
+      aria-label={getComboboxAriaLabel(showLabel, label)}
       onFocusCapture={() => !disabled && !expanded && setExpanded(true)}
       onBlurCapture={(e: FocusEvent<HTMLDivElement, Element>) => {
         if (!(e.currentTarget as Node)?.contains(e.relatedTarget as Node)) {
@@ -258,151 +317,71 @@ const DropdownInput = <TFieldValues extends FieldValues>({
       onKeyDown={onKeyDown}
     >
       {showLabel && <Label name={name} color={error && 'red'} label={label} required={required} />}
-      <div
-        className={classNames(
-          styles.inputWrapper,
-          error && styles.error,
-          pillsBelow && styles.inputWrapperPillsBelow,
-          // NOTE: Exposing for CSS Selectors
-          'dropdown-input-wrapper',
-        )}
+      <DropdownFieldControls
+        name={name}
+        value={value}
+        methods={methods}
+        error={Boolean(error)}
+        pillsBelow={pillsBelow}
+        hasInlinePills={!pillsBelow && selectedOptions.length > 0}
+        clearable={clearable}
+        disabled={disabled}
+        searchable={searchable}
+        showInputAsText={showInputAsText}
+        showTextControl={!disabled || selectedOptions.length === 0}
+        placeholder={placeholder}
+        inputValue={inputValue}
+        inlinePills={multiple && !pillsBelow ? selectedPills : null}
+        inputRef={attachInputRef}
         onBlurCapture={() => {
           nextFocusElemRef.current = undefined;
         }}
         onMouseDown={focusInput}
-      >
-        <div
-          className={classNames(
-            styles.pillAndInput,
-            !pillsBelow && selectedOptions.length && styles.hasValue,
-            pillsBelow && styles.pillAndInputSingleLine,
-          )}
-          onMouseDown={focusInput}
-        >
-          {multiple && !pillsBelow && renderSelectedPills()}
-          {(!disabled || !selectedOptions.length) &&
-            (showInputAsText ? (
-              <span ref={attachInputRef} className={styles.inputAsText} tabIndex={0}>
-                {inputValue}
-              </span>
-            ) : (
-              <input
-                ref={attachInputRef}
-                type='text'
-                role={searchable ? 'searchbox' : undefined}
-                disabled={disabled}
-                placeholder={placeholder}
-                className={styles.input}
-                onChange={onInputChange}
-                value={inputValue}
-                onKeyDown={onInputKeyDown}
-                readOnly={!searchable}
-              />
-            ))}
-        </div>
-        {clearable && (
-          <ClearButton
-            name={name}
-            value={value}
-            methods={methods}
-            className={styles.clearBtn}
-            disabled={disabled}
-            onClick={() => {
-              if (!multiple) {
-                setDraftValue('');
-              }
-            }}
-          />
-        )}
-        <ArrowDownIcon
-          aria-hidden
-          className={styles.expandIcon}
-          onMouseDown={(e) => {
-            inputRef.current?.[isExpanded ? 'blur' : 'focus']();
-            e.preventDefault();
-          }}
-        />
-      </div>
+        onInputChange={onInputChange}
+        onInputKeyDown={onInputKeyDown}
+        onClearDraft={() => {
+          if (!multiple) {
+            setDraftValue('');
+          }
+        }}
+        onToggleExpand={(e) => {
+          inputRef.current?.[isExpanded ? 'blur' : 'focus']();
+          e.preventDefault();
+        }}
+      />
       {multiple && pillsBelow && selectedOptions.length > 0 && (
         <div className={styles.selectedPillsBelow} data-testid={`${name}-selected-pills`}>
-          {renderSelectedPills()}
+          {selectedPills}
         </div>
       )}
-      <div className={styles.dropdownListContainer}>
-        <ul
-          className={styles.dropdownList}
-          id={listId}
-          role='listbox'
-          aria-multiselectable={multiple}
-          onTransitionEnd={(e) => {
-            if (
-              e.target === e.currentTarget &&
-              !isExpanded &&
-              (multiple || !selectedOptions.length)
-            ) {
-              setDraftValue('');
-            }
-          }}
-        >
-          {hasCreateItem && (
-            <CheckBoxItem
-              label={'Add "' + inputValue + '"'}
-              checked={false}
-              onChange={() => {
-                createItem(inputValue);
-                handleCloseOnSelect();
-              }}
-              type='pill'
-              role='option'
-            />
-          )}
-          {filteredOptions.map(({ label, value }) => (
-            <CheckBoxItem
-              key={String(value)}
-              label={label}
-              checked={isSelected(value)}
-              role='option'
-              type={radioMode ? 'radio' : undefined}
-              onChange={(selected) => {
-                if (multiple) {
-                  setSelectedOptions(
-                    selected
-                      ? [...selectedOptions, value]
-                      : selectedOptions.filter((item) => item !== value),
-                  );
-                } else {
-                  setSelectedOptions(selected ? [value] : []);
-                }
-
-                handleCloseOnSelect();
-              }}
-            />
-          ))}
-          {!hasCreateItem && !filteredOptions.length && (
-            <CheckBoxItem
-              type='pill'
-              label='No options'
-              checked={false}
-              role='option'
-              aria-disabled
-              onChange={emptyFunc}
-              className={styles.noOptionItem}
-              tabIndex={-1}
-            />
-          )}
-        </ul>
-      </div>
+      <DropdownList
+        listId={listId}
+        multiple={multiple}
+        radioMode={!multiple && radioMode}
+        isExpanded={isExpanded}
+        hasCreateItem={hasCreateItem}
+        inputValue={inputValue}
+        filteredOptions={filteredOptions}
+        isSelected={isSelected}
+        onCreate={() => {
+          createItem(inputValue);
+          handleCloseOnSelect();
+        }}
+        onToggleOption={(optionValue, selected) => {
+          setSelectedOptions(nextSelectedValues(selectedOptions, optionValue, selected, multiple));
+          handleCloseOnSelect();
+        }}
+        onCollapseClearDraft={() => {
+          if (multiple || selectedOptions.length === 0) {
+            setDraftValue('');
+          }
+        }}
+      />
       <HelperText>{helperText}</HelperText>
       {error && (
         <ErrorBox message={error.message?.toString() || defaultErrorMessage} label={label} />
       )}
-      {multiple &&
-        selectedOptions.map((option) => (
-          <input key={String(option)} type='hidden' name={name} value={String(option)} />
-        ))}
-      {!multiple && selectedOptions.length > 0 && (
-        <input type='hidden' name={name} value={String(selectedOptions[0])} />
-      )}
+      <HiddenSelectedValues name={name} multiple={multiple} selectedOptions={selectedOptions} />
     </div>
   );
 };

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -168,9 +168,7 @@ const DropdownInput = <TFieldValues extends FieldValues>(
         state.setDraftValue('');
       }}
       onToggleExpand={state.toggleExpand}
-      onClearNextFocus={() => {
-        state.nextFocusElemRef.current = undefined;
-      }}
+      onClearNextFocus={state.clearNextFocus}
       createFromInput={state.createFromInput}
       toggleOption={state.toggleOption}
       clearDraftOnCollapse={state.clearDraftOnCollapse}

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -1,386 +1,180 @@
 'use client';
 
-import {
-  useState,
-  ChangeEvent,
-  KeyboardEvent,
-  useRef,
-  useLayoutEffect,
-  FocusEvent,
-  KeyboardEventHandler,
-  useId,
-  useMemo,
-} from 'react';
-import styles from './dropdown.module.css';
-import classNames from 'classnames';
 import { FieldValues } from 'react-hook-form';
-import CheckBoxItem from '../CheckBoxItem/CheckBoxItem';
-import Label from '../Label/Label';
-import { PillFocusEventHandler } from '@/app/interfaces/Pill';
-import { SelectOption, DropdownInputProps } from '@/app/interfaces/FormElements';
-import ErrorBox from '../ErrorBox/ErrorBox';
 import Pill from '../Pill/Pill';
-import HelperText from '../HelperText/HelperText';
-import useDefaultValue from '@/app/hooks/useDefaultValue';
-import { emptyFunc } from '@/app/utilities/common';
-import DropdownFieldControls from './DropdownFieldControls';
-import {
-  buildOptionLookup,
-  buildSelectedLookup,
-  canCreateOption,
-  fieldValueFromSelection,
-  filterSearchableOptions,
-  nextSelectedValues,
-  resolveDisplayInputValue,
-  toSelectedOptions,
-  type SelectValue,
-} from './dropdownSelection';
+import { DropdownInputProps } from '@/app/interfaces/FormElements';
+import DropdownComboboxView from './DropdownComboboxView';
+import { useDropdownInputState } from './useDropdownInputState';
 
 const BUTTON_ARIA_LABEL = 'Clear';
 
-function getComboboxAriaLabel(showLabel: boolean, label?: string): string | undefined {
-  return showLabel ? undefined : label || undefined;
-}
-
-type DropdownListProps = {
-  listId: string;
-  multiple: boolean;
-  radioMode: boolean;
-  isExpanded: boolean;
-  hasCreateItem: boolean;
-  inputValue: string;
-  filteredOptions: SelectOption[];
-  isSelected: (val: SelectValue) => boolean;
-  onCreate: () => void;
-  onToggleOption: (value: SelectValue, selected: boolean) => void;
-  onCollapseClearDraft: () => void;
-};
-
-function DropdownList({
-  listId,
-  multiple,
-  radioMode,
-  isExpanded,
-  hasCreateItem,
-  inputValue,
-  filteredOptions,
-  isSelected,
-  onCreate,
-  onToggleOption,
-  onCollapseClearDraft,
-}: DropdownListProps) {
-  return (
-    <div className={styles.dropdownListContainer}>
-      <ul
-        className={styles.dropdownList}
-        id={listId}
-        role='listbox'
-        aria-multiselectable={multiple}
-        onTransitionEnd={(e) => {
-          if (e.target === e.currentTarget && !isExpanded) {
-            onCollapseClearDraft();
-          }
-        }}
-      >
-        {hasCreateItem && (
-          <CheckBoxItem
-            label={'Add "' + inputValue + '"'}
-            checked={false}
-            onChange={onCreate}
-            type='pill'
-            role='option'
-          />
-        )}
-        {filteredOptions.map(({ label, value }) => (
-          <CheckBoxItem
-            key={String(value)}
-            label={label}
-            checked={isSelected(value)}
-            role='option'
-            type={radioMode ? 'radio' : undefined}
-            onChange={(selected) => onToggleOption(value, selected)}
-          />
-        ))}
-        {!hasCreateItem && !filteredOptions.length && (
-          <CheckBoxItem
-            type='pill'
-            label='No options'
-            checked={false}
-            role='option'
-            aria-disabled
-            onChange={emptyFunc}
-            className={styles.noOptionItem}
-            tabIndex={-1}
-          />
-        )}
-      </ul>
-    </div>
-  );
-}
-
-function HiddenSelectedValues({
-  name,
-  multiple,
-  selectedOptions,
-}: {
-  name: string;
-  multiple: boolean;
-  selectedOptions: SelectValue[];
-}) {
-  if (multiple) {
-    return selectedOptions.map((option) => (
-      <input key={String(option)} type='hidden' name={name} value={String(option)} />
-    ));
+function shouldShowPillsBelow(
+  multiple: boolean,
+  pillsBelow: boolean,
+  selectedCount: number,
+): boolean {
+  if (!multiple) {
+    return false;
   }
-  if (!selectedOptions.length) {
+  if (!pillsBelow) {
+    return false;
+  }
+  return selectedCount > 0;
+}
+
+function resolveInlinePills(
+  multiple: boolean,
+  pillsBelow: boolean,
+  selectedPills: React.ReactNode,
+): React.ReactNode {
+  if (!multiple) {
     return null;
   }
-  return <input type='hidden' name={name} value={String(selectedOptions[0])} />;
+  if (pillsBelow) {
+    return null;
+  }
+  return selectedPills;
 }
 
-const DropdownInput = <TFieldValues extends FieldValues>({
-  name,
-  label,
-  defaultValue,
-  showLabel = false,
+function shouldShowTextControl(disabled: boolean | undefined, selectedCount: number): boolean {
+  if (!disabled) {
+    return true;
+  }
+  return selectedCount === 0;
+}
+
+function boolProp(value: boolean | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  return value;
+}
+
+function isSearchableEnabled(searchable: boolean | undefined): boolean {
+  return searchable !== false;
+}
+
+type ResolvedDropdownFlags = {
+  showLabel: boolean;
+  required: boolean;
+  clearable: boolean;
+  radioMode: boolean;
+  multiple: boolean;
+  pillsBelow: boolean;
+  showInputAsText: boolean;
+  searchable: boolean;
+};
+
+function resolveDropdownFlags<TFieldValues extends FieldValues>(
+  props: DropdownInputProps<TFieldValues>,
+): ResolvedDropdownFlags {
+  return {
+    showLabel: boolProp(props.showLabel, false),
+    required: boolProp(props.required, false),
+    clearable: boolProp(props.clearable, true),
+    radioMode: boolProp(props.radioMode, false),
+    multiple: boolProp(props.multiple, false),
+    pillsBelow: boolProp(props.pillsBelow, false),
+    showInputAsText: boolProp(props.showInputAsText, false),
+    searchable: isSearchableEnabled(props.searchable),
+  };
+}
+
+function SelectedOptionPills({
   options,
-  placeholder,
-  helperText,
-  required = false,
-  onChange,
-  className,
-  renderProps,
-  creatable,
-  searchable = true,
-  clearable = true,
-  radioMode = false,
-  multiple = false,
-  pillsBelow = false,
-  closeOnSelect = false,
-  showInputAsText = false,
-  cols,
-  defaultErrorMessage,
-  onDraftChange,
-  methods,
-}: DropdownInputProps<TFieldValues>) => {
-  const {
-    field,
-    formState: { errors },
-  } = renderProps;
-  const error = errors[name];
-  const { disabled, onBlur, value } = field;
-  const inputRef = useRef<HTMLInputElement | HTMLSpanElement | undefined>(undefined);
-  const nextFocusElemRef = useRef<HTMLElement | undefined>(undefined);
-  const selectedOptions = useMemo(() => toSelectedOptions(value), [value]);
-  const listId = useId();
-  const [expanded, setExpanded] = useState(false);
-  const [_inputValue, setInputValue] = useState('');
-
-  useDefaultValue<TFieldValues>({
-    renderProps,
-    defaultValue,
-    setValue: methods.setValue,
-  });
-
-  const setSelectedOptions = (val: SelectValue[]) => {
-    const cleaned = toSelectedOptions(val);
-    field.onChange(fieldValueFromSelection(cleaned, multiple));
-    onChange?.(cleaned);
-  };
-
-  const { getLabel, exists } = useMemo(() => buildOptionLookup(options), [options]);
-  const isSelected = useMemo(() => buildSelectedLookup(selectedOptions), [selectedOptions]);
-  const inputValue = resolveDisplayInputValue(multiple, selectedOptions, _inputValue, getLabel);
-
-  const setDraftValue = (next: string) => {
-    setInputValue(next);
-    onDraftChange?.(next);
-  };
-
-  const createItem = (val: string) => {
-    const trimmed = val.trim();
-    if (!creatable || !trimmed) {
-      return;
-    }
-    setDraftValue('');
-    if (!isSelected(trimmed)) {
-      setSelectedOptions([...selectedOptions, trimmed]);
-    }
-    inputRef.current?.focus();
-  };
-
-  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (!searchable) {
-      return;
-    }
-    setDraftValue(e.target.value);
-    if (!multiple && selectedOptions.length) {
-      setSelectedOptions([]);
-    }
-  };
-
-  const onRemove = (val: SelectValue) => {
-    setSelectedOptions(selectedOptions.filter((item) => item !== val));
-  };
-
-  const onPillFocus: PillFocusEventHandler = ({ parent }) => {
-    if (parent) {
-      nextFocusElemRef.current = parent.nextElementSibling as HTMLElement;
-    }
-  };
-
-  const selectedPills = selectedOptions.map((option) => (
+  getLabel,
+  disabled,
+  onRemove,
+  onFocus,
+}: {
+  options: Array<string | number | boolean>;
+  getLabel: (value: string | number | boolean) => string;
+  disabled?: boolean;
+  onRemove: (value: string | number | boolean) => void;
+  onFocus: Parameters<typeof Pill>[0]['onFocus'];
+}) {
+  return options.map((option) => (
     <Pill
       key={String(option)}
       label={getLabel(option)}
       value={option}
       selected
       onClose={onRemove}
-      onFocus={onPillFocus}
+      onFocus={onFocus}
       disabled={disabled}
       button-aria-label={BUTTON_ARIA_LABEL}
     />
   ));
+}
 
-  const hasCreateItem = canCreateOption({
-    disabled,
-    creatable,
-    inputValue,
-    exists,
-    isSelected,
-  });
-
-  const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && hasCreateItem) {
-      createItem(inputValue);
-    }
-  };
-
-  const onKeyDown: KeyboardEventHandler<HTMLDivElement> = ({ key }) => {
-    if (key === 'Escape') {
-      setExpanded(false);
-      inputRef.current?.focus();
-    }
-  };
-
-  const attachInputRef = (node: HTMLInputElement | HTMLSpanElement | null) => {
-    inputRef.current = node || undefined;
-    field.ref(node);
-  };
-
-  const handleCloseOnSelect = () => {
-    if (!closeOnSelect) {
-      return;
-    }
-    setExpanded(false);
-    (document.activeElement as HTMLElement)?.blur();
-  };
-
-  useLayoutEffect(() => {
-    nextFocusElemRef.current?.focus();
-  }, [selectedOptions]);
-
-  const isExpanded = Boolean(!disabled && expanded);
-  const filteredOptions = filterSearchableOptions(options, inputValue, searchable);
-
-  const focusInput = (e: React.MouseEvent<HTMLElement>) => {
-    if (e.currentTarget !== e.target) {
-      return;
-    }
-    if (document.activeElement === inputRef.current) {
-      e.preventDefault();
-      return;
-    }
-    setTimeout(() => inputRef.current?.focus());
-  };
+const DropdownInput = <TFieldValues extends FieldValues>(
+  props: DropdownInputProps<TFieldValues>,
+) => {
+  const flags = resolveDropdownFlags(props);
+  const state = useDropdownInputState(props);
+  const selectedPills = (
+    <SelectedOptionPills
+      options={state.selectedOptions}
+      getLabel={state.getLabel}
+      disabled={state.disabled}
+      onRemove={state.onRemove}
+      onFocus={state.onPillFocus}
+    />
+  );
 
   return (
-    <div
-      className={classNames(
-        styles.container,
-        'border-box-parent',
-        cols && 'col-md-' + cols,
-        className,
+    <DropdownComboboxView
+      name={props.name}
+      label={props.label}
+      showLabel={flags.showLabel}
+      placeholder={props.placeholder}
+      helperText={props.helperText}
+      required={flags.required}
+      className={props.className}
+      clearable={flags.clearable}
+      radioMode={flags.radioMode}
+      multiple={flags.multiple}
+      pillsBelow={flags.pillsBelow}
+      showInputAsText={flags.showInputAsText}
+      searchable={flags.searchable}
+      cols={props.cols}
+      defaultErrorMessage={props.defaultErrorMessage}
+      methods={props.methods}
+      error={state.error}
+      disabled={state.disabled}
+      value={state.value}
+      selectedOptions={state.selectedOptions}
+      isSelected={state.isSelected}
+      inputValue={state.inputValue}
+      isExpanded={state.isExpanded}
+      filteredOptions={state.filteredOptions}
+      hasCreateItem={state.hasCreateItem}
+      selectedPills={selectedPills}
+      showBelowPills={shouldShowPillsBelow(
+        flags.multiple,
+        flags.pillsBelow,
+        state.selectedOptions.length,
       )}
-      role='combobox'
-      aria-controls={listId}
-      aria-expanded={isExpanded}
-      aria-disabled={disabled}
-      aria-label={getComboboxAriaLabel(showLabel, label)}
-      onFocusCapture={() => !disabled && !expanded && setExpanded(true)}
-      onBlurCapture={(e: FocusEvent<HTMLDivElement, Element>) => {
-        if (!(e.currentTarget as Node)?.contains(e.relatedTarget as Node)) {
-          onBlur();
-          setExpanded(false);
-        }
+      inlinePills={resolveInlinePills(flags.multiple, flags.pillsBelow, selectedPills)}
+      showTextControl={shouldShowTextControl(state.disabled, state.selectedOptions.length)}
+      attachInputRef={state.attachInputRef}
+      expandIfEnabled={state.expandIfEnabled}
+      collapseIfLeaving={state.collapseIfLeaving}
+      onKeyDown={state.onKeyDown}
+      focusInput={state.focusInput}
+      onInputChange={state.onInputChange}
+      onInputKeyDown={state.onInputKeyDown}
+      onClearDraft={() => {
+        state.setDraftValue('');
       }}
-      onKeyDown={onKeyDown}
-    >
-      {showLabel && <Label name={name} color={error && 'red'} label={label} required={required} />}
-      <DropdownFieldControls
-        name={name}
-        value={value}
-        methods={methods}
-        error={Boolean(error)}
-        pillsBelow={pillsBelow}
-        hasInlinePills={!pillsBelow && selectedOptions.length > 0}
-        clearable={clearable}
-        disabled={disabled}
-        searchable={searchable}
-        showInputAsText={showInputAsText}
-        showTextControl={!disabled || selectedOptions.length === 0}
-        placeholder={placeholder}
-        inputValue={inputValue}
-        inlinePills={multiple && !pillsBelow ? selectedPills : null}
-        inputRef={attachInputRef}
-        onBlurCapture={() => {
-          nextFocusElemRef.current = undefined;
-        }}
-        onMouseDown={focusInput}
-        onInputChange={onInputChange}
-        onInputKeyDown={onInputKeyDown}
-        onClearDraft={() => {
-          setDraftValue('');
-        }}
-        onToggleExpand={(e) => {
-          inputRef.current?.[isExpanded ? 'blur' : 'focus']();
-          e.preventDefault();
-        }}
-      />
-      {multiple && pillsBelow && selectedOptions.length > 0 && (
-        <div className={styles.selectedPillsBelow} data-testid={`${name}-selected-pills`}>
-          {selectedPills}
-        </div>
-      )}
-      <DropdownList
-        listId={listId}
-        multiple={multiple}
-        radioMode={!multiple && radioMode}
-        isExpanded={isExpanded}
-        hasCreateItem={hasCreateItem}
-        inputValue={inputValue}
-        filteredOptions={filteredOptions}
-        isSelected={isSelected}
-        onCreate={() => {
-          createItem(inputValue);
-          handleCloseOnSelect();
-        }}
-        onToggleOption={(optionValue, selected) => {
-          setSelectedOptions(nextSelectedValues(selectedOptions, optionValue, selected, multiple));
-          handleCloseOnSelect();
-        }}
-        onCollapseClearDraft={() => {
-          if (multiple || selectedOptions.length === 0) {
-            setDraftValue('');
-          }
-        }}
-      />
-      <HelperText>{helperText}</HelperText>
-      {error && (
-        <ErrorBox message={error.message?.toString() || defaultErrorMessage} label={label} />
-      )}
-      <HiddenSelectedValues name={name} multiple={multiple} selectedOptions={selectedOptions} />
-    </div>
+      onToggleExpand={state.toggleExpand}
+      onClearNextFocus={() => {
+        state.nextFocusElemRef.current = undefined;
+      }}
+      createFromInput={state.createFromInput}
+      toggleOption={state.toggleOption}
+      clearDraftOnCollapse={state.clearDraftOnCollapse}
+    />
   );
 };
 

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -340,9 +340,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
         onInputChange={onInputChange}
         onInputKeyDown={onInputKeyDown}
         onClearDraft={() => {
-          if (!multiple) {
-            setDraftValue('');
-          }
+          setDraftValue('');
         }}
         onToggleExpand={(e) => {
           inputRef.current?.[isExpanded ? 'blur' : 'focus']();

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -30,6 +30,13 @@ const BUTTON_ARIA_LABEL = 'Clear';
 
 type SelectValue = SelectOption['value'];
 
+function getComboboxAriaLabel(showLabel: boolean, label?: string): string | undefined {
+  if (showLabel) {
+    return undefined;
+  }
+  return label || undefined;
+}
+
 const DropdownInput = <TFieldValues extends FieldValues>({
   name,
   label,
@@ -58,6 +65,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     formState: { errors },
   } = renderProps;
   const error = errors[name];
+  const comboboxAriaLabel = getComboboxAriaLabel(showLabel, label);
   const { disabled, onBlur, value } = field;
 
   const inputRef = useRef<HTMLInputElement | HTMLSpanElement | undefined>(undefined);
@@ -210,6 +218,7 @@ const DropdownInput = <TFieldValues extends FieldValues>({
       aria-controls={listId}
       aria-expanded={isExpanded}
       aria-disabled={disabled}
+      aria-label={comboboxAriaLabel}
       onFocusCapture={() => !disabled && !expanded && setExpanded(true)}
       onBlurCapture={(e: FocusEvent<HTMLDivElement, Element>) => {
         if (!(e.currentTarget as Node)?.contains(e.relatedTarget as Node)) {

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -126,11 +126,15 @@ const DropdownInput = <TFieldValues extends FieldValues>({
     if (!creatable) {
       return;
     }
-    const valLowerCase = val.toLowerCase();
+    const trimmed = val.trim();
+    if (!trimmed) {
+      return;
+    }
+    const valLowerCase = trimmed.toLowerCase();
     setInputValue('');
     const option = selectedOptions.find((option) => String(option).toLowerCase() === valLowerCase);
     if (!option) {
-      setSelectedOptions([...selectedOptions, val]);
+      setSelectedOptions([...selectedOptions, trimmed]);
     }
     inputRef.current?.focus();
   };

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -375,10 +375,10 @@ const DropdownInput = <TFieldValues extends FieldValues>({
       )}
       {multiple &&
         selectedOptions.map((option) => (
-          <input key={String(option)} type='hidden' name={name} value={option} />
+          <input key={String(option)} type='hidden' name={name} value={String(option)} />
         ))}
       {!multiple && selectedOptions.length > 0 && (
-        <input type='hidden' name={name} value={selectedOptions[0]} />
+        <input type='hidden' name={name} value={String(selectedOptions[0])} />
       )}
     </div>
   );

--- a/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
+++ b/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
@@ -274,6 +274,35 @@ describe('DropdownInput advanced behaviour', () => {
     expect(screen.getByDisplayValue('banana')).toBeInTheDocument();
   });
 
+  it('does not render an empty pill after deselecting the last multiple option', () => {
+    render(
+      <TestWrapper defaultValues={{ fruits: ['apple'] }}>
+        <Dropdown name='fruits' label='Fruits' options={options} multiple placeholder='Select' />
+      </TestWrapper>,
+    );
+
+    fireEvent.focus(screen.getByPlaceholderText('Select'));
+    const appleOption = screen
+      .getAllByRole('option')
+      .find((option) => option.textContent?.includes('Apple'))!;
+    fireEvent.click(appleOption);
+
+    expect(screen.queryByDisplayValue('apple')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+    expect(screen.getByPlaceholderText('Select')).toBeInTheDocument();
+  });
+
+  it('does not render an empty pill when the field value is an empty string', () => {
+    render(
+      <TestWrapper defaultValues={{ fruits: '' }}>
+        <Dropdown name='fruits' label='Fruits' options={options} multiple placeholder='Select' />
+      </TestWrapper>,
+    );
+
+    expect(screen.queryAllByRole('button', { pressed: true })).toHaveLength(0);
+    expect(screen.getByPlaceholderText('Select')).toBeInTheDocument();
+  });
+
   it('shows label fallback for values not in options', () => {
     render(
       <TestWrapper defaultValues={{ fruit: 'unknown-value' }}>

--- a/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
+++ b/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
@@ -321,9 +321,9 @@ describe('DropdownInput advanced behaviour', () => {
     expect(pillsRow).toHaveTextContent('Apple');
     expect(pillsRow).toHaveTextContent('Banana');
     expect(screen.getByPlaceholderText('Select fruit')).toHaveValue('');
-    expect(screen.getByPlaceholderText('Select fruit').closest('.dropdown-input-wrapper')).not.toContainElement(
-      pillsRow,
-    );
+    expect(
+      screen.getByPlaceholderText('Select fruit').closest('.dropdown-input-wrapper'),
+    ).not.toContainElement(pillsRow);
   });
 
   it('notifies onDraftChange while typing searchable text', async () => {

--- a/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
+++ b/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
@@ -303,6 +303,48 @@ describe('DropdownInput advanced behaviour', () => {
     expect(screen.getByPlaceholderText('Select')).toBeInTheDocument();
   });
 
+  it('renders selected pills below the input when pillsBelow is set', () => {
+    render(
+      <TestWrapper defaultValues={{ fruits: ['apple', 'banana'] }}>
+        <Dropdown
+          name='fruits'
+          label='Fruits'
+          options={options}
+          multiple
+          pillsBelow
+          placeholder='Select fruit'
+        />
+      </TestWrapper>,
+    );
+
+    const pillsRow = screen.getByTestId('fruits-selected-pills');
+    expect(pillsRow).toHaveTextContent('Apple');
+    expect(pillsRow).toHaveTextContent('Banana');
+    expect(screen.getByPlaceholderText('Select fruit')).toHaveValue('');
+    expect(screen.getByPlaceholderText('Select fruit').closest('.dropdown-input-wrapper')).not.toContainElement(
+      pillsRow,
+    );
+  });
+
+  it('notifies onDraftChange while typing searchable text', async () => {
+    const onDraftChange = jest.fn();
+    render(
+      <TestWrapper>
+        <Dropdown
+          name='fruit'
+          label='Fruit'
+          options={options}
+          placeholder='Search'
+          creatable
+          onDraftChange={onDraftChange}
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Search'), { target: { value: 'business' } });
+    expect(onDraftChange).toHaveBeenCalledWith('business');
+  });
+
   it('shows label fallback for values not in options', () => {
     render(
       <TestWrapper defaultValues={{ fruit: 'unknown-value' }}>

--- a/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
+++ b/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
@@ -72,6 +72,55 @@ describe('DropdownInput advanced behaviour', () => {
     expect(handleChange).toHaveBeenCalledWith(['Dragonfruit']);
   });
 
+  it('trims whitespace when creating a creatable option', () => {
+    const handleChange = jest.fn();
+
+    render(
+      <TestWrapper>
+        <Dropdown
+          name='fruit'
+          label='Fruit'
+          options={options}
+          placeholder='Search'
+          creatable
+          onChange={handleChange}
+        />
+      </TestWrapper>,
+    );
+
+    const input = screen.getByPlaceholderText('Search');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '  Papaya  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(handleChange).toHaveBeenCalledWith(['Papaya']);
+    expect(document.querySelector('input[type="hidden"][name="fruit"]')).toHaveValue('Papaya');
+  });
+
+  it('does not create a blank creatable option from whitespace-only input', () => {
+    const handleChange = jest.fn();
+
+    render(
+      <TestWrapper>
+        <Dropdown
+          name='fruit'
+          label='Fruit'
+          options={options}
+          placeholder='Search'
+          creatable
+          onChange={handleChange}
+        />
+      </TestWrapper>,
+    );
+
+    const input = screen.getByPlaceholderText('Search');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
   it('creates a new option via the Add item button', () => {
     render(
       <TestWrapper>

--- a/src/app/components/formElements/Dropdown/__tests__/dropdownSelection.test.ts
+++ b/src/app/components/formElements/Dropdown/__tests__/dropdownSelection.test.ts
@@ -1,0 +1,147 @@
+import {
+  buildOptionLookup,
+  buildSelectedLookup,
+  canCreateOption,
+  fieldValueFromSelection,
+  filterSearchableOptions,
+  nextSelectedValues,
+  resolveDisplayInputValue,
+  toSelectedOptions,
+} from '../dropdownSelection';
+
+describe('dropdownSelection', () => {
+  describe('toSelectedOptions', () => {
+    it('treats null, undefined, and empty string as no selection', () => {
+      expect(toSelectedOptions(null)).toEqual([]);
+      expect(toSelectedOptions(undefined)).toEqual([]);
+      expect(toSelectedOptions('')).toEqual([]);
+    });
+
+    it('drops blank entries that clear/deselect paths leave behind', () => {
+      expect(toSelectedOptions(['Music', '', '  ', 'Nursing'])).toEqual(['Music', 'Nursing']);
+      expect(toSelectedOptions([''])).toEqual([]);
+    });
+
+    it('wraps a single non-empty value', () => {
+      expect(toSelectedOptions('Sydney')).toEqual(['Sydney']);
+    });
+  });
+
+  describe('nextSelectedValues', () => {
+    it('replaces selection in single-select mode', () => {
+      expect(nextSelectedValues(['a'], 'b', true, false)).toEqual(['b']);
+      expect(nextSelectedValues(['a'], 'a', false, false)).toEqual([]);
+    });
+
+    it('adds and removes in multi-select mode', () => {
+      expect(nextSelectedValues(['a'], 'b', true, true)).toEqual(['a', 'b']);
+      expect(nextSelectedValues(['a', 'b'], 'a', false, true)).toEqual(['b']);
+    });
+  });
+
+  describe('fieldValueFromSelection', () => {
+    it('stores arrays for multiple and scalar/empty for single', () => {
+      expect(fieldValueFromSelection(['a', 'b'], true)).toEqual(['a', 'b']);
+      expect(fieldValueFromSelection(['a'], false)).toBe('a');
+      expect(fieldValueFromSelection([], false)).toBe('');
+    });
+  });
+
+  describe('canCreateOption', () => {
+    const exists = (val: string | number) => String(val) === 'Music';
+    const isSelected = (val: string | number) => String(val).toLowerCase() === 'nursing';
+
+    it('rejects disabled, non-creatable, blank, existing, and selected values', () => {
+      expect(
+        canCreateOption({
+          disabled: true,
+          creatable: true,
+          inputValue: 'Art',
+          exists,
+          isSelected,
+        }),
+      ).toBe(false);
+      expect(
+        canCreateOption({
+          creatable: false,
+          inputValue: 'Art',
+          exists,
+          isSelected,
+        }),
+      ).toBe(false);
+      expect(
+        canCreateOption({
+          creatable: true,
+          inputValue: '   ',
+          exists,
+          isSelected,
+        }),
+      ).toBe(false);
+      expect(
+        canCreateOption({
+          creatable: true,
+          inputValue: 'Music',
+          exists,
+          isSelected,
+        }),
+      ).toBe(false);
+      expect(
+        canCreateOption({
+          creatable: true,
+          inputValue: 'Nursing',
+          exists,
+          isSelected,
+        }),
+      ).toBe(false);
+    });
+
+    it('allows a novel trimmed value', () => {
+      expect(
+        canCreateOption({
+          creatable: true,
+          inputValue: '  Business  ',
+          exists,
+          isSelected,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('filterSearchableOptions', () => {
+    const options = [
+      { label: 'Digital Skills', value: 'digital-skills' },
+      { label: 'Nursing', value: 'nursing' },
+    ];
+
+    it('returns all options when not searchable', () => {
+      expect(filterSearchableOptions(options, 'zzz', false)).toEqual(options);
+    });
+
+    it('filters by label substring case-insensitively', () => {
+      expect(filterSearchableOptions(options, 'dig', true)).toEqual([options[0]]);
+      expect(filterSearchableOptions(options, 'NOPE', true)).toEqual([]);
+    });
+  });
+
+  describe('lookups and display value', () => {
+    it('resolves labels and membership', () => {
+      const { getLabel, exists } = buildOptionLookup([{ label: 'Music', value: 'music' }]);
+      expect(getLabel('music')).toBe('Music');
+      expect(getLabel('unknown')).toBe('unknown');
+      expect(exists('music')).toBe(true);
+      expect(exists('unknown')).toBe(false);
+    });
+
+    it('matches selected values case-insensitively', () => {
+      const isSelected = buildSelectedLookup(['Music']);
+      expect(isSelected('music')).toBe(true);
+      expect(isSelected('Nursing')).toBe(false);
+    });
+
+    it('shows label for single-select selection instead of draft', () => {
+      expect(resolveDisplayInputValue(false, ['music'], 'draft', () => 'Music')).toBe('Music');
+      expect(resolveDisplayInputValue(true, ['music'], 'draft', () => 'Music')).toBe('draft');
+      expect(resolveDisplayInputValue(false, [], 'draft', () => 'Music')).toBe('draft');
+    });
+  });
+});

--- a/src/app/components/formElements/Dropdown/dropdown.module.css
+++ b/src/app/components/formElements/Dropdown/dropdown.module.css
@@ -136,6 +136,31 @@
   align-self: flex-start;
 }
 
+.inputWrapperPillsBelow {
+  align-items: center;
+}
+
+.inputWrapperPillsBelow .clearBtn {
+  margin-top: 0;
+  align-self: center;
+}
+
+.pillAndInputSingleLine {
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.selectedPillsBelow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.selectedPillsBelow > [role='button'] {
+  margin: 0;
+}
+
 .expandIcon {
   padding: 6px 5px;
   transition: transform 150ms linear;

--- a/src/app/components/formElements/Dropdown/dropdown.module.css
+++ b/src/app/components/formElements/Dropdown/dropdown.module.css
@@ -106,7 +106,7 @@
   overflow-y: auto;
   background-color: white;
   width: 100%;
-  z-index: 1;
+  z-index: 20;
   box-shadow: 0px 2px 2px 0px #00000026;
   flex-direction: column;
   transition: all 200ms ease-in-out;

--- a/src/app/components/formElements/Dropdown/dropdownSelection.ts
+++ b/src/app/components/formElements/Dropdown/dropdownSelection.ts
@@ -2,13 +2,23 @@ import type { SelectOption } from '@/app/interfaces/FormElements';
 
 export type SelectValue = SelectOption['value'];
 
+function isBlankSelection(item: unknown): boolean {
+  if (item == null) {
+    return true;
+  }
+  return String(item).trim() === '';
+}
+
 /** Clear/deselect paths may store '' instead of []; never treat that as a selected value. */
 export function toSelectedOptions(value: unknown): SelectValue[] {
-  if (value == null || value === '') {
+  if (value == null) {
+    return [];
+  }
+  if (value === '') {
     return [];
   }
   const values = Array.isArray(value) ? value : [value];
-  return values.filter((item) => item != null && String(item).trim() !== '');
+  return values.filter((item) => !isBlankSelection(item));
 }
 
 export function buildOptionLookup(options: readonly SelectOption[]) {
@@ -17,8 +27,13 @@ export function buildOptionLookup(options: readonly SelectOption[]) {
     byValue[String(item.value)] = item;
   }
   return {
-    getLabel: (val: SelectValue): SelectOption['label'] =>
-      byValue[String(val)]?.label || String(val),
+    getLabel: (val: SelectValue): SelectOption['label'] => {
+      const match = byValue[String(val)];
+      if (match) {
+        return match.label;
+      }
+      return String(val);
+    },
     exists: (val: SelectValue): boolean => String(val) in byValue,
   };
 }
@@ -62,7 +77,10 @@ export function fieldValueFromSelection(cleaned: SelectValue[], multiple: boolea
   if (multiple) {
     return cleaned;
   }
-  return cleaned.length ? cleaned[0] : '';
+  if (cleaned.length) {
+    return cleaned[0];
+  }
+  return '';
 }
 
 export function canCreateOption(params: {
@@ -73,10 +91,22 @@ export function canCreateOption(params: {
   isSelected: (val: SelectValue) => boolean;
 }): boolean {
   const trimmed = params.inputValue.trim();
-  if (params.disabled || !params.creatable || !trimmed) {
+  if (params.disabled) {
     return false;
   }
-  return !params.exists(trimmed) && !params.isSelected(trimmed);
+  if (!params.creatable) {
+    return false;
+  }
+  if (!trimmed) {
+    return false;
+  }
+  if (params.exists(trimmed)) {
+    return false;
+  }
+  if (params.isSelected(trimmed)) {
+    return false;
+  }
+  return true;
 }
 
 export function resolveDisplayInputValue(

--- a/src/app/components/formElements/Dropdown/dropdownSelection.ts
+++ b/src/app/components/formElements/Dropdown/dropdownSelection.ts
@@ -1,0 +1,92 @@
+import type { SelectOption } from '@/app/interfaces/FormElements';
+
+export type SelectValue = SelectOption['value'];
+
+/** Clear/deselect paths may store '' instead of []; never treat that as a selected value. */
+export function toSelectedOptions(value: unknown): SelectValue[] {
+  if (value == null || value === '') {
+    return [];
+  }
+  const values = Array.isArray(value) ? value : [value];
+  return values.filter((item) => item != null && String(item).trim() !== '');
+}
+
+export function buildOptionLookup(options: readonly SelectOption[]) {
+  const byValue: Record<string, SelectOption> = {};
+  for (const item of options) {
+    byValue[String(item.value)] = item;
+  }
+  return {
+    getLabel: (val: SelectValue): SelectOption['label'] =>
+      byValue[String(val)]?.label || String(val),
+    exists: (val: SelectValue): boolean => String(val) in byValue,
+  };
+}
+
+export function buildSelectedLookup(selectedOptions: readonly SelectValue[]) {
+  const selected: Record<string, true> = {};
+  for (const item of selectedOptions) {
+    selected[String(item).toLowerCase()] = true;
+  }
+  return (val: SelectValue): boolean => String(val).toLowerCase() in selected;
+}
+
+export function filterSearchableOptions(
+  options: readonly SelectOption[],
+  inputValue: string,
+  searchable: boolean,
+): SelectOption[] {
+  if (!searchable) {
+    return [...options];
+  }
+  const query = inputValue.toLowerCase();
+  return options.filter((option) => option.label.toLowerCase().includes(query));
+}
+
+export function nextSelectedValues(
+  selectedOptions: readonly SelectValue[],
+  value: SelectValue,
+  selected: boolean,
+  multiple: boolean,
+): SelectValue[] {
+  if (!multiple) {
+    return selected ? [value] : [];
+  }
+  if (selected) {
+    return [...selectedOptions, value];
+  }
+  return selectedOptions.filter((item) => item !== value);
+}
+
+export function fieldValueFromSelection(cleaned: SelectValue[], multiple: boolean): unknown {
+  if (multiple) {
+    return cleaned;
+  }
+  return cleaned.length ? cleaned[0] : '';
+}
+
+export function canCreateOption(params: {
+  disabled?: boolean;
+  creatable?: boolean;
+  inputValue: string;
+  exists: (val: SelectValue) => boolean;
+  isSelected: (val: SelectValue) => boolean;
+}): boolean {
+  const trimmed = params.inputValue.trim();
+  if (params.disabled || !params.creatable || !trimmed) {
+    return false;
+  }
+  return !params.exists(trimmed) && !params.isSelected(trimmed);
+}
+
+export function resolveDisplayInputValue(
+  multiple: boolean,
+  selectedOptions: readonly SelectValue[],
+  draft: string,
+  getLabel: (val: SelectValue) => string,
+): string {
+  if (!multiple && selectedOptions.length) {
+    return getLabel(selectedOptions[0]);
+  }
+  return draft;
+}

--- a/src/app/components/formElements/Dropdown/useDropdownInputState.ts
+++ b/src/app/components/formElements/Dropdown/useDropdownInputState.ts
@@ -10,7 +10,7 @@ import {
   useMemo,
   MutableRefObject,
 } from 'react';
-import { FieldValues, Path, RefCallBack } from 'react-hook-form';
+import { FieldValues, Path, PathValue, RefCallBack } from 'react-hook-form';
 import { PillFocusEventHandler } from '@/app/interfaces/Pill';
 import { DropdownInputProps } from '@/app/interfaces/FormElements';
 import useDefaultValue from '@/app/hooks/useDefaultValue';
@@ -56,7 +56,7 @@ type DropdownCore<TFieldValues extends FieldValues> = {
   error: unknown;
   disabled?: boolean;
   onBlur: () => void;
-  value: unknown;
+  value: PathValue<TFieldValues, Path<TFieldValues>>;
   fieldRef: RefCallBack;
   selectedOptions: SelectValue[];
   getLabel: (val: SelectValue) => string;

--- a/src/app/components/formElements/Dropdown/useDropdownInputState.ts
+++ b/src/app/components/formElements/Dropdown/useDropdownInputState.ts
@@ -8,8 +8,9 @@ import {
   useLayoutEffect,
   KeyboardEventHandler,
   useMemo,
+  MutableRefObject,
 } from 'react';
-import { FieldValues, Path } from 'react-hook-form';
+import { FieldValues, Path, RefCallBack } from 'react-hook-form';
 import { PillFocusEventHandler } from '@/app/interfaces/Pill';
 import { DropdownInputProps } from '@/app/interfaces/FormElements';
 import useDefaultValue from '@/app/hooks/useDefaultValue';
@@ -47,25 +48,43 @@ function boolProp(value: boolean | undefined, fallback: boolean): boolean {
   return value;
 }
 
-export function useDropdownInputState<TFieldValues extends FieldValues>(
+type DropdownCore<TFieldValues extends FieldValues> = {
+  params: UseDropdownInputStateParams<TFieldValues>;
+  searchable: boolean;
+  multiple: boolean;
+  closeOnSelect: boolean;
+  error: unknown;
+  disabled?: boolean;
+  onBlur: () => void;
+  value: unknown;
+  fieldRef: RefCallBack;
+  selectedOptions: SelectValue[];
+  getLabel: (val: SelectValue) => string;
+  isSelected: (val: SelectValue) => boolean;
+  exists: (val: SelectValue) => boolean;
+  inputValue: string;
+  isExpanded: boolean;
+  filteredOptions: ReturnType<typeof filterSearchableOptions>;
+  hasCreateItem: boolean;
+  expanded: boolean;
+  setExpanded: (next: boolean) => void;
+  setDraftValue: (next: string) => void;
+  setSelectedOptions: (val: SelectValue[]) => void;
+  inputRef: MutableRefObject<HTMLInputElement | HTMLSpanElement | undefined>;
+  nextFocusElemRef: MutableRefObject<HTMLElement | undefined>;
+};
+
+function useDropdownCore<TFieldValues extends FieldValues>(
   params: UseDropdownInputStateParams<TFieldValues>,
-) {
-  const name = params.name;
-  const defaultValue = params.defaultValue;
-  const options = params.options;
-  const onChange = params.onChange;
-  const renderProps = params.renderProps;
-  const creatable = params.creatable;
+): DropdownCore<TFieldValues> {
   const searchable = boolProp(params.searchable, true);
   const multiple = boolProp(params.multiple, false);
   const closeOnSelect = boolProp(params.closeOnSelect, false);
-  const onDraftChange = params.onDraftChange;
-  const methods = params.methods;
   const {
     field,
     formState: { errors },
-  } = renderProps;
-  const error = errors[name as Path<TFieldValues>];
+  } = params.renderProps;
+  const error = errors[params.name as Path<TFieldValues>];
   const { disabled, onBlur, value } = field;
   const inputRef = useRef<HTMLInputElement | HTMLSpanElement | undefined>(undefined);
   const nextFocusElemRef = useRef<HTMLElement | undefined>(undefined);
@@ -74,134 +93,159 @@ export function useDropdownInputState<TFieldValues extends FieldValues>(
   const [draftValue, setDraftValueState] = useState('');
 
   useDefaultValue<TFieldValues>({
-    renderProps,
-    defaultValue,
-    setValue: methods.setValue,
+    renderProps: params.renderProps,
+    defaultValue: params.defaultValue,
+    setValue: params.methods.setValue,
   });
 
   const setSelectedOptions = (val: SelectValue[]) => {
     const cleaned = toSelectedOptions(val);
     field.onChange(fieldValueFromSelection(cleaned, multiple));
-    onChange?.(cleaned);
+    params.onChange?.(cleaned);
   };
 
-  const { getLabel, exists } = useMemo(() => buildOptionLookup(options), [options]);
+  const { getLabel, exists } = useMemo(() => buildOptionLookup(params.options), [params.options]);
   const isSelected = useMemo(() => buildSelectedLookup(selectedOptions), [selectedOptions]);
   const inputValue = resolveDisplayInputValue(multiple, selectedOptions, draftValue, getLabel);
-
   const setDraftValue = (next: string) => {
     setDraftValueState(next);
-    onDraftChange?.(next);
+    params.onDraftChange?.(next);
   };
-
-  const createItem = (val: string) => {
-    const trimmed = val.trim();
-    if (!creatable) {
-      return;
-    }
-    if (!trimmed) {
-      return;
-    }
-    setDraftValue('');
-    if (!isSelected(trimmed)) {
-      setSelectedOptions([...selectedOptions, trimmed]);
-    }
-    inputRef.current?.focus();
-  };
-
-  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (!searchable) {
-      return;
-    }
-    setDraftValue(e.target.value);
-    if (multiple) {
-      return;
-    }
-    if (selectedOptions.length === 0) {
-      return;
-    }
-    setSelectedOptions([]);
-  };
-
-  const onRemove = (val: SelectValue) => {
-    setSelectedOptions(selectedOptions.filter((item) => item !== val));
-  };
-
-  const onPillFocus: PillFocusEventHandler = ({ parent }) => {
-    if (parent) {
-      nextFocusElemRef.current = parent.nextElementSibling as HTMLElement;
-    }
-  };
-
+  const isExpanded = Boolean(disabled ? false : expanded);
+  const filteredOptions = filterSearchableOptions(params.options, inputValue, searchable);
   const hasCreateItem = canCreateOption({
     disabled,
-    creatable,
+    creatable: params.creatable,
     inputValue,
     exists,
     isSelected,
   });
 
+  useLayoutEffect(() => {
+    nextFocusElemRef.current?.focus();
+  }, [selectedOptions]);
+
+  return {
+    params,
+    searchable,
+    multiple,
+    closeOnSelect,
+    error,
+    disabled,
+    onBlur,
+    value,
+    fieldRef: field.ref,
+    selectedOptions,
+    getLabel,
+    isSelected,
+    exists,
+    inputValue,
+    isExpanded,
+    filteredOptions,
+    hasCreateItem,
+    expanded,
+    setExpanded,
+    setDraftValue,
+    setSelectedOptions,
+    inputRef,
+    nextFocusElemRef,
+  };
+}
+
+function useDropdownHandlers<TFieldValues extends FieldValues>(core: DropdownCore<TFieldValues>) {
+  const createItem = (val: string) => {
+    const trimmed = val.trim();
+    if (!core.params.creatable) {
+      return;
+    }
+    if (!trimmed) {
+      return;
+    }
+    core.setDraftValue('');
+    if (!core.isSelected(trimmed)) {
+      core.setSelectedOptions([...core.selectedOptions, trimmed]);
+    }
+    core.inputRef.current?.focus();
+  };
+
+  const handleCloseOnSelect = () => {
+    if (!core.closeOnSelect) {
+      return;
+    }
+    core.setExpanded(false);
+    (document.activeElement as HTMLElement)?.blur();
+  };
+
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!core.searchable) {
+      return;
+    }
+    core.setDraftValue(e.target.value);
+    if (core.multiple) {
+      return;
+    }
+    if (core.selectedOptions.length === 0) {
+      return;
+    }
+    core.setSelectedOptions([]);
+  };
+
+  const onRemove = (val: SelectValue) => {
+    core.setSelectedOptions(core.selectedOptions.filter((item) => item !== val));
+  };
+
+  const onPillFocus: PillFocusEventHandler = ({ parent }) => {
+    if (parent) {
+      core.nextFocusElemRef.current = parent.nextElementSibling as HTMLElement;
+    }
+  };
+
   const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key !== 'Enter') {
       return;
     }
-    if (!hasCreateItem) {
+    if (!core.hasCreateItem) {
       return;
     }
-    createItem(inputValue);
+    createItem(core.inputValue);
   };
 
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = ({ key }) => {
     if (key !== 'Escape') {
       return;
     }
-    setExpanded(false);
-    inputRef.current?.focus();
+    core.setExpanded(false);
+    core.inputRef.current?.focus();
   };
 
   const attachInputRef = (node: HTMLInputElement | HTMLSpanElement | null) => {
     if (node) {
-      inputRef.current = node;
+      core.inputRef.current = node;
     } else {
-      inputRef.current = undefined;
+      core.inputRef.current = undefined;
     }
-    field.ref(node);
+    core.fieldRef(node);
   };
-
-  const handleCloseOnSelect = () => {
-    if (!closeOnSelect) {
-      return;
-    }
-    setExpanded(false);
-    (document.activeElement as HTMLElement)?.blur();
-  };
-
-  useLayoutEffect(() => {
-    nextFocusElemRef.current?.focus();
-  }, [selectedOptions]);
-
-  const isExpanded = Boolean(disabled ? false : expanded);
-  const filteredOptions = filterSearchableOptions(options, inputValue, searchable);
 
   const focusInput = (e: React.MouseEvent<HTMLElement>) => {
     if (e.currentTarget !== e.target) {
       return;
     }
-    if (document.activeElement === inputRef.current) {
+    if (document.activeElement === core.inputRef.current) {
       e.preventDefault();
       return;
     }
-    setTimeout(() => inputRef.current?.focus());
+    setTimeout(() => core.inputRef.current?.focus());
   };
 
   const expandIfEnabled = () => {
-    if (disabled) {
+    if (core.disabled) {
       return;
     }
-    if (expanded) {
+    if (core.expanded) {
       return;
     }
-    setExpanded(true);
+    core.setExpanded(true);
   };
 
   const collapseIfLeaving = (relatedTarget: EventTarget | null, currentTarget: EventTarget) => {
@@ -209,34 +253,36 @@ export function useDropdownInputState<TFieldValues extends FieldValues>(
     if (stillInside) {
       return;
     }
-    onBlur();
-    setExpanded(false);
+    core.onBlur();
+    core.setExpanded(false);
   };
 
   const toggleOption = (optionValue: SelectValue, selected: boolean) => {
-    setSelectedOptions(nextSelectedValues(selectedOptions, optionValue, selected, multiple));
+    core.setSelectedOptions(
+      nextSelectedValues(core.selectedOptions, optionValue, selected, core.multiple),
+    );
     handleCloseOnSelect();
   };
 
   const createFromInput = () => {
-    createItem(inputValue);
+    createItem(core.inputValue);
     handleCloseOnSelect();
   };
 
   const clearDraftOnCollapse = () => {
-    if (multiple) {
-      setDraftValue('');
+    if (core.multiple) {
+      core.setDraftValue('');
       return;
     }
-    if (selectedOptions.length === 0) {
-      setDraftValue('');
+    if (core.selectedOptions.length === 0) {
+      core.setDraftValue('');
     }
   };
 
   const toggleExpand = (e: React.MouseEvent) => {
-    const input = inputRef.current;
+    const input = core.inputRef.current;
     if (input) {
-      if (isExpanded) {
+      if (core.isExpanded) {
         input.blur();
       } else {
         input.focus();
@@ -245,23 +291,14 @@ export function useDropdownInputState<TFieldValues extends FieldValues>(
     e.preventDefault();
   };
 
+  const clearNextFocus = () => {
+    core.nextFocusElemRef.current = undefined;
+  };
+
   return {
-    error,
-    disabled,
-    value,
-    selectedOptions,
-    getLabel,
-    isSelected,
-    inputValue,
-    isExpanded,
-    filteredOptions,
-    hasCreateItem,
-    inputRef,
-    nextFocusElemRef,
-    setDraftValue,
+    onInputChange,
     onRemove,
     onPillFocus,
-    onInputChange,
     onInputKeyDown,
     onKeyDown,
     attachInputRef,
@@ -272,6 +309,29 @@ export function useDropdownInputState<TFieldValues extends FieldValues>(
     createFromInput,
     clearDraftOnCollapse,
     toggleExpand,
+    clearNextFocus,
+  };
+}
+
+export function useDropdownInputState<TFieldValues extends FieldValues>(
+  params: UseDropdownInputStateParams<TFieldValues>,
+) {
+  const core = useDropdownCore(params);
+  const handlers = useDropdownHandlers(core);
+
+  return {
+    error: core.error,
+    disabled: core.disabled,
+    value: core.value,
+    selectedOptions: core.selectedOptions,
+    getLabel: core.getLabel,
+    isSelected: core.isSelected,
+    inputValue: core.inputValue,
+    isExpanded: core.isExpanded,
+    filteredOptions: core.filteredOptions,
+    hasCreateItem: core.hasCreateItem,
+    setDraftValue: core.setDraftValue,
+    ...handlers,
   };
 }
 

--- a/src/app/components/formElements/Dropdown/useDropdownInputState.ts
+++ b/src/app/components/formElements/Dropdown/useDropdownInputState.ts
@@ -1,0 +1,280 @@
+'use client';
+
+import {
+  useState,
+  ChangeEvent,
+  KeyboardEvent,
+  useRef,
+  useLayoutEffect,
+  KeyboardEventHandler,
+  useMemo,
+} from 'react';
+import { FieldValues, Path } from 'react-hook-form';
+import { PillFocusEventHandler } from '@/app/interfaces/Pill';
+import { DropdownInputProps } from '@/app/interfaces/FormElements';
+import useDefaultValue from '@/app/hooks/useDefaultValue';
+import {
+  buildOptionLookup,
+  buildSelectedLookup,
+  canCreateOption,
+  fieldValueFromSelection,
+  filterSearchableOptions,
+  nextSelectedValues,
+  resolveDisplayInputValue,
+  toSelectedOptions,
+  type SelectValue,
+} from './dropdownSelection';
+
+type UseDropdownInputStateParams<TFieldValues extends FieldValues> = Pick<
+  DropdownInputProps<TFieldValues>,
+  | 'name'
+  | 'defaultValue'
+  | 'options'
+  | 'onChange'
+  | 'renderProps'
+  | 'creatable'
+  | 'searchable'
+  | 'multiple'
+  | 'closeOnSelect'
+  | 'onDraftChange'
+  | 'methods'
+>;
+
+function boolProp(value: boolean | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  return value;
+}
+
+export function useDropdownInputState<TFieldValues extends FieldValues>(
+  params: UseDropdownInputStateParams<TFieldValues>,
+) {
+  const name = params.name;
+  const defaultValue = params.defaultValue;
+  const options = params.options;
+  const onChange = params.onChange;
+  const renderProps = params.renderProps;
+  const creatable = params.creatable;
+  const searchable = boolProp(params.searchable, true);
+  const multiple = boolProp(params.multiple, false);
+  const closeOnSelect = boolProp(params.closeOnSelect, false);
+  const onDraftChange = params.onDraftChange;
+  const methods = params.methods;
+  const {
+    field,
+    formState: { errors },
+  } = renderProps;
+  const error = errors[name as Path<TFieldValues>];
+  const { disabled, onBlur, value } = field;
+  const inputRef = useRef<HTMLInputElement | HTMLSpanElement | undefined>(undefined);
+  const nextFocusElemRef = useRef<HTMLElement | undefined>(undefined);
+  const selectedOptions = useMemo(() => toSelectedOptions(value), [value]);
+  const [expanded, setExpanded] = useState(false);
+  const [draftValue, setDraftValueState] = useState('');
+
+  useDefaultValue<TFieldValues>({
+    renderProps,
+    defaultValue,
+    setValue: methods.setValue,
+  });
+
+  const setSelectedOptions = (val: SelectValue[]) => {
+    const cleaned = toSelectedOptions(val);
+    field.onChange(fieldValueFromSelection(cleaned, multiple));
+    onChange?.(cleaned);
+  };
+
+  const { getLabel, exists } = useMemo(() => buildOptionLookup(options), [options]);
+  const isSelected = useMemo(() => buildSelectedLookup(selectedOptions), [selectedOptions]);
+  const inputValue = resolveDisplayInputValue(multiple, selectedOptions, draftValue, getLabel);
+
+  const setDraftValue = (next: string) => {
+    setDraftValueState(next);
+    onDraftChange?.(next);
+  };
+
+  const createItem = (val: string) => {
+    const trimmed = val.trim();
+    if (!creatable) {
+      return;
+    }
+    if (!trimmed) {
+      return;
+    }
+    setDraftValue('');
+    if (!isSelected(trimmed)) {
+      setSelectedOptions([...selectedOptions, trimmed]);
+    }
+    inputRef.current?.focus();
+  };
+
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (!searchable) {
+      return;
+    }
+    setDraftValue(e.target.value);
+    if (multiple) {
+      return;
+    }
+    if (selectedOptions.length === 0) {
+      return;
+    }
+    setSelectedOptions([]);
+  };
+
+  const onRemove = (val: SelectValue) => {
+    setSelectedOptions(selectedOptions.filter((item) => item !== val));
+  };
+
+  const onPillFocus: PillFocusEventHandler = ({ parent }) => {
+    if (parent) {
+      nextFocusElemRef.current = parent.nextElementSibling as HTMLElement;
+    }
+  };
+
+  const hasCreateItem = canCreateOption({
+    disabled,
+    creatable,
+    inputValue,
+    exists,
+    isSelected,
+  });
+
+  const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Enter') {
+      return;
+    }
+    if (!hasCreateItem) {
+      return;
+    }
+    createItem(inputValue);
+  };
+
+  const onKeyDown: KeyboardEventHandler<HTMLDivElement> = ({ key }) => {
+    if (key !== 'Escape') {
+      return;
+    }
+    setExpanded(false);
+    inputRef.current?.focus();
+  };
+
+  const attachInputRef = (node: HTMLInputElement | HTMLSpanElement | null) => {
+    if (node) {
+      inputRef.current = node;
+    } else {
+      inputRef.current = undefined;
+    }
+    field.ref(node);
+  };
+
+  const handleCloseOnSelect = () => {
+    if (!closeOnSelect) {
+      return;
+    }
+    setExpanded(false);
+    (document.activeElement as HTMLElement)?.blur();
+  };
+
+  useLayoutEffect(() => {
+    nextFocusElemRef.current?.focus();
+  }, [selectedOptions]);
+
+  const isExpanded = Boolean(disabled ? false : expanded);
+  const filteredOptions = filterSearchableOptions(options, inputValue, searchable);
+
+  const focusInput = (e: React.MouseEvent<HTMLElement>) => {
+    if (e.currentTarget !== e.target) {
+      return;
+    }
+    if (document.activeElement === inputRef.current) {
+      e.preventDefault();
+      return;
+    }
+    setTimeout(() => inputRef.current?.focus());
+  };
+
+  const expandIfEnabled = () => {
+    if (disabled) {
+      return;
+    }
+    if (expanded) {
+      return;
+    }
+    setExpanded(true);
+  };
+
+  const collapseIfLeaving = (relatedTarget: EventTarget | null, currentTarget: EventTarget) => {
+    const stillInside = (currentTarget as Node).contains(relatedTarget as Node);
+    if (stillInside) {
+      return;
+    }
+    onBlur();
+    setExpanded(false);
+  };
+
+  const toggleOption = (optionValue: SelectValue, selected: boolean) => {
+    setSelectedOptions(nextSelectedValues(selectedOptions, optionValue, selected, multiple));
+    handleCloseOnSelect();
+  };
+
+  const createFromInput = () => {
+    createItem(inputValue);
+    handleCloseOnSelect();
+  };
+
+  const clearDraftOnCollapse = () => {
+    if (multiple) {
+      setDraftValue('');
+      return;
+    }
+    if (selectedOptions.length === 0) {
+      setDraftValue('');
+    }
+  };
+
+  const toggleExpand = (e: React.MouseEvent) => {
+    const input = inputRef.current;
+    if (input) {
+      if (isExpanded) {
+        input.blur();
+      } else {
+        input.focus();
+      }
+    }
+    e.preventDefault();
+  };
+
+  return {
+    error,
+    disabled,
+    value,
+    selectedOptions,
+    getLabel,
+    isSelected,
+    inputValue,
+    isExpanded,
+    filteredOptions,
+    hasCreateItem,
+    inputRef,
+    nextFocusElemRef,
+    setDraftValue,
+    onRemove,
+    onPillFocus,
+    onInputChange,
+    onInputKeyDown,
+    onKeyDown,
+    attachInputRef,
+    focusInput,
+    expandIfEnabled,
+    collapseIfLeaving,
+    toggleOption,
+    createFromInput,
+    clearDraftOnCollapse,
+    toggleExpand,
+  };
+}
+
+export type DropdownInputState = ReturnType<typeof useDropdownInputState>;
+
+export type { SelectValue };

--- a/src/app/components/formElements/Pill/pill.module.css
+++ b/src/app/components/formElements/Pill/pill.module.css
@@ -8,6 +8,7 @@
   gap: 8px;
   border: 0.5px solid #3e3e3e40;
   background: var(--pure-white);
+  color: var(--BondBlack);
 }
 
 .pill[aria-pressed='true'] {
@@ -23,6 +24,11 @@
 
 .pill > label {
   padding: 4px 0px;
+  color: inherit;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .clear {

--- a/src/app/components/institutionProviderCard/institutionProviderCard.module.css
+++ b/src/app/components/institutionProviderCard/institutionProviderCard.module.css
@@ -306,25 +306,25 @@
     top: 26px;
   }
 
-  /* 2-up directory — ~6 cards per phone screen, with breathing room */
+  /* 2-up directory / search — denser cards so ~4–5 fit on a phone screen */
   .card.cardCompact {
-    min-height: 220px;
+    min-height: 200px;
   }
 
   .card.cardCompact .cardTop {
-    height: 72px;
+    height: 64px;
   }
 
   .card.cardCompact .cardBody {
-    padding: 14px 0 16px;
-    gap: 12px;
+    padding: 10px 0 12px;
+    gap: 10px;
     justify-content: space-between;
   }
 
   .card.cardCompact .nameWrap {
     width: 88%;
-    min-height: 56px;
-    padding: 8px 10px;
+    min-height: 48px;
+    padding: 6px 8px;
   }
 
   .card.cardCompact .nameWrap span {
@@ -341,18 +341,29 @@
     font-size: clamp(10px, 2.6vw, 12px);
   }
 
+  .card.cardCompact .logoWrap {
+    width: 82%;
+    min-height: 36px;
+    max-height: 52px;
+    padding: 6px 8px;
+  }
+
+  .card.cardCompact .logoWrap img {
+    max-height: 40px;
+  }
+
   .card.cardCompact .ctaButton {
     width: 88%;
-    height: 36px;
-    min-height: 36px;
+    height: 34px;
+    min-height: 34px;
     padding: 0;
-    font-size: 13px;
+    font-size: 12px;
     white-space: nowrap;
   }
 
   .card.cardCompact .comingSoon {
     margin-top: 4px;
-    min-height: 36px;
+    min-height: 34px;
     width: 88%;
     padding: 6px 8px;
     font-size: 12px;

--- a/src/app/components/providerSearch/ProviderCoursesPlaceholder.tsx
+++ b/src/app/components/providerSearch/ProviderCoursesPlaceholder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
 import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
 import { trackProviderCoursesPlaceholderView } from '@/app/utilities/providerSearch/providerSearchGa';
@@ -15,7 +15,13 @@ export default function ProviderCoursesPlaceholder({
   providerSlug,
   providerName,
 }: ProviderCoursesPlaceholderProps) {
+  const trackedSlugRef = useRef<string | null>(null);
+
   useEffect(() => {
+    if (trackedSlugRef.current === providerSlug) {
+      return;
+    }
+    trackedSlugRef.current = providerSlug;
     trackProviderCoursesPlaceholderView(providerSlug);
   }, [providerSlug]);
 

--- a/src/app/components/providerSearch/ProviderCoursesPlaceholder.tsx
+++ b/src/app/components/providerSearch/ProviderCoursesPlaceholder.tsx
@@ -3,9 +3,6 @@
 import { useEffect } from 'react';
 import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
 import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
-import ActionButton from '@/app/components/buttons/ActionButton';
-import { BUTTON_STYLE } from '@/app/utilities/constants';
-import { buildEndorsedLiveDetailHref } from '@/app/utilities/demoAccess';
 import { trackProviderCoursesPlaceholderView } from '@/app/utilities/providerSearch/providerSearchGa';
 import styles from './providerCoursesPlaceholder.module.css';
 
@@ -24,18 +21,28 @@ export default function ProviderCoursesPlaceholder({
 
   return (
     <main className={styles.page}>
-      <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
-        Courses from {providerName}
-      </Typography>
-      <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-        Courses are coming soon. In the meantime, explore this provider&apos;s endorsed profile.
-      </Typography>
-      <ActionButton
-        type='button'
-        label='View provider profile'
-        style={BUTTON_STYLE.Primary}
-        to={buildEndorsedLiveDetailHref(providerSlug)}
-      />
+      <header className={styles.header}>
+        <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
+          Courses from {providerName}
+        </Typography>
+        <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+          Course listings for this provider will appear here.
+        </Typography>
+      </header>
+
+      <section className={styles.courseList} aria-label={`Courses from ${providerName}`}>
+        <div className={styles.emptyCourseCard} role='status'>
+          <Typography
+            variant={TypographyVariant.Body2Strong}
+            color={TypographyColorToken.BondBlack}
+          >
+            No courses listed yet
+          </Typography>
+          <Typography variant={TypographyVariant.Body2} color={TypographyColorToken.BondBlack}>
+            Check back soon for promoted courses from {providerName}.
+          </Typography>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/components/providerSearch/ProviderCoursesPlaceholder.tsx
+++ b/src/app/components/providerSearch/ProviderCoursesPlaceholder.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
+import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
+import ActionButton from '@/app/components/buttons/ActionButton';
+import { BUTTON_STYLE } from '@/app/utilities/constants';
+import { buildEndorsedLiveDetailHref } from '@/app/utilities/demoAccess';
+import { trackProviderCoursesPlaceholderView } from '@/app/utilities/providerSearch/providerSearchGa';
+import styles from './providerCoursesPlaceholder.module.css';
+
+type ProviderCoursesPlaceholderProps = {
+  providerSlug: string;
+  providerName: string;
+};
+
+export default function ProviderCoursesPlaceholder({
+  providerSlug,
+  providerName,
+}: ProviderCoursesPlaceholderProps) {
+  useEffect(() => {
+    trackProviderCoursesPlaceholderView(providerSlug);
+  }, [providerSlug]);
+
+  return (
+    <main className={styles.page}>
+      <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
+        Courses from {providerName}
+      </Typography>
+      <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+        Courses are coming soon. In the meantime, explore this provider&apos;s endorsed profile.
+      </Typography>
+      <ActionButton
+        type='button'
+        label='View provider profile'
+        style={BUTTON_STYLE.Primary}
+        to={buildEndorsedLiveDetailHref(providerSlug)}
+      />
+    </main>
+  );
+}

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -8,9 +8,6 @@ import cardStyles from '@/app/components/institutionProviderCard/institutionProv
 import EndorsedCertifiedBadge from '@/app/components/endorsedProviders/EndorsedCertifiedBadge';
 import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
 import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
-import ActionButton from '@/app/components/buttons/ActionButton';
-import { BUTTON_STYLE } from '@/app/utilities/constants';
-import { EMERGING_PROVIDERS_DIRECTORY_PATH } from '@/app/components/emergingInstitutions/emergingProvidersPaths';
 import {
   buildEndorsedProviderDetailHref,
   resolveEndorsedProviderLogoSrc,
@@ -66,6 +63,89 @@ function resolveHref(
   return buildEmergingProviderDetailHref(provider.slug);
 }
 
+function renderProviderCard(params: {
+  provider: ProviderSearchRecord;
+  tier: ProviderSearchTier;
+  searchDemo: boolean;
+  position: number;
+  filters: ProviderSearchFilters;
+}) {
+  const { provider, tier, searchDemo, position, filters } = params;
+  const href = resolveHref(provider, tier, searchDemo);
+  const logoSrc =
+    provider.kind === 'endorsed'
+      ? resolveEndorsedProviderLogoSrc(
+          provider.slug,
+          provider.logoSrc || '/images/AcademiaLogoLong.png',
+          ENDORSED_PROVIDER_LOGO_BY_SLUG,
+        )
+      : undefined;
+  const logoDimensions = logoSrc ? getLogoDimensions(logoSrc) : null;
+  const emergingState = provider.emergingState as AustralianState | undefined;
+
+  return (
+    <InstitutionProviderCard
+      key={`${tier}-${provider.slug}`}
+      equalWidth
+      ndaCertified={provider.ndaCertified}
+      ctaHref={href}
+      comingSoonLabel={href ? undefined : 'Profile coming soon'}
+      header={
+        provider.kind === 'emerging'
+          ? {
+              kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
+              stateTint: emergingState ?? 'NSW',
+            }
+          : provider.topBackgroundImage
+            ? {
+                kind: INSTITUTION_PROVIDER_HEADER_KIND.REMOTE_IMAGE,
+                src: provider.topBackgroundImage,
+              }
+            : { kind: INSTITUTION_PROVIDER_HEADER_KIND.YELLOW }
+      }
+      badge={
+        provider.kind === 'endorsed' ? (
+          <EndorsedCertifiedBadge size='card' certified={provider.ndaCertified} />
+        ) : undefined
+      }
+      center={
+        provider.kind === 'endorsed' && logoSrc && logoDimensions ? (
+          <Image
+            src={logoSrc}
+            alt={provider.name}
+            width={logoDimensions.width}
+            height={logoDimensions.height}
+            className={classNames(cardStyles.logo)}
+          />
+        ) : (
+          <Typography
+            variant={TypographyVariant.Body2Strong}
+            color={TypographyColorToken.BondBlack}
+          >
+            {provider.name}
+          </Typography>
+        )
+      }
+      gaEvent={
+        href
+          ? {
+              eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
+              category: PROVIDER_SEARCH_GA.resultClick.category,
+              params: {
+                provider_slug: provider.slug,
+                provider_tier: tier,
+                result_position: position,
+                interest_areas: joinGaMultiValue(filters.interestAreas),
+                locations: joinGaMultiValue(filters.locations),
+                destination_url: href,
+              },
+            }
+          : undefined
+      }
+    />
+  );
+}
+
 export default function ProviderSearchResults({
   results,
   filters,
@@ -82,14 +162,8 @@ export default function ProviderSearchResults({
             No providers matched your search
           </Typography>
           <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-            Try a different area of study or location, or explore emerging providers.
+            Try a different area of study or location.
           </Typography>
-          <ActionButton
-            type='button'
-            label='Explore emerging providers'
-            style={BUTTON_STYLE.Secondary}
-            to={EMERGING_PROVIDERS_DIRECTORY_PATH}
-          />
         </div>
       ) : (
         PROVIDER_SEARCH_TIER_ORDER.map((tier) => {
@@ -115,99 +189,18 @@ export default function ProviderSearchResults({
               <div className={styles.cardGrid}>
                 {providers.map((provider) => {
                   globalPosition += 1;
-                  const position = globalPosition;
-                  const href = resolveHref(provider, tier, searchDemo);
-                  const logoSrc =
-                    provider.kind === 'endorsed'
-                      ? resolveEndorsedProviderLogoSrc(
-                          provider.slug,
-                          provider.logoSrc || '/images/AcademiaLogoLong.png',
-                          ENDORSED_PROVIDER_LOGO_BY_SLUG,
-                        )
-                      : undefined;
-                  const logoDimensions = logoSrc ? getLogoDimensions(logoSrc) : null;
-                  const emergingState = provider.emergingState as AustralianState | undefined;
-
-                  return (
-                    <InstitutionProviderCard
-                      key={`${tier}-${provider.slug}`}
-                      equalWidth
-                      ndaCertified={provider.ndaCertified}
-                      ctaHref={href}
-                      comingSoonLabel={href ? undefined : 'Profile coming soon'}
-                      header={
-                        provider.kind === 'emerging'
-                          ? {
-                              kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
-                              stateTint: emergingState ?? 'NSW',
-                            }
-                          : provider.topBackgroundImage
-                            ? {
-                                kind: INSTITUTION_PROVIDER_HEADER_KIND.REMOTE_IMAGE,
-                                src: provider.topBackgroundImage,
-                              }
-                            : { kind: INSTITUTION_PROVIDER_HEADER_KIND.YELLOW }
-                      }
-                      badge={
-                        provider.kind === 'endorsed' ? (
-                          <EndorsedCertifiedBadge size='card' certified={provider.ndaCertified} />
-                        ) : undefined
-                      }
-                      center={
-                        provider.kind === 'endorsed' && logoSrc && logoDimensions ? (
-                          <Image
-                            src={logoSrc}
-                            alt={provider.name}
-                            width={logoDimensions.width}
-                            height={logoDimensions.height}
-                            className={classNames(cardStyles.logo)}
-                          />
-                        ) : (
-                          <Typography
-                            variant={TypographyVariant.Body2Strong}
-                            color={TypographyColorToken.BondBlack}
-                          >
-                            {provider.name}
-                          </Typography>
-                        )
-                      }
-                      gaEvent={
-                        href
-                          ? {
-                              eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
-                              category: PROVIDER_SEARCH_GA.resultClick.category,
-                              params: {
-                                provider_slug: provider.slug,
-                                provider_tier: tier,
-                                result_position: position,
-                                interest_areas: joinGaMultiValue(filters.interestAreas),
-                                locations: joinGaMultiValue(filters.locations),
-                                destination_url: href,
-                              },
-                            }
-                          : undefined
-                      }
-                    />
-                  );
+                  return renderProviderCard({
+                    provider,
+                    tier,
+                    searchDemo,
+                    position: globalPosition,
+                    filters,
+                  });
                 })}
               </div>
             </section>
           );
         })
-      )}
-
-      {totalCount > 0 && results.emerging.length === 0 && (
-        <div className={styles.emergingFallback}>
-          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-            Looking for more options?
-          </Typography>
-          <ActionButton
-            type='button'
-            label='Explore emerging providers'
-            style={BUTTON_STYLE.Secondary}
-            to={EMERGING_PROVIDERS_DIRECTORY_PATH}
-          />
-        </div>
       )}
     </div>
   );

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -165,20 +165,27 @@ function groupPositionedByTier(items: PositionedProviderSearchResult[]) {
 function TierSectionHeader({ tier }: { tier: ProviderSearchTier }) {
   const meta = PROVIDER_SEARCH_TIER_META[tier];
   const isProminent = meta.emphasis === 'endorsed';
+  const eyebrowColor = isProminent
+    ? TypographyColorToken.CherryPie
+    : TypographyColorToken.BondBlackVariant;
+  const titleVariant = isProminent ? TypographyVariant.H2 : TypographyVariant.H3;
+  const titleColor = isProminent
+    ? TypographyColorToken.BondBlack
+    : TypographyColorToken.BondBlackVariant;
 
   return (
     <header className={styles.tierHeader}>
       <Typography
         variant={TypographyVariant.Body3Strong}
-        color={isProminent ? TypographyColorToken.CherryPie : TypographyColorToken.BondBlackVariant}
+        color={eyebrowColor}
         className={styles.tierEyebrow}
       >
         {meta.eyebrow}
       </Typography>
       <Typography
         id={`provider-search-tier-${tier}`}
-        variant={isProminent ? TypographyVariant.H2 : TypographyVariant.H3}
-        color={isProminent ? TypographyColorToken.BondBlack : TypographyColorToken.BondBlackVariant}
+        variant={titleVariant}
+        color={titleColor}
         className={classNames(
           styles.tierHeading,
           isProminent ? styles.tierHeadingProminent : styles.tierHeadingQuiet,
@@ -187,7 +194,7 @@ function TierSectionHeader({ tier }: { tier: ProviderSearchTier }) {
         {PROVIDER_SEARCH_TIER_HEADING[tier]}
       </Typography>
       <div
-        className={classNames(styles.tierRule, !isProminent && styles.tierRuleQuiet)}
+        className={classNames(styles.tierRule, isProminent ? undefined : styles.tierRuleQuiet)}
         aria-hidden='true'
       />
       <Typography

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -16,7 +16,6 @@ import {
 import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
 import { ENDORSED_PROVIDER_LOGO_BY_SLUG } from '@/app/components/endorsedProviders/endorsedProviderBrandAssets';
 import {
-  PROVIDER_SEARCH_GA,
   PROVIDER_SEARCH_TIER_HEADING,
   PROVIDER_SEARCH_TIER_ORDER,
   type ProviderSearchFilters,
@@ -25,7 +24,11 @@ import {
   type ProviderSearchTierResults,
 } from '@/app/utilities/providerSearch/constants';
 import { buildEndorsedCoursesHref } from '@/app/utilities/providerSearch/buildSearchHref';
-import { joinGaMultiValue } from '@/app/utilities/providerSearch/normalize';
+import { buildProviderSearchResultClickAnalytics } from '@/app/utilities/providerSearch/providerSearchGa';
+import {
+  listPositionedProviderSearchResults,
+  type PositionedProviderSearchResult,
+} from '@/app/utilities/providerSearch/searchProviders';
 import type { AustralianState } from '@/app/components/emergingInstitutions/emergingInstitutionTypes';
 import styles from './providerSearchResults.module.css';
 
@@ -57,36 +60,27 @@ function resolveEndorsedHref(
   return buildEndorsedProviderDetailHref(provider.slug, '');
 }
 
-function searchResultGaEvent(params: {
-  provider: ProviderSearchRecord;
-  tier: ProviderSearchTier;
-  position: number;
-  filters: ProviderSearchFilters;
-  destinationUrl: string;
-}) {
-  const { provider, tier, position, filters, destinationUrl } = params;
-  return {
-    eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
-    category: PROVIDER_SEARCH_GA.resultClick.category,
-    params: {
-      provider_slug: provider.slug,
-      provider_tier: tier,
-      result_position: position,
-      interest_areas: joinGaMultiValue(filters.interestAreas),
-      locations: joinGaMultiValue(filters.locations),
-      destination_url: destinationUrl,
-    },
-  };
+function resultClickAnalytics(
+  item: PositionedProviderSearchResult,
+  filters: ProviderSearchFilters,
+  destinationUrl: string,
+) {
+  return buildProviderSearchResultClickAnalytics({
+    providerSlug: item.provider.slug,
+    providerTier: item.tier,
+    resultPosition: item.position,
+    interestAreas: filters.interestAreas,
+    locations: filters.locations,
+    destinationUrl,
+  });
 }
 
-function renderEndorsedCard(params: {
-  provider: ProviderSearchRecord;
-  tier: ProviderSearchTier;
-  searchDemo: boolean;
-  position: number;
-  filters: ProviderSearchFilters;
-}) {
-  const { provider, tier, searchDemo, position, filters } = params;
+function renderEndorsedCard(
+  item: PositionedProviderSearchResult,
+  searchDemo: boolean,
+  filters: ProviderSearchFilters,
+) {
+  const { provider, tier } = item;
   const href = resolveEndorsedHref(provider, tier, searchDemo);
   const logoSrc = resolveEndorsedProviderLogoSrc(
     provider.slug,
@@ -119,60 +113,50 @@ function renderEndorsedCard(params: {
           />
         </div>
       }
-      gaEvent={searchResultGaEvent({
-        provider,
-        tier,
-        position,
-        filters,
-        destinationUrl: href,
-      })}
+      gaEvent={resultClickAnalytics(item, filters, href)}
     />
   );
 }
 
-function renderEmergingCard(params: {
-  provider: ProviderSearchRecord;
-  tier: ProviderSearchTier;
-  position: number;
-  filters: ProviderSearchFilters;
-}) {
-  const { provider, tier, position, filters } = params;
-  const state = (provider.emergingState as AustralianState | undefined) ?? 'NSW';
+function renderEmergingCard(item: PositionedProviderSearchResult, filters: ProviderSearchFilters) {
+  const { provider } = item;
+  const state = provider.emergingState as AustralianState;
   const hasProfile = hasEmergingProviderProfile(provider.slug);
   const destinationUrl = hasProfile ? buildEmergingProviderDetailHref(provider.slug) : undefined;
 
   return (
     <EmergingInstitutionCard
-      key={`${tier}-${provider.slug}`}
+      key={`${item.tier}-${provider.slug}`}
       name={provider.name}
       state={state}
       ctaOpenInNewTab={false}
-      gaEvent={
-        destinationUrl
-          ? searchResultGaEvent({
-              provider,
-              tier,
-              position,
-              filters,
-              destinationUrl,
-            })
-          : undefined
-      }
+      gaEvent={destinationUrl ? resultClickAnalytics(item, filters, destinationUrl) : undefined}
     />
   );
 }
 
-function renderProviderCard(params: {
-  provider: ProviderSearchRecord;
-  tier: ProviderSearchTier;
-  searchDemo: boolean;
-  position: number;
-  filters: ProviderSearchFilters;
-}) {
-  if (params.provider.kind === 'emerging') {
-    return renderEmergingCard(params);
+function renderProviderCard(
+  item: PositionedProviderSearchResult,
+  searchDemo: boolean,
+  filters: ProviderSearchFilters,
+) {
+  if (item.provider.kind === 'emerging') {
+    return renderEmergingCard(item, filters);
   }
-  return renderEndorsedCard(params);
+  return renderEndorsedCard(item, searchDemo, filters);
+}
+
+function groupPositionedByTier(items: PositionedProviderSearchResult[]) {
+  const byTier = new Map<ProviderSearchTier, PositionedProviderSearchResult[]>();
+  for (const item of items) {
+    const bucket = byTier.get(item.tier) ?? [];
+    bucket.push(item);
+    byTier.set(item.tier, bucket);
+  }
+  return PROVIDER_SEARCH_TIER_ORDER.filter((tier) => byTier.has(tier)).map((tier) => ({
+    tier,
+    items: byTier.get(tier) ?? [],
+  }));
 }
 
 export default function ProviderSearchResults({
@@ -181,7 +165,8 @@ export default function ProviderSearchResults({
   searchDemo,
   totalCount,
 }: ProviderSearchResultsProps) {
-  let globalPosition = 0;
+  const positioned = listPositionedProviderSearchResults(results);
+  const tierGroups = groupPositionedByTier(positioned);
 
   return (
     <div className={styles.root}>
@@ -195,41 +180,25 @@ export default function ProviderSearchResults({
           </Typography>
         </div>
       ) : (
-        PROVIDER_SEARCH_TIER_ORDER.map((tier) => {
-          const providers = results[tier];
-          if (providers.length === 0) {
-            return null;
-          }
-
-          return (
-            <section
-              key={tier}
-              className={styles.tierSection}
-              aria-labelledby={`provider-search-tier-${tier}`}
+        tierGroups.map(({ tier, items }) => (
+          <section
+            key={tier}
+            className={styles.tierSection}
+            aria-labelledby={`provider-search-tier-${tier}`}
+          >
+            <Typography
+              id={`provider-search-tier-${tier}`}
+              variant={TypographyVariant.H2}
+              color={TypographyColorToken.BondBlack}
+              className={styles.tierHeading}
             >
-              <Typography
-                id={`provider-search-tier-${tier}`}
-                variant={TypographyVariant.H2}
-                color={TypographyColorToken.BondBlack}
-                className={styles.tierHeading}
-              >
-                {PROVIDER_SEARCH_TIER_HEADING[tier]}
-              </Typography>
-              <div className={styles.cardGrid}>
-                {providers.map((provider) => {
-                  globalPosition += 1;
-                  return renderProviderCard({
-                    provider,
-                    tier,
-                    searchDemo,
-                    position: globalPosition,
-                    filters,
-                  });
-                })}
-              </div>
-            </section>
-          );
-        })
+              {PROVIDER_SEARCH_TIER_HEADING[tier]}
+            </Typography>
+            <div className={styles.cardGrid}>
+              {items.map((item) => renderProviderCard(item, searchDemo, filters))}
+            </div>
+          </section>
+        ))
       )}
     </div>
   );

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image, { type StaticImageData } from 'next/image';
+import classNames from 'classnames';
 import InstitutionProviderCard from '@/app/components/institutionProviderCard/InstitutionProviderCard';
 import { INSTITUTION_PROVIDER_HEADER_KIND } from '@/app/components/institutionProviderCard/institutionProviderHeader';
 import cardStyles from '@/app/components/institutionProviderCard/institutionProviderCard.module.css';
@@ -17,6 +18,7 @@ import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergin
 import { ENDORSED_PROVIDER_LOGO_BY_SLUG } from '@/app/components/endorsedProviders/endorsedProviderBrandAssets';
 import {
   PROVIDER_SEARCH_TIER_HEADING,
+  PROVIDER_SEARCH_TIER_META,
   PROVIDER_SEARCH_TIER_ORDER,
   type ProviderSearchFilters,
   type ProviderSearchRecord,
@@ -160,6 +162,45 @@ function groupPositionedByTier(items: PositionedProviderSearchResult[]) {
   }));
 }
 
+function TierSectionHeader({ tier }: { tier: ProviderSearchTier }) {
+  const meta = PROVIDER_SEARCH_TIER_META[tier];
+  const isProminent = meta.emphasis === 'endorsed';
+
+  return (
+    <header className={styles.tierHeader}>
+      <Typography
+        variant={TypographyVariant.Body3Strong}
+        color={isProminent ? TypographyColorToken.CherryPie : TypographyColorToken.BondBlackVariant}
+        className={styles.tierEyebrow}
+      >
+        {meta.eyebrow}
+      </Typography>
+      <Typography
+        id={`provider-search-tier-${tier}`}
+        variant={isProminent ? TypographyVariant.H2 : TypographyVariant.H3}
+        color={isProminent ? TypographyColorToken.BondBlack : TypographyColorToken.BondBlackVariant}
+        className={classNames(
+          styles.tierHeading,
+          isProminent ? styles.tierHeadingProminent : styles.tierHeadingQuiet,
+        )}
+      >
+        {PROVIDER_SEARCH_TIER_HEADING[tier]}
+      </Typography>
+      <div
+        className={classNames(styles.tierRule, !isProminent && styles.tierRuleQuiet)}
+        aria-hidden='true'
+      />
+      <Typography
+        variant={TypographyVariant.Body2}
+        color={TypographyColorToken.BondBlackVariant}
+        className={styles.tierSubtitle}
+      >
+        {meta.subtitle}
+      </Typography>
+    </header>
+  );
+}
+
 export default function ProviderSearchResults({
   results,
   filters,
@@ -181,25 +222,26 @@ export default function ProviderSearchResults({
           </Typography>
         </div>
       ) : (
-        tierGroups.map(({ tier, items }) => (
-          <section
-            key={tier}
-            className={styles.tierSection}
-            aria-labelledby={`provider-search-tier-${tier}`}
-          >
-            <Typography
-              id={`provider-search-tier-${tier}`}
-              variant={TypographyVariant.H2}
-              color={TypographyColorToken.BondBlack}
-              className={styles.tierHeading}
+        tierGroups.map(({ tier, items }) => {
+          const isProminent = PROVIDER_SEARCH_TIER_META[tier].emphasis === 'endorsed';
+          return (
+            <section
+              key={tier}
+              className={classNames(
+                styles.tierSection,
+                isProminent ? styles.tierSectionProminent : styles.tierSectionQuiet,
+              )}
+              aria-labelledby={`provider-search-tier-${tier}`}
             >
-              {PROVIDER_SEARCH_TIER_HEADING[tier]}
-            </Typography>
-            <div className={styles.cardGrid}>
-              {items.map((item) => renderProviderCard(item, searchDemo, filters))}
-            </div>
-          </section>
-        ))
+              <div className={styles.tierInner}>
+                <TierSectionHeader tier={tier} />
+                <div className={styles.cardGrid}>
+                  {items.map((item) => renderProviderCard(item, searchDemo, filters))}
+                </div>
+              </div>
+            </section>
+          );
+        })
       )}
     </div>
   );

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -100,7 +100,6 @@ function renderEndorsedCard(params: {
       key={`${tier}-${provider.slug}`}
       ndaCertified={provider.ndaCertified}
       ctaHref={href}
-      compact
       header={
         provider.topBackgroundImage
           ? {

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -94,6 +94,7 @@ function renderEndorsedCard(
       key={`${tier}-${provider.slug}`}
       ndaCertified={provider.ndaCertified}
       ctaHref={href}
+      compact
       header={
         provider.topBackgroundImage
           ? {

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import Image, { type StaticImageData } from 'next/image';
+import classNames from 'classnames';
+import InstitutionProviderCard from '@/app/components/institutionProviderCard/InstitutionProviderCard';
+import { INSTITUTION_PROVIDER_HEADER_KIND } from '@/app/components/institutionProviderCard/institutionProviderHeader';
+import cardStyles from '@/app/components/institutionProviderCard/institutionProviderCard.module.css';
+import EndorsedCertifiedBadge from '@/app/components/endorsedProviders/EndorsedCertifiedBadge';
+import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
+import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
+import ActionButton from '@/app/components/buttons/ActionButton';
+import { BUTTON_STYLE } from '@/app/utilities/constants';
+import { EMERGING_PROVIDERS_DIRECTORY_PATH } from '@/app/components/emergingInstitutions/emergingProvidersPaths';
+import {
+  buildEndorsedProviderDetailHref,
+  resolveEndorsedProviderLogoSrc,
+} from '@/app/utilities/endorsedProvidersDemo';
+import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
+import { hasEmergingProviderProfile } from '@/app/components/emergingInstitutions/emergingProviderProfileSlugs';
+import { ENDORSED_PROVIDER_LOGO_BY_SLUG } from '@/app/components/endorsedProviders/endorsedProviderBrandAssets';
+import {
+  PROVIDER_SEARCH_GA,
+  PROVIDER_SEARCH_TIER_HEADING,
+  PROVIDER_SEARCH_TIER_ORDER,
+  type ProviderSearchFilters,
+  type ProviderSearchRecord,
+  type ProviderSearchTier,
+  type ProviderSearchTierResults,
+} from '@/app/utilities/providerSearch/constants';
+import { buildEndorsedCoursesHref } from '@/app/utilities/providerSearch/buildSearchHref';
+import { joinGaMultiValue } from '@/app/utilities/providerSearch/normalize';
+import type { AustralianState } from '@/app/components/emergingInstitutions/emergingInstitutionTypes';
+import styles from './providerSearchResults.module.css';
+
+const FALLBACK_LOGO_WIDTH = 921;
+const FALLBACK_LOGO_HEIGHT = 271;
+
+type ProviderSearchResultsProps = {
+  results: ProviderSearchTierResults;
+  filters: ProviderSearchFilters;
+  searchDemo: boolean;
+  totalCount: number;
+};
+
+function getLogoDimensions(logoSrc: string | StaticImageData): { width: number; height: number } {
+  if (typeof logoSrc === 'string') {
+    return { width: FALLBACK_LOGO_WIDTH, height: FALLBACK_LOGO_HEIGHT };
+  }
+  return { width: logoSrc.width, height: logoSrc.height };
+}
+
+function resolveHref(
+  provider: ProviderSearchRecord,
+  tier: ProviderSearchTier,
+  searchDemo: boolean,
+): string | undefined {
+  if (provider.kind === 'endorsed') {
+    if (tier === 'course_endorsed') {
+      return buildEndorsedCoursesHref(provider.slug, { searchDemo });
+    }
+    return buildEndorsedProviderDetailHref(provider.slug, '');
+  }
+  if (!hasEmergingProviderProfile(provider.slug)) {
+    return undefined;
+  }
+  return buildEmergingProviderDetailHref(provider.slug);
+}
+
+export default function ProviderSearchResults({
+  results,
+  filters,
+  searchDemo,
+  totalCount,
+}: ProviderSearchResultsProps) {
+  let globalPosition = 0;
+
+  return (
+    <div className={styles.root}>
+      {totalCount === 0 ? (
+        <div className={styles.emptyState} role='status'>
+          <Typography variant={TypographyVariant.H2} color={TypographyColorToken.BondBlack}>
+            No providers matched your search
+          </Typography>
+          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+            Try a different area of study or location, or explore emerging providers.
+          </Typography>
+          <ActionButton
+            type='button'
+            label='Explore emerging providers'
+            style={BUTTON_STYLE.Secondary}
+            to={EMERGING_PROVIDERS_DIRECTORY_PATH}
+          />
+        </div>
+      ) : (
+        PROVIDER_SEARCH_TIER_ORDER.map((tier) => {
+          const providers = results[tier];
+          if (providers.length === 0) {
+            return null;
+          }
+
+          return (
+            <section
+              key={tier}
+              className={styles.tierSection}
+              aria-labelledby={`provider-search-tier-${tier}`}
+            >
+              <Typography
+                id={`provider-search-tier-${tier}`}
+                variant={TypographyVariant.H2}
+                color={TypographyColorToken.BondBlack}
+                className={styles.tierHeading}
+              >
+                {PROVIDER_SEARCH_TIER_HEADING[tier]}
+              </Typography>
+              <div className={styles.cardGrid}>
+                {providers.map((provider) => {
+                  globalPosition += 1;
+                  const position = globalPosition;
+                  const href = resolveHref(provider, tier, searchDemo);
+                  const logoSrc =
+                    provider.kind === 'endorsed'
+                      ? resolveEndorsedProviderLogoSrc(
+                          provider.slug,
+                          provider.logoSrc || '/images/AcademiaLogoLong.png',
+                          ENDORSED_PROVIDER_LOGO_BY_SLUG,
+                        )
+                      : undefined;
+                  const logoDimensions = logoSrc ? getLogoDimensions(logoSrc) : null;
+                  const emergingState = provider.emergingState as AustralianState | undefined;
+
+                  return (
+                    <InstitutionProviderCard
+                      key={`${tier}-${provider.slug}`}
+                      equalWidth
+                      ndaCertified={provider.ndaCertified}
+                      ctaHref={href}
+                      comingSoonLabel={href ? undefined : 'Profile coming soon'}
+                      header={
+                        provider.kind === 'emerging'
+                          ? {
+                              kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
+                              stateTint: emergingState ?? 'NSW',
+                            }
+                          : provider.topBackgroundImage
+                            ? {
+                                kind: INSTITUTION_PROVIDER_HEADER_KIND.REMOTE_IMAGE,
+                                src: provider.topBackgroundImage,
+                              }
+                            : { kind: INSTITUTION_PROVIDER_HEADER_KIND.YELLOW }
+                      }
+                      badge={
+                        provider.kind === 'endorsed' ? (
+                          <EndorsedCertifiedBadge size='card' certified={provider.ndaCertified} />
+                        ) : undefined
+                      }
+                      center={
+                        provider.kind === 'endorsed' && logoSrc && logoDimensions ? (
+                          <Image
+                            src={logoSrc}
+                            alt={provider.name}
+                            width={logoDimensions.width}
+                            height={logoDimensions.height}
+                            className={classNames(cardStyles.logo)}
+                          />
+                        ) : (
+                          <Typography
+                            variant={TypographyVariant.Body2Strong}
+                            color={TypographyColorToken.BondBlack}
+                          >
+                            {provider.name}
+                          </Typography>
+                        )
+                      }
+                      gaEvent={
+                        href
+                          ? {
+                              eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
+                              category: PROVIDER_SEARCH_GA.resultClick.category,
+                              params: {
+                                provider_slug: provider.slug,
+                                provider_tier: tier,
+                                result_position: position,
+                                interest_areas: joinGaMultiValue(filters.interestAreas),
+                                locations: joinGaMultiValue(filters.locations),
+                                destination_url: href,
+                              },
+                            }
+                          : undefined
+                      }
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })
+      )}
+
+      {totalCount > 0 && results.emerging.length === 0 && (
+        <div className={styles.emergingFallback}>
+          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+            Looking for more options?
+          </Typography>
+          <ActionButton
+            type='button'
+            label='Explore emerging providers'
+            style={BUTTON_STYLE.Secondary}
+            to={EMERGING_PROVIDERS_DIRECTORY_PATH}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -4,6 +4,8 @@ import Image, { type StaticImageData } from 'next/image';
 import InstitutionProviderCard from '@/app/components/institutionProviderCard/InstitutionProviderCard';
 import { INSTITUTION_PROVIDER_HEADER_KIND } from '@/app/components/institutionProviderCard/institutionProviderHeader';
 import cardStyles from '@/app/components/institutionProviderCard/institutionProviderCard.module.css';
+import EmergingInstitutionCard from '@/app/components/emergingInstitutions/EmergingInstitutionCard';
+import { hasEmergingProviderProfile } from '@/app/components/emergingInstitutions/emergingProviderProfileSlugs';
 import EndorsedCertifiedBadge from '@/app/components/endorsedProviders/EndorsedCertifiedBadge';
 import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
 import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
@@ -12,7 +14,6 @@ import {
   resolveEndorsedProviderLogoSrc,
 } from '@/app/utilities/endorsedProvidersDemo';
 import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
-import { hasEmergingProviderProfile } from '@/app/components/emergingInstitutions/emergingProviderProfileSlugs';
 import { ENDORSED_PROVIDER_LOGO_BY_SLUG } from '@/app/components/endorsedProviders/endorsedProviderBrandAssets';
 import {
   PROVIDER_SEARCH_GA,
@@ -45,21 +46,121 @@ function getLogoDimensions(logoSrc: string | StaticImageData): { width: number; 
   return { width: logoSrc.width, height: logoSrc.height };
 }
 
-function resolveHref(
+function resolveEndorsedHref(
   provider: ProviderSearchRecord,
   tier: ProviderSearchTier,
   searchDemo: boolean,
-): string | undefined {
-  if (provider.kind === 'endorsed') {
-    if (tier === 'course_endorsed') {
-      return buildEndorsedCoursesHref(provider.slug, { searchDemo });
-    }
-    return buildEndorsedProviderDetailHref(provider.slug, '');
+): string {
+  if (tier === 'course_endorsed') {
+    return buildEndorsedCoursesHref(provider.slug, { searchDemo });
   }
-  if (!hasEmergingProviderProfile(provider.slug)) {
-    return undefined;
-  }
-  return buildEmergingProviderDetailHref(provider.slug);
+  return buildEndorsedProviderDetailHref(provider.slug, '');
+}
+
+function searchResultGaEvent(params: {
+  provider: ProviderSearchRecord;
+  tier: ProviderSearchTier;
+  position: number;
+  filters: ProviderSearchFilters;
+  destinationUrl: string;
+}) {
+  const { provider, tier, position, filters, destinationUrl } = params;
+  return {
+    eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
+    category: PROVIDER_SEARCH_GA.resultClick.category,
+    params: {
+      provider_slug: provider.slug,
+      provider_tier: tier,
+      result_position: position,
+      interest_areas: joinGaMultiValue(filters.interestAreas),
+      locations: joinGaMultiValue(filters.locations),
+      destination_url: destinationUrl,
+    },
+  };
+}
+
+function renderEndorsedCard(params: {
+  provider: ProviderSearchRecord;
+  tier: ProviderSearchTier;
+  searchDemo: boolean;
+  position: number;
+  filters: ProviderSearchFilters;
+}) {
+  const { provider, tier, searchDemo, position, filters } = params;
+  const href = resolveEndorsedHref(provider, tier, searchDemo);
+  const logoSrc = resolveEndorsedProviderLogoSrc(
+    provider.slug,
+    provider.logoSrc || '/images/AcademiaLogoLong.png',
+    ENDORSED_PROVIDER_LOGO_BY_SLUG,
+  );
+  const logoDimensions = getLogoDimensions(logoSrc);
+
+  return (
+    <InstitutionProviderCard
+      key={`${tier}-${provider.slug}`}
+      ndaCertified={provider.ndaCertified}
+      ctaHref={href}
+      compact
+      header={
+        provider.topBackgroundImage
+          ? {
+              kind: INSTITUTION_PROVIDER_HEADER_KIND.REMOTE_IMAGE,
+              src: provider.topBackgroundImage,
+            }
+          : { kind: INSTITUTION_PROVIDER_HEADER_KIND.YELLOW }
+      }
+      badge={<EndorsedCertifiedBadge size='card' certified={provider.ndaCertified} />}
+      center={
+        <div className={cardStyles.logoWrap}>
+          <Image
+            src={logoSrc}
+            alt={`${provider.name} logo`}
+            width={logoDimensions.width}
+            height={logoDimensions.height}
+          />
+        </div>
+      }
+      gaEvent={searchResultGaEvent({
+        provider,
+        tier,
+        position,
+        filters,
+        destinationUrl: href,
+      })}
+    />
+  );
+}
+
+function renderEmergingCard(params: {
+  provider: ProviderSearchRecord;
+  tier: ProviderSearchTier;
+  position: number;
+  filters: ProviderSearchFilters;
+}) {
+  const { provider, tier, position, filters } = params;
+  const state = (provider.emergingState as AustralianState | undefined) ?? 'NSW';
+  const hasProfile = hasEmergingProviderProfile(provider.slug);
+  const destinationUrl = hasProfile ? buildEmergingProviderDetailHref(provider.slug) : undefined;
+
+  return (
+    <EmergingInstitutionCard
+      key={`${tier}-${provider.slug}`}
+      name={provider.name}
+      state={state}
+      ctaOpenInNewTab={false}
+      gaEvent={
+        destinationUrl
+          ? searchResultGaEvent({
+              provider,
+              tier,
+              position,
+              filters,
+              destinationUrl,
+            })
+          : undefined
+      }
+    />
+  );
 }
 
 function renderProviderCard(params: {
@@ -69,80 +170,10 @@ function renderProviderCard(params: {
   position: number;
   filters: ProviderSearchFilters;
 }) {
-  const { provider, tier, searchDemo, position, filters } = params;
-  const href = resolveHref(provider, tier, searchDemo);
-  const logoSrc =
-    provider.kind === 'endorsed'
-      ? resolveEndorsedProviderLogoSrc(
-          provider.slug,
-          provider.logoSrc || '/images/AcademiaLogoLong.png',
-          ENDORSED_PROVIDER_LOGO_BY_SLUG,
-        )
-      : undefined;
-  const logoDimensions = logoSrc ? getLogoDimensions(logoSrc) : null;
-  const emergingState = provider.emergingState as AustralianState | undefined;
-
-  return (
-    <InstitutionProviderCard
-      key={`${tier}-${provider.slug}`}
-      ndaCertified={provider.ndaCertified}
-      ctaHref={href}
-      comingSoonLabel={href ? undefined : 'Profile coming soon'}
-      header={
-        provider.kind === 'emerging'
-          ? {
-              kind: INSTITUTION_PROVIDER_HEADER_KIND.EMERGING_DEFAULT,
-              stateTint: emergingState ?? 'NSW',
-            }
-          : provider.topBackgroundImage
-            ? {
-                kind: INSTITUTION_PROVIDER_HEADER_KIND.REMOTE_IMAGE,
-                src: provider.topBackgroundImage,
-              }
-            : { kind: INSTITUTION_PROVIDER_HEADER_KIND.YELLOW }
-      }
-      badge={
-        provider.kind === 'endorsed' ? (
-          <EndorsedCertifiedBadge size='card' certified={provider.ndaCertified} />
-        ) : undefined
-      }
-      center={
-        provider.kind === 'endorsed' && logoSrc && logoDimensions ? (
-          <div className={cardStyles.logoWrap}>
-            <Image
-              src={logoSrc}
-              alt={`${provider.name} logo`}
-              width={logoDimensions.width}
-              height={logoDimensions.height}
-            />
-          </div>
-        ) : (
-          <Typography
-            variant={TypographyVariant.Body2Strong}
-            color={TypographyColorToken.BondBlack}
-          >
-            {provider.name}
-          </Typography>
-        )
-      }
-      gaEvent={
-        href
-          ? {
-              eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
-              category: PROVIDER_SEARCH_GA.resultClick.category,
-              params: {
-                provider_slug: provider.slug,
-                provider_tier: tier,
-                result_position: position,
-                interest_areas: joinGaMultiValue(filters.interestAreas),
-                locations: joinGaMultiValue(filters.locations),
-                destination_url: href,
-              },
-            }
-          : undefined
-      }
-    />
-  );
+  if (params.provider.kind === 'emerging') {
+    return renderEmergingCard(params);
+  }
+  return renderEndorsedCard(params);
 }
 
 export default function ProviderSearchResults({

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image, { type StaticImageData } from 'next/image';
-import classNames from 'classnames';
 import InstitutionProviderCard from '@/app/components/institutionProviderCard/InstitutionProviderCard';
 import { INSTITUTION_PROVIDER_HEADER_KIND } from '@/app/components/institutionProviderCard/institutionProviderHeader';
 import cardStyles from '@/app/components/institutionProviderCard/institutionProviderCard.module.css';
@@ -86,7 +85,6 @@ function renderProviderCard(params: {
   return (
     <InstitutionProviderCard
       key={`${tier}-${provider.slug}`}
-      equalWidth
       ndaCertified={provider.ndaCertified}
       ctaHref={href}
       comingSoonLabel={href ? undefined : 'Profile coming soon'}
@@ -110,13 +108,14 @@ function renderProviderCard(params: {
       }
       center={
         provider.kind === 'endorsed' && logoSrc && logoDimensions ? (
-          <Image
-            src={logoSrc}
-            alt={provider.name}
-            width={logoDimensions.width}
-            height={logoDimensions.height}
-            className={classNames(cardStyles.logo)}
-          />
+          <div className={cardStyles.logoWrap}>
+            <Image
+              src={logoSrc}
+              alt={`${provider.name} logo`}
+              width={logoDimensions.width}
+              height={logoDimensions.height}
+            />
+          </div>
         ) : (
           <Typography
             variant={TypographyVariant.Body2Strong}

--- a/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
@@ -30,10 +30,10 @@ export default function ProviderSearchResultsTracker({
   const lastKeyRef = useRef<string>('');
 
   useEffect(() => {
-    const key = queryKey({ interestAreas, locations });
-    if (key === '' || key === '::') {
+    if (interestAreas.length === 0 && locations.length === 0) {
       return;
     }
+    const key = queryKey({ interestAreas, locations });
     if (lastKeyRef.current === key) {
       return;
     }

--- a/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { ProviderSearchFilters } from '@/app/utilities/providerSearch/constants';
+import { trackProviderSearchResultsView } from '@/app/utilities/providerSearch/providerSearchGa';
+
+type ProviderSearchResultsTrackerProps = {
+  interestAreas: string[];
+  locations: string[];
+  resultCountTotal: number;
+  countCourseEndorsed: number;
+  countStarredEndorsed: number;
+  countEndorsed: number;
+  countEmerging: number;
+};
+
+function queryKey(filters: ProviderSearchFilters): string {
+  return `${filters.interestAreas.join('|')}::${filters.locations.join('|')}`;
+}
+
+export default function ProviderSearchResultsTracker({
+  interestAreas,
+  locations,
+  resultCountTotal,
+  countCourseEndorsed,
+  countStarredEndorsed,
+  countEndorsed,
+  countEmerging,
+}: ProviderSearchResultsTrackerProps) {
+  const lastKeyRef = useRef<string>('');
+
+  useEffect(() => {
+    const key = queryKey({ interestAreas, locations });
+    if (key === '' || key === '::') {
+      return;
+    }
+    if (lastKeyRef.current === key) {
+      return;
+    }
+    lastKeyRef.current = key;
+    trackProviderSearchResultsView({
+      interestAreas,
+      locations,
+      resultCountTotal,
+      countCourseEndorsed,
+      countStarredEndorsed,
+      countEndorsed,
+      countEmerging,
+      hasResults: resultCountTotal > 0,
+    });
+  }, [
+    interestAreas,
+    locations,
+    resultCountTotal,
+    countCourseEndorsed,
+    countStarredEndorsed,
+    countEndorsed,
+    countEmerging,
+  ]);
+
+  return null;
+}

--- a/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
@@ -30,9 +30,6 @@ export default function ProviderSearchResultsTracker({
   const lastKeyRef = useRef<string>('');
 
   useEffect(() => {
-    if (interestAreas.length === 0 && locations.length === 0) {
-      return;
-    }
     const key = queryKey({ interestAreas, locations });
     if (lastKeyRef.current === key) {
       return;

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -107,6 +107,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
             label='Search'
             icon={searchSrc}
             disabled={!canSearch}
+            className={compact ? styles.compactSearchButton : undefined}
           />
         </div>
       </div>

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { FormHTMLAttributes } from 'react';
+import { FormHTMLAttributes, useState } from 'react';
 import classNames from 'classnames';
-import { useForm, useWatch, type UseFormReturn } from 'react-hook-form';
+import { useForm, type UseFormReturn } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import Form from '@/app/components/formElements/Form';
 import Dropdown from '@/app/components/formElements/Dropdown/Dropdown';
@@ -15,7 +15,7 @@ import {
 } from '@/app/utilities/providerSearch/constants';
 import { buildProviderSearchHref } from '@/app/utilities/providerSearch/buildSearchHref';
 import { trackProviderSearchSubmit } from '@/app/utilities/providerSearch/providerSearchGa';
-import { uniqueSortedStrings } from '@/app/utilities/providerSearch/normalize';
+import { mergeSearchTokens, uniqueSortedStrings } from '@/app/utilities/providerSearch/normalize';
 import styles from './providerStudySearch.module.css';
 
 export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
@@ -51,6 +51,8 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
   ...rest
 }) => {
   const router = useRouter();
+  const [areaDraft, setAreaDraft] = useState('');
+  const [locationDraft, setLocationDraft] = useState('');
   const methods: UseFormReturn<ProviderStudySearchFormValues> =
     useForm<ProviderStudySearchFormValues>({
       mode: 'onChange',
@@ -60,20 +62,14 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
       },
     });
 
-  const watchedValues = useWatch({ control: methods.control });
-  const { interestAreas: selectedAreas, locations: selectedLocations } =
-    normalizeFormValues(watchedValues);
-  const canSearch = selectedAreas.length > 0 || selectedLocations.length > 0;
-
   return (
     <Form
       methods={methods}
       className={classNames(styles.container, compact && styles.compact, className)}
       onSubmit={methods.handleSubmit((values) => {
-        const { interestAreas, locations } = normalizeFormValues(values);
-        if (interestAreas.length === 0 && locations.length === 0) {
-          return;
-        }
+        const selected = normalizeFormValues(values);
+        const interestAreas = mergeSearchTokens(selected.interestAreas, areaDraft);
+        const locations = mergeSearchTokens(selected.locations, locationDraft);
         trackProviderSearchSubmit({ surface, interestAreas, locations });
         router.push(buildProviderSearchHref({ interestAreas, locations }, { searchDemo }));
       })}
@@ -89,7 +85,9 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           placeholder={compact ? 'What do you want to study?' : 'Ex. Nursing or digital'}
           multiple
           creatable
+          pillsBelow
           options={interestAreaOptions}
+          onDraftChange={setAreaDraft}
         />
         <Dropdown<ProviderStudySearchFormValues>
           name='Location'
@@ -98,7 +96,9 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           placeholder={compact ? 'Where do you want to study?' : 'Ex. Sydney'}
           multiple
           creatable
+          pillsBelow
           options={locationOptions}
+          onDraftChange={setLocationDraft}
         />
         <div className={styles.buttonContainer}>
           <ActionButton
@@ -106,7 +106,6 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
             style={BUTTON_STYLE.Primary}
             label='Search'
             icon={searchSrc}
-            disabled={!canSearch}
             className={compact ? styles.compactSearchButton : undefined}
           />
         </div>

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { FormHTMLAttributes, useMemo } from 'react';
+import classNames from 'classnames';
+import { useForm, useWatch, type UseFormReturn } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+import Form from '@/app/components/formElements/Form';
+import Dropdown from '@/app/components/formElements/Dropdown/Dropdown';
+import ActionButton from '@/app/components/buttons/ActionButton';
+import searchSrc from '@/app/images/Search.svg';
+import { BUTTON_STYLE } from '@/app/utilities/constants';
+import {
+  type ProviderSearchSurface,
+  type ProviderStudySearchFormValues,
+} from '@/app/utilities/providerSearch/constants';
+import { buildProviderSearchHref } from '@/app/utilities/providerSearch/buildSearchHref';
+import { trackProviderSearchSubmit } from '@/app/utilities/providerSearch/providerSearchGa';
+import { uniqueSortedStrings } from '@/app/utilities/providerSearch/normalize';
+import styles from './providerStudySearch.module.css';
+
+export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
+  interestAreaOptions: { label: string; value: string }[];
+  locationOptions: { label: string; value: string }[];
+  defaultInterestAreas?: string[];
+  defaultLocations?: string[];
+  surface: ProviderSearchSurface;
+  searchDemo?: boolean;
+};
+
+const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
+  className,
+  interestAreaOptions,
+  locationOptions,
+  defaultInterestAreas = [],
+  defaultLocations = [],
+  surface,
+  searchDemo = false,
+  ...rest
+}) => {
+  const router = useRouter();
+  const methods: UseFormReturn<ProviderStudySearchFormValues> =
+    useForm<ProviderStudySearchFormValues>({
+      mode: 'onChange',
+      defaultValues: {
+        InterestArea: defaultInterestAreas,
+        Location: defaultLocations,
+      },
+    });
+
+  const watchedValues = useWatch({ control: methods.control });
+  const selectedAreas = useMemo(
+    () => uniqueSortedStrings(watchedValues.InterestArea ?? []),
+    [watchedValues.InterestArea],
+  );
+  const selectedLocations = useMemo(
+    () => uniqueSortedStrings(watchedValues.Location ?? []),
+    [watchedValues.Location],
+  );
+  const canSearch = selectedAreas.length > 0 || selectedLocations.length > 0;
+
+  return (
+    <Form
+      methods={methods}
+      className={classNames(styles.container, className)}
+      onSubmit={methods.handleSubmit((values) => {
+        const interestAreas = uniqueSortedStrings(values.InterestArea ?? []);
+        const locations = uniqueSortedStrings(values.Location ?? []);
+        if (interestAreas.length === 0 && locations.length === 0) {
+          return;
+        }
+        trackProviderSearchSubmit({
+          surface,
+          interestAreas,
+          locations,
+        });
+        router.push(
+          buildProviderSearchHref(
+            { interestAreas, locations },
+            { searchDemo },
+          ),
+        );
+      })}
+      aria-label='Search providers by area of study and location'
+      role='search'
+      {...rest}
+    >
+      <div className={styles.content}>
+        <Dropdown<ProviderStudySearchFormValues>
+          name='InterestArea'
+          label='What do you want to study?'
+          showLabel
+          placeholder='Ex. Nursing'
+          multiple
+          options={interestAreaOptions}
+        />
+        <Dropdown<ProviderStudySearchFormValues>
+          name='Location'
+          label='Where do you want to study?'
+          showLabel
+          placeholder='Ex. Sydney'
+          multiple
+          options={locationOptions}
+        />
+        <div className={styles.buttonContainer}>
+          <ActionButton
+            type='submit'
+            style={BUTTON_STYLE.Primary}
+            label='Search'
+            icon={searchSrc}
+            disabled={!canSearch}
+          />
+        </div>
+      </div>
+    </Form>
+  );
+};
+
+export default ProviderStudySearch;

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -29,7 +29,10 @@ export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
 };
 
 function asSelectedList(value: unknown): string[] {
-  return Array.isArray(value) ? uniqueSortedStrings(value) : [];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return uniqueSortedStrings(value);
 }
 
 function normalizeFormValues(values: Partial<ProviderStudySearchFormValues>) {
@@ -37,6 +40,41 @@ function normalizeFormValues(values: Partial<ProviderStudySearchFormValues>) {
     interestAreas: asSelectedList(values.InterestArea),
     locations: asSelectedList(values.Location),
   };
+}
+
+function interestPlaceholder(compact: boolean): string {
+  if (compact) {
+    return 'What do you want to study?';
+  }
+  return 'Ex. Nursing or digital';
+}
+
+function locationPlaceholder(compact: boolean): string {
+  if (compact) {
+    return 'Where do you want to study?';
+  }
+  return 'Ex. Sydney';
+}
+
+function submitProviderSearch(params: {
+  values: Partial<ProviderStudySearchFormValues>;
+  areaDraft: string;
+  locationDraft: string;
+  surface: ProviderSearchSurface;
+  searchDemo: boolean;
+  push: (href: string) => void;
+}): void {
+  const selected = normalizeFormValues(params.values);
+  const interestAreas = mergeSearchTokens(selected.interestAreas, params.areaDraft);
+  const locations = mergeSearchTokens(selected.locations, params.locationDraft);
+  trackProviderSearchSubmit({
+    surface: params.surface,
+    interestAreas,
+    locations,
+  });
+  params.push(
+    buildProviderSearchHref({ interestAreas, locations }, { searchDemo: params.searchDemo }),
+  );
 }
 
 const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
@@ -65,13 +103,16 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
   return (
     <Form
       methods={methods}
-      className={classNames(styles.container, compact && styles.compact, className)}
+      className={classNames(styles.container, compact ? styles.compact : undefined, className)}
       onSubmit={methods.handleSubmit((values) => {
-        const selected = normalizeFormValues(values);
-        const interestAreas = mergeSearchTokens(selected.interestAreas, areaDraft);
-        const locations = mergeSearchTokens(selected.locations, locationDraft);
-        trackProviderSearchSubmit({ surface, interestAreas, locations });
-        router.push(buildProviderSearchHref({ interestAreas, locations }, { searchDemo }));
+        submitProviderSearch({
+          values,
+          areaDraft,
+          locationDraft,
+          surface,
+          searchDemo,
+          push: router.push,
+        });
       })}
       aria-label='Search providers by area of study and location'
       role='search'
@@ -82,7 +123,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           name='InterestArea'
           label='What do you want to study?'
           showLabel={!compact}
-          placeholder={compact ? 'What do you want to study?' : 'Ex. Nursing or digital'}
+          placeholder={interestPlaceholder(compact)}
           multiple
           creatable
           pillsBelow
@@ -93,7 +134,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           name='Location'
           label='Where do you want to study?'
           showLabel={!compact}
-          placeholder={compact ? 'Where do you want to study?' : 'Ex. Sydney'}
+          placeholder={locationPlaceholder(compact)}
           multiple
           creatable
           pillsBelow

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -25,6 +25,7 @@ export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
   defaultLocations?: string[];
   surface: ProviderSearchSurface;
   searchDemo?: boolean;
+  compact?: boolean;
 };
 
 const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
@@ -35,6 +36,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
   defaultLocations = [],
   surface,
   searchDemo = false,
+  compact = false,
   ...rest
 }) => {
   const router = useRouter();
@@ -61,7 +63,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
   return (
     <Form
       methods={methods}
-      className={classNames(styles.container, className)}
+      className={classNames(styles.container, compact && styles.compact, className)}
       onSubmit={methods.handleSubmit((values) => {
         const interestAreas = uniqueSortedStrings(values.InterestArea ?? []);
         const locations = uniqueSortedStrings(values.Location ?? []);
@@ -84,8 +86,9 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           name='InterestArea'
           label='What do you want to study?'
           showLabel
-          placeholder='Ex. Nursing'
+          placeholder='Ex. Nursing or digital'
           multiple
+          creatable
           options={interestAreaOptions}
         />
         <Dropdown<ProviderStudySearchFormValues>
@@ -94,6 +97,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           showLabel
           placeholder='Ex. Sydney'
           multiple
+          creatable
           options={locationOptions}
         />
         <div className={styles.buttonContainer}>

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -28,10 +28,14 @@ export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
   compact?: boolean;
 };
 
+function asSelectedList(value: unknown): string[] {
+  return Array.isArray(value) ? uniqueSortedStrings(value) : [];
+}
+
 function normalizeFormValues(values: Partial<ProviderStudySearchFormValues>) {
   return {
-    interestAreas: uniqueSortedStrings(values.InterestArea ?? []),
-    locations: uniqueSortedStrings(values.Location ?? []),
+    interestAreas: asSelectedList(values.InterestArea),
+    locations: asSelectedList(values.Location),
   };
 }
 

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -28,7 +28,7 @@ export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
   compact?: boolean;
 };
 
-function normalizeFormValues(values: ProviderStudySearchFormValues) {
+function normalizeFormValues(values: Partial<ProviderStudySearchFormValues>) {
   return {
     interestAreas: uniqueSortedStrings(values.InterestArea ?? []),
     locations: uniqueSortedStrings(values.Location ?? []),

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormHTMLAttributes, useMemo } from 'react';
+import { FormHTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { useForm, useWatch, type UseFormReturn } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
@@ -28,6 +28,13 @@ export type ProviderStudySearchProps = FormHTMLAttributes<HTMLFormElement> & {
   compact?: boolean;
 };
 
+function normalizeFormValues(values: ProviderStudySearchFormValues) {
+  return {
+    interestAreas: uniqueSortedStrings(values.InterestArea ?? []),
+    locations: uniqueSortedStrings(values.Location ?? []),
+  };
+}
+
 const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
   className,
   interestAreaOptions,
@@ -50,14 +57,8 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
     });
 
   const watchedValues = useWatch({ control: methods.control });
-  const selectedAreas = useMemo(
-    () => uniqueSortedStrings(watchedValues.InterestArea ?? []),
-    [watchedValues.InterestArea],
-  );
-  const selectedLocations = useMemo(
-    () => uniqueSortedStrings(watchedValues.Location ?? []),
-    [watchedValues.Location],
-  );
+  const { interestAreas: selectedAreas, locations: selectedLocations } =
+    normalizeFormValues(watchedValues);
   const canSearch = selectedAreas.length > 0 || selectedLocations.length > 0;
 
   return (
@@ -65,16 +66,11 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
       methods={methods}
       className={classNames(styles.container, compact && styles.compact, className)}
       onSubmit={methods.handleSubmit((values) => {
-        const interestAreas = uniqueSortedStrings(values.InterestArea ?? []);
-        const locations = uniqueSortedStrings(values.Location ?? []);
+        const { interestAreas, locations } = normalizeFormValues(values);
         if (interestAreas.length === 0 && locations.length === 0) {
           return;
         }
-        trackProviderSearchSubmit({
-          surface,
-          interestAreas,
-          locations,
-        });
+        trackProviderSearchSubmit({ surface, interestAreas, locations });
         router.push(buildProviderSearchHref({ interestAreas, locations }, { searchDemo }));
       })}
       aria-label='Search providers by area of study and location'

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -86,6 +86,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           multiple
           creatable
           pillsBelow
+          clearable={false}
           options={interestAreaOptions}
           onDraftChange={setAreaDraft}
         />
@@ -97,6 +98,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           multiple
           creatable
           pillsBelow
+          clearable={false}
           options={locationOptions}
           onDraftChange={setLocationDraft}
         />

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -73,12 +73,7 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           interestAreas,
           locations,
         });
-        router.push(
-          buildProviderSearchHref(
-            { interestAreas, locations },
-            { searchDemo },
-          ),
-        );
+        router.push(buildProviderSearchHref({ interestAreas, locations }, { searchDemo }));
       })}
       aria-label='Search providers by area of study and location'
       role='search'

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -86,7 +86,6 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           multiple
           creatable
           pillsBelow
-          clearable={false}
           options={interestAreaOptions}
           onDraftChange={setAreaDraft}
         />
@@ -98,7 +97,6 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           multiple
           creatable
           pillsBelow
-          clearable={false}
           options={locationOptions}
           onDraftChange={setLocationDraft}
         />

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -85,8 +85,8 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
         <Dropdown<ProviderStudySearchFormValues>
           name='InterestArea'
           label='What do you want to study?'
-          showLabel
-          placeholder='Ex. Nursing or digital'
+          showLabel={!compact}
+          placeholder={compact ? 'What do you want to study?' : 'Ex. Nursing or digital'}
           multiple
           creatable
           options={interestAreaOptions}
@@ -94,8 +94,8 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
         <Dropdown<ProviderStudySearchFormValues>
           name='Location'
           label='Where do you want to study?'
-          showLabel
-          placeholder='Ex. Sydney'
+          showLabel={!compact}
+          placeholder={compact ? 'Where do you want to study?' : 'Ex. Sydney'}
           multiple
           creatable
           options={locationOptions}

--- a/src/app/components/providerSearch/__tests__/ProviderCoursesPlaceholder.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderCoursesPlaceholder.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ProviderCoursesPlaceholder from '../ProviderCoursesPlaceholder';
+
+jest.mock('@/app/utilities/providerSearch/providerSearchGa', () => ({
+  trackProviderCoursesPlaceholderView: jest.fn(),
+}));
+
+jest.mock('../../buttons/ActionButton', () => ({
+  __esModule: true,
+  default: ({ label, to }: { label: string; to?: string }) => <a href={to}>{label}</a>,
+}));
+
+import { trackProviderCoursesPlaceholderView } from '@/app/utilities/providerSearch/providerSearchGa';
+
+describe('ProviderCoursesPlaceholder', () => {
+  it('renders coming-soon copy, profile CTA, and tracks view', () => {
+    render(<ProviderCoursesPlaceholder providerSlug='collarts' providerName='Collarts' />);
+
+    expect(screen.getByText('Courses from Collarts')).toBeInTheDocument();
+    expect(screen.getByText(/Courses are coming soon/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View provider profile' })).toHaveAttribute(
+      'href',
+      '/endorsedproviders/collarts',
+    );
+    expect(trackProviderCoursesPlaceholderView).toHaveBeenCalledWith('collarts');
+  });
+});

--- a/src/app/components/providerSearch/__tests__/ProviderCoursesPlaceholder.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderCoursesPlaceholder.test.tsx
@@ -8,23 +8,15 @@ jest.mock('@/app/utilities/providerSearch/providerSearchGa', () => ({
   trackProviderCoursesPlaceholderView: jest.fn(),
 }));
 
-jest.mock('../../buttons/ActionButton', () => ({
-  __esModule: true,
-  default: ({ label, to }: { label: string; to?: string }) => <a href={to}>{label}</a>,
-}));
-
 import { trackProviderCoursesPlaceholderView } from '@/app/utilities/providerSearch/providerSearchGa';
 
 describe('ProviderCoursesPlaceholder', () => {
-  it('renders coming-soon copy, profile CTA, and tracks view', () => {
+  it('renders an empty courses list without a profile CTA', () => {
     render(<ProviderCoursesPlaceholder providerSlug='collarts' providerName='Collarts' />);
 
     expect(screen.getByText('Courses from Collarts')).toBeInTheDocument();
-    expect(screen.getByText(/Courses are coming soon/)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'View provider profile' })).toHaveAttribute(
-      'href',
-      '/endorsedproviders/collarts',
-    );
+    expect(screen.getByText('No courses listed yet')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'View provider profile' })).not.toBeInTheDocument();
     expect(trackProviderCoursesPlaceholderView).toHaveBeenCalledWith('collarts');
   });
 });

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -23,6 +23,17 @@ jest.mock('../../institutionProviderCard/InstitutionProviderCard', () => ({
   ),
 }));
 
+jest.mock('../../emergingInstitutions/EmergingInstitutionCard', () => ({
+  __esModule: true,
+  default: ({ name, state }: { name: string; state: string }) => (
+    <div data-testid='emerging-card'>
+      <span>{name}</span>
+      <span>{state}</span>
+      <a href={`/emergingproviders/${name.toLowerCase().replace(/\s+/g, '-')}`}>Explore More</a>
+    </div>
+  ),
+}));
+
 jest.mock('../../endorsedProviders/EndorsedCertifiedBadge', () => ({
   __esModule: true,
   default: () => <div>badge</div>,
@@ -52,7 +63,7 @@ describe('ProviderSearchResults', () => {
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('renders matching providers as cards across tiers', () => {
+  it('renders matching providers as shared cards across tiers', () => {
     const results = emptyResults();
     results.course_endorsed = [
       {
@@ -105,7 +116,9 @@ describe('ProviderSearchResults', () => {
     expect(screen.getByText('NDA Certified providers')).toBeInTheDocument();
     expect(screen.getByText('Emerging providers')).toBeInTheDocument();
     expect(screen.getByText('Jazz Music Institute')).toBeInTheDocument();
-    expect(screen.getAllByTestId('provider-card')).toHaveLength(3);
+    expect(screen.getByText('QLD')).toBeInTheDocument();
+    expect(screen.getAllByTestId('provider-card')).toHaveLength(2);
+    expect(screen.getAllByTestId('emerging-card')).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: 'Explore More' })[0]).toHaveAttribute(
       'href',
       '/endorsedproviders/collarts/courses?searchDemo=1',

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ProviderSearchResults from '../ProviderSearchResults';
+import type { ProviderSearchTierResults } from '@/app/utilities/providerSearch/constants';
+
+jest.mock('../../institutionProviderCard/InstitutionProviderCard', () => ({
+  __esModule: true,
+  default: ({
+    center,
+    ctaHref,
+    comingSoonLabel,
+  }: {
+    center: React.ReactNode;
+    ctaHref?: string;
+    comingSoonLabel?: string;
+  }) => (
+    <div data-testid='provider-card'>
+      <div>{center}</div>
+      {ctaHref ? <a href={ctaHref}>Explore More</a> : <span>{comingSoonLabel}</span>}
+    </div>
+  ),
+}));
+
+jest.mock('../../endorsedProviders/EndorsedCertifiedBadge', () => ({
+  __esModule: true,
+  default: () => <div>badge</div>,
+}));
+
+jest.mock('../../buttons/ActionButton', () => ({
+  __esModule: true,
+  default: ({ label, to }: { label: string; to?: string }) => <a href={to}>{label}</a>,
+}));
+
+jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
+
+const emptyResults = (): ProviderSearchTierResults => ({
+  course_endorsed: [],
+  starred_endorsed: [],
+  endorsed: [],
+  emerging: [],
+});
+
+describe('ProviderSearchResults', () => {
+  it('renders empty state with emerging directory CTA', () => {
+    render(
+      <ProviderSearchResults
+        results={emptyResults()}
+        filters={{ interestAreas: ['Music'], locations: [] }}
+        searchDemo={false}
+        totalCount={0}
+      />,
+    );
+
+    expect(screen.getByText('No providers matched your search')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Explore emerging providers' })).toHaveAttribute(
+      'href',
+      '/emergingproviders',
+    );
+  });
+
+  it('renders tier headings and course-endorsed href', () => {
+    const results = emptyResults();
+    results.course_endorsed = [
+      {
+        kind: 'endorsed',
+        slug: 'collarts',
+        name: 'Collarts',
+        interestAreas: ['Music'],
+        locations: ['Melbourne'],
+        ndaCertified: false,
+        hasPromotedCourses: true,
+        logoSrc: '/images/AcademiaLogoLong.png',
+        topBackgroundImage: '/images/CollartsCover.webp',
+      },
+    ];
+    results.starred_endorsed = [
+      {
+        kind: 'endorsed',
+        slug: 'nepean-community-college',
+        name: 'Nepean Community College',
+        interestAreas: [],
+        locations: ['Sydney'],
+        ndaCertified: true,
+        hasPromotedCourses: false,
+        logoSrc: '/images/AcademiaLogoLong.png',
+      },
+    ];
+
+    render(
+      <ProviderSearchResults
+        results={results}
+        filters={{ interestAreas: ['Music'], locations: ['Sydney'] }}
+        searchDemo
+        totalCount={2}
+      />,
+    );
+
+    expect(screen.getByText('Courses from endorsed providers')).toBeInTheDocument();
+    expect(screen.getByText('NDA Certified providers')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'Explore More' })[0]).toHaveAttribute(
+      'href',
+      '/endorsedproviders/collarts/courses?searchDemo=1',
+    );
+    expect(screen.getByRole('link', { name: 'Explore emerging providers' })).toBeInTheDocument();
+  });
+});

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -28,11 +28,6 @@ jest.mock('../../endorsedProviders/EndorsedCertifiedBadge', () => ({
   default: () => <div>badge</div>,
 }));
 
-jest.mock('../../buttons/ActionButton', () => ({
-  __esModule: true,
-  default: ({ label, to }: { label: string; to?: string }) => <a href={to}>{label}</a>,
-}));
-
 jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 const emptyResults = (): ProviderSearchTierResults => ({
@@ -43,7 +38,7 @@ const emptyResults = (): ProviderSearchTierResults => ({
 });
 
 describe('ProviderSearchResults', () => {
-  it('renders empty state with emerging directory CTA', () => {
+  it('renders empty state without directory links', () => {
     render(
       <ProviderSearchResults
         results={emptyResults()}
@@ -54,13 +49,10 @@ describe('ProviderSearchResults', () => {
     );
 
     expect(screen.getByText('No providers matched your search')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Explore emerging providers' })).toHaveAttribute(
-      'href',
-      '/emergingproviders',
-    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
-  it('renders tier headings and course-endorsed href', () => {
+  it('renders matching providers as cards across tiers', () => {
     const results = emptyResults();
     results.course_endorsed = [
       {
@@ -87,22 +79,37 @@ describe('ProviderSearchResults', () => {
         logoSrc: '/images/AcademiaLogoLong.png',
       },
     ];
+    results.emerging = [
+      {
+        kind: 'emerging',
+        slug: 'jazz-music-institute',
+        name: 'Jazz Music Institute',
+        interestAreas: ['Music'],
+        locations: ['QLD'],
+        ndaCertified: false,
+        hasPromotedCourses: false,
+        emergingState: 'QLD',
+      },
+    ];
 
     render(
       <ProviderSearchResults
         results={results}
-        filters={{ interestAreas: ['Music'], locations: ['Sydney'] }}
+        filters={{ interestAreas: ['Music'], locations: [] }}
         searchDemo
-        totalCount={2}
+        totalCount={3}
       />,
     );
 
-    expect(screen.getByText('Courses from endorsed providers')).toBeInTheDocument();
+    expect(screen.getByText('Providers with courses')).toBeInTheDocument();
     expect(screen.getByText('NDA Certified providers')).toBeInTheDocument();
+    expect(screen.getByText('Emerging providers')).toBeInTheDocument();
+    expect(screen.getByText('Jazz Music Institute')).toBeInTheDocument();
+    expect(screen.getAllByTestId('provider-card')).toHaveLength(3);
     expect(screen.getAllByRole('link', { name: 'Explore More' })[0]).toHaveAttribute(
       'href',
       '/endorsedproviders/collarts/courses?searchDemo=1',
     );
-    expect(screen.getByRole('link', { name: 'Explore emerging providers' })).toBeInTheDocument();
+    expect(screen.queryByText(/Explore emerging providers/i)).not.toBeInTheDocument();
   });
 });

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -43,7 +43,6 @@ jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
 
 const emptyResults = (): ProviderSearchTierResults => ({
   course_endorsed: [],
-  starred_endorsed: [],
   endorsed: [],
   emerging: [],
 });
@@ -78,7 +77,7 @@ describe('ProviderSearchResults', () => {
         topBackgroundImage: '/images/CollartsCover.webp',
       },
     ];
-    results.starred_endorsed = [
+    results.endorsed = [
       {
         kind: 'endorsed',
         slug: 'nepean-community-college',
@@ -113,7 +112,8 @@ describe('ProviderSearchResults', () => {
     );
 
     expect(screen.getByText('Providers with courses')).toBeInTheDocument();
-    expect(screen.getByText('NDA Certified providers')).toBeInTheDocument();
+    expect(screen.getByText('Endorsed providers')).toBeInTheDocument();
+    expect(screen.queryByText('NDA Certified providers')).not.toBeInTheDocument();
     expect(screen.getByText('Emerging providers')).toBeInTheDocument();
     expect(screen.getByText('Jazz Music Institute')).toBeInTheDocument();
     expect(screen.getByText('QLD')).toBeInTheDocument();

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -11,25 +11,47 @@ jest.mock('../../institutionProviderCard/InstitutionProviderCard', () => ({
     center,
     ctaHref,
     comingSoonLabel,
+    gaEvent,
   }: {
     center: React.ReactNode;
     ctaHref?: string;
     comingSoonLabel?: string;
+    gaEvent?: { eventName: string; params: { provider_slug?: string; result_position?: number } };
   }) => (
     <div data-testid='provider-card'>
       <div>{center}</div>
-      {ctaHref ? <a href={ctaHref}>Explore More</a> : <span>{comingSoonLabel}</span>}
+      {ctaHref ? (
+        <a href={ctaHref} data-event={gaEvent?.eventName} data-slug={gaEvent?.params.provider_slug}>
+          Explore More
+        </a>
+      ) : (
+        <span>{comingSoonLabel}</span>
+      )}
     </div>
   ),
 }));
 
 jest.mock('../../emergingInstitutions/EmergingInstitutionCard', () => ({
   __esModule: true,
-  default: ({ name, state }: { name: string; state: string }) => (
+  default: ({
+    name,
+    state,
+    gaEvent,
+  }: {
+    name: string;
+    state: string;
+    gaEvent?: { params: { destination_url?: string; provider_slug?: string } };
+  }) => (
     <div data-testid='emerging-card'>
       <span>{name}</span>
       <span>{state}</span>
-      <a href={`/emergingproviders/${name.toLowerCase().replace(/\s+/g, '-')}`}>Explore More</a>
+      {gaEvent?.params.destination_url ? (
+        <a href={gaEvent.params.destination_url} data-slug={gaEvent.params.provider_slug}>
+          Explore More
+        </a>
+      ) : (
+        <span>Coming soon</span>
+      )}
     </div>
   ),
 }));
@@ -37,6 +59,10 @@ jest.mock('../../emergingInstitutions/EmergingInstitutionCard', () => ({
 jest.mock('../../endorsedProviders/EndorsedCertifiedBadge', () => ({
   __esModule: true,
   default: () => <div>badge</div>,
+}));
+
+jest.mock('../../emergingInstitutions/emergingProviderProfileSlugs', () => ({
+  hasEmergingProviderProfile: (slug: string) => slug === 'jazz-music-institute',
 }));
 
 jest.mock('next/image', () => require('@/testUtils/mockNextImage'));
@@ -123,10 +149,46 @@ describe('ProviderSearchResults', () => {
     expect(screen.getByText('QLD')).toBeInTheDocument();
     expect(screen.getAllByTestId('provider-card')).toHaveLength(2);
     expect(screen.getAllByTestId('emerging-card')).toHaveLength(1);
-    expect(screen.getAllByRole('link', { name: 'Explore More' })[0]).toHaveAttribute(
+
+    const links = screen.getAllByRole('link', { name: 'Explore More' });
+    expect(links[0]).toHaveAttribute(
       'href',
       '/endorsedproviders/collarts/courses?searchDemo=1',
     );
+    expect(links[0]).toHaveAttribute('data-slug', 'collarts');
+    expect(links[1]).toHaveAttribute('href', expect.stringContaining('nepean'));
+    expect(links[1]).toHaveAttribute('data-slug', 'nepean-community-college');
+    expect(links[2]).toHaveAttribute('href', '/emergingproviders/jazz-music-institute');
+    expect(links[2]).toHaveAttribute('data-slug', 'jazz-music-institute');
     expect(screen.queryByText(/Explore emerging providers/i)).not.toBeInTheDocument();
+  });
+
+  it('does not invent emerging CTAs when the provider has no profile', () => {
+    const results = emptyResults();
+    results.emerging = [
+      {
+        kind: 'emerging',
+        slug: 'unknown-college',
+        name: 'Unknown College',
+        interestAreas: ['Music'],
+        locations: ['NSW'],
+        ndaCertified: false,
+        hasPromotedCourses: false,
+        emergingState: 'NSW',
+      },
+    ];
+
+    render(
+      <ProviderSearchResults
+        results={results}
+        filters={{ interestAreas: [], locations: [] }}
+        searchDemo={false}
+        totalCount={1}
+      />,
+    );
+
+    expect(screen.getByText('Unknown College')).toBeInTheDocument();
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -113,6 +113,10 @@ describe('ProviderSearchResults', () => {
 
     expect(screen.getByText('Providers with courses')).toBeInTheDocument();
     expect(screen.getByText('Endorsed providers')).toBeInTheDocument();
+    expect(screen.getAllByText('NDA ENDORSED')).toHaveLength(2);
+    expect(screen.getByText('EXPLORING')).toBeInTheDocument();
+    expect(screen.getByText('Neuro-inclusive institutions verified by NDA')).toBeInTheDocument();
+    expect(screen.getByText('Building neuro-inclusion — not yet endorsed')).toBeInTheDocument();
     expect(screen.queryByText('NDA Certified providers')).not.toBeInTheDocument();
     expect(screen.getByText('Emerging providers')).toBeInTheDocument();
     expect(screen.getByText('Jazz Music Institute')).toBeInTheDocument();

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -151,10 +151,7 @@ describe('ProviderSearchResults', () => {
     expect(screen.getAllByTestId('emerging-card')).toHaveLength(1);
 
     const links = screen.getAllByRole('link', { name: 'Explore More' });
-    expect(links[0]).toHaveAttribute(
-      'href',
-      '/endorsedproviders/collarts/courses?searchDemo=1',
-    );
+    expect(links[0]).toHaveAttribute('href', '/endorsedproviders/collarts/courses?searchDemo=1');
     expect(links[0]).toHaveAttribute('data-slug', 'collarts');
     expect(links[1]).toHaveAttribute('href', expect.stringContaining('nepean'));
     expect(links[1]).toHaveAttribute('data-slug', 'nepean-community-college');

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import ProviderSearchResultsTracker from '../ProviderSearchResultsTracker';
+
+const trackMock = jest.fn();
+
+jest.mock('@/app/utilities/providerSearch/providerSearchGa', () => ({
+  trackProviderSearchResultsView: (...args: unknown[]) => trackMock(...args),
+}));
+
+describe('ProviderSearchResultsTracker', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+  });
+
+  it('fires results_view once per distinct query', () => {
+    const { rerender } = render(
+      <ProviderSearchResultsTracker
+        interestAreas={['Music']}
+        locations={['Sydney']}
+        resultCountTotal={2}
+        countCourseEndorsed={1}
+        countStarredEndorsed={0}
+        countEndorsed={1}
+        countEmerging={0}
+      />,
+    );
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ProviderSearchResultsTracker
+        interestAreas={['Music']}
+        locations={['Sydney']}
+        resultCountTotal={2}
+        countCourseEndorsed={1}
+        countStarredEndorsed={0}
+        countEndorsed={1}
+        countEmerging={0}
+      />,
+    );
+    expect(trackMock).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ProviderSearchResultsTracker
+        interestAreas={['Nursing']}
+        locations={[]}
+        resultCountTotal={0}
+        countCourseEndorsed={0}
+        countStarredEndorsed={0}
+        countEndorsed={0}
+        countEmerging={0}
+      />,
+    );
+    expect(trackMock).toHaveBeenCalledTimes(2);
+    expect(trackMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        interestAreas: ['Nursing'],
+        hasResults: false,
+      }),
+    );
+  });
+
+  it('does not fire when filters are empty', () => {
+    render(
+      <ProviderSearchResultsTracker
+        interestAreas={[]}
+        locations={[]}
+        resultCountTotal={0}
+        countCourseEndorsed={0}
+        countStarredEndorsed={0}
+        countEndorsed={0}
+        countEmerging={0}
+      />,
+    );
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
@@ -63,18 +63,25 @@ describe('ProviderSearchResultsTracker', () => {
     );
   });
 
-  it('does not fire when filters are empty', () => {
+  it('fires browse-all results_view when filters are empty', () => {
     render(
       <ProviderSearchResultsTracker
         interestAreas={[]}
         locations={[]}
-        resultCountTotal={0}
-        countCourseEndorsed={0}
-        countStarredEndorsed={0}
-        countEndorsed={0}
-        countEmerging={0}
+        resultCountTotal={12}
+        countCourseEndorsed={1}
+        countStarredEndorsed={2}
+        countEndorsed={4}
+        countEmerging={5}
       />,
     );
-    expect(trackMock).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interestAreas: [],
+        locations: [],
+        resultCountTotal: 12,
+        hasResults: true,
+      }),
+    );
   });
 });

--- a/src/app/components/providerSearch/__tests__/ProviderStudySearch.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderStudySearch.test.tsx
@@ -29,16 +29,22 @@ jest.mock('../../formElements/Dropdown/Dropdown', () => ({
   default: function MockSearchDropdown({
     name,
     label,
+    onDraftChange,
   }: {
     name: 'InterestArea' | 'Location';
     label: string;
+    onDraftChange?: (draft: string) => void;
   }) {
     const { useFormContext } = require('react-hook-form');
     const { setValue, watch } = useFormContext();
     const value = watch(name) ?? [];
     return (
-      <label>
-        {label}
+      <div>
+        <span>{label}</span>
+        <input
+          aria-label={`${name}-draft`}
+          onChange={(event) => onDraftChange?.(event.target.value)}
+        />
         <select
           aria-label={label}
           multiple
@@ -55,7 +61,7 @@ jest.mock('../../formElements/Dropdown/Dropdown', () => ({
           <option value='Sydney'>Sydney</option>
           <option value='Melbourne'>Melbourne</option>
         </select>
-      </label>
+      </div>
     );
   },
 }));
@@ -68,7 +74,8 @@ describe('ProviderStudySearch', () => {
     (trackProviderSearchSubmit as jest.Mock).mockClear();
   });
 
-  it('disables search until an area or location is selected', () => {
+  it('allows searching with no selections to browse all providers', async () => {
+    const user = userEvent.setup();
     render(
       <ProviderStudySearch
         surface='homepage'
@@ -83,7 +90,18 @@ describe('ProviderStudySearch', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled();
+    const searchButton = screen.getByRole('button', { name: 'Search' });
+    expect(searchButton).toBeEnabled();
+    await user.click(searchButton);
+
+    await waitFor(() => {
+      expect(trackProviderSearchSubmit).toHaveBeenCalledWith({
+        surface: 'homepage',
+        interestAreas: [],
+        locations: [],
+      });
+      expect(pushMock).toHaveBeenCalledWith('/search');
+    });
   });
 
   it('submits selected filters to /search and tracks GA', async () => {
@@ -115,6 +133,29 @@ describe('ProviderStudySearch', () => {
         locations: ['Sydney'],
       });
       expect(pushMock).toHaveBeenCalledWith('/search?InterestArea=Music&Location=Sydney');
+    });
+  });
+
+  it('includes typed draft text like business without requiring a pill', async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderStudySearch
+        surface='homepage'
+        interestAreaOptions={[{ label: 'Music', value: 'Music' }]}
+        locationOptions={[{ label: 'Sydney', value: 'Sydney' }]}
+      />,
+    );
+
+    await user.type(screen.getByLabelText('InterestArea-draft'), 'business');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(trackProviderSearchSubmit).toHaveBeenCalledWith({
+        surface: 'homepage',
+        interestAreas: ['business'],
+        locations: [],
+      });
+      expect(pushMock).toHaveBeenCalledWith('/search?InterestArea=business');
     });
   });
 });

--- a/src/app/components/providerSearch/__tests__/ProviderStudySearch.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderStudySearch.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProviderStudySearch from '../ProviderStudySearch';
+
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+jest.mock('@/app/utilities/providerSearch/providerSearchGa', () => ({
+  trackProviderSearchSubmit: jest.fn(),
+}));
+
+jest.mock('../../buttons/ActionButton', () => ({
+  __esModule: true,
+  default: ({ label, disabled, type }: { label: string; disabled?: boolean; type?: string }) => (
+    <button type={type === 'submit' ? 'submit' : 'button'} disabled={disabled}>
+      {label}
+    </button>
+  ),
+}));
+
+jest.mock('../../formElements/Dropdown/Dropdown', () => ({
+  __esModule: true,
+  default: function MockSearchDropdown({
+    name,
+    label,
+  }: {
+    name: 'InterestArea' | 'Location';
+    label: string;
+  }) {
+    const { useFormContext } = require('react-hook-form');
+    const { setValue, watch } = useFormContext();
+    const value = watch(name) ?? [];
+    return (
+      <label>
+        {label}
+        <select
+          aria-label={label}
+          multiple
+          value={value}
+          onChange={(event) => {
+            const selected = Array.from(event.target.selectedOptions).map(
+              (option: HTMLOptionElement) => option.value,
+            );
+            setValue(name, selected, { shouldDirty: true, shouldValidate: true });
+          }}
+        >
+          <option value='Music'>Music</option>
+          <option value='Nursing'>Nursing</option>
+          <option value='Sydney'>Sydney</option>
+          <option value='Melbourne'>Melbourne</option>
+        </select>
+      </label>
+    );
+  },
+}));
+
+import { trackProviderSearchSubmit } from '@/app/utilities/providerSearch/providerSearchGa';
+
+describe('ProviderStudySearch', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    (trackProviderSearchSubmit as jest.Mock).mockClear();
+  });
+
+  it('disables search until an area or location is selected', () => {
+    render(
+      <ProviderStudySearch
+        surface='homepage'
+        interestAreaOptions={[
+          { label: 'Music', value: 'Music' },
+          { label: 'Nursing', value: 'Nursing' },
+        ]}
+        locationOptions={[
+          { label: 'Sydney', value: 'Sydney' },
+          { label: 'Melbourne', value: 'Melbourne' },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Search' })).toBeDisabled();
+  });
+
+  it('submits selected filters to /search and tracks GA', async () => {
+    const user = userEvent.setup();
+    render(
+      <ProviderStudySearch
+        surface='homepage'
+        interestAreaOptions={[
+          { label: 'Music', value: 'Music' },
+          { label: 'Nursing', value: 'Nursing' },
+        ]}
+        locationOptions={[
+          { label: 'Sydney', value: 'Sydney' },
+          { label: 'Melbourne', value: 'Melbourne' },
+        ]}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText('What do you want to study?'), ['Music']);
+    await user.selectOptions(screen.getByLabelText('Where do you want to study?'), ['Sydney']);
+
+    expect(screen.getByRole('button', { name: 'Search' })).toBeEnabled();
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(trackProviderSearchSubmit).toHaveBeenCalledWith({
+        surface: 'homepage',
+        interestAreas: ['Music'],
+        locations: ['Sydney'],
+      });
+      expect(pushMock).toHaveBeenCalledWith('/search?InterestArea=Music&Location=Sydney');
+    });
+  });
+});

--- a/src/app/components/providerSearch/providerCoursesPlaceholder.module.css
+++ b/src/app/components/providerSearch/providerCoursesPlaceholder.module.css
@@ -1,0 +1,11 @@
+.page {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 5vw;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.25rem;
+  box-sizing: border-box;
+}

--- a/src/app/components/providerSearch/providerCoursesPlaceholder.module.css
+++ b/src/app/components/providerSearch/providerCoursesPlaceholder.module.css
@@ -5,7 +5,32 @@
   padding: 3rem 5vw;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 1.25rem;
+  align-items: stretch;
+  gap: 1.5rem;
+  box-sizing: border-box;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.courseList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+}
+
+.emptyCourseCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 1.25rem;
+  border: 1px solid var(--grey-300);
+  border-radius: 8px;
+  background-color: var(--GhostWhite);
   box-sizing: border-box;
 }

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -10,23 +10,29 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  align-items: center;
 }
 
 .tierHeading {
   margin: 0;
+  width: 100%;
 }
 
 .cardGrid {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-start;
+  justify-content: space-evenly;
   align-items: stretch;
   gap: clamp(18px, 3.6vw, 47px);
-  width: 100%;
+  width: 90%;
+  margin-inline: auto;
 }
 
 .cardGrid > * {
   flex: 0 0 auto;
+  width: 20%;
+  min-width: 220px;
+  max-width: 274px;
 }
 
 .emptyState {
@@ -37,6 +43,13 @@
   width: 100%;
 }
 
+@media (max-width: 1024px) {
+  .cardGrid {
+    max-width: min(684px, 90%);
+    gap: 29px;
+  }
+}
+
 @media (max-width: 768px) {
   .cardGrid {
     display: grid;
@@ -44,8 +57,17 @@
     gap: 16px;
     width: min(92vw, 560px);
     max-width: min(92vw, 560px);
+    margin-inline: auto;
+    justify-content: stretch;
   }
 
+  .cardGrid > * {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  /* Odd total: last card alone — match one column width, centered */
   .cardGrid > *:last-child:nth-child(odd) {
     grid-column: 1 / -1;
     justify-self: center;

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -23,8 +23,7 @@
   width: 100%;
 }
 
-.emptyState,
-.emergingFallback {
+.emptyState {
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -19,8 +19,14 @@
 .cardGrid {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.25rem;
+  justify-content: flex-start;
+  align-items: stretch;
+  gap: clamp(18px, 3.6vw, 47px);
   width: 100%;
+}
+
+.cardGrid > * {
+  flex: 0 0 auto;
 }
 
 .emptyState {
@@ -29,4 +35,21 @@
   align-items: flex-start;
   gap: 1rem;
   width: 100%;
+}
+
+@media (max-width: 768px) {
+  .cardGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    width: min(92vw, 560px);
+    max-width: min(92vw, 560px);
+  }
+
+  .cardGrid > *:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+    justify-self: center;
+    width: calc((100% - 16px) / 2);
+    max-width: calc((100% - 16px) / 2);
+  }
 }

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -61,3 +61,20 @@
     flex: none;
   }
 }
+
+/* Phone: one full-width card per row — 2-up is too skinny */
+@media (max-width: 560px) {
+  .cardGrid {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 20px;
+    width: 100%;
+  }
+
+  .cardGrid > * {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+  }
+}

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -2,7 +2,7 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 2.5rem;
+  gap: 0;
 }
 
 .tierSection {
@@ -10,22 +10,88 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  align-items: stretch;
+  box-sizing: border-box;
+}
+
+.tierInner {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 5vw;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
   align-items: flex-start;
 }
 
-@media (max-width: 560px) {
-  .root {
-    gap: 1.5rem;
-  }
+/* Endorsed / course tiers: soft purple stage */
+.tierSectionProminent {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--cherryPie) 10%, transparent) 0%,
+    color-mix(in srgb, var(--cherryPie) 6%, var(--GhostWhiteVariant)) 100%
+  );
+  border-block: 1px solid color-mix(in srgb, var(--cherryPie) 14%, transparent);
+  padding: 1.75rem 0 2.25rem;
+  gap: 0;
+}
 
-  .tierSection {
-    gap: 0.75rem;
-  }
+.tierSectionProminent .tierInner {
+  gap: 1.35rem;
+}
+
+/* Emerging: quieter, plain page stage */
+.tierSectionQuiet {
+  background: transparent;
+  padding: 2rem 0 2.5rem;
+  gap: 0;
+}
+
+.tierHeader {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  width: 100%;
+}
+
+.tierEyebrow {
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .tierHeading {
   margin: 0;
   width: 100%;
+}
+
+.tierHeadingProminent {
+  color: var(--BondBlack);
+}
+
+.tierHeadingQuiet {
+  color: var(--BondBlackVariant);
+}
+
+.tierRule {
+  width: 4rem;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--cherryPie);
+}
+
+.tierRuleQuiet {
+  width: 2.5rem;
+  height: 2px;
+  background: color-mix(in srgb, var(--BondBlackVariant) 35%, transparent);
+}
+
+.tierSubtitle {
+  margin: 0;
+  max-width: 42rem;
 }
 
 /* Match emerging directory card row so InstitutionProviderCard keeps its own sizing. */
@@ -44,6 +110,10 @@
   align-items: flex-start;
   gap: 1rem;
   width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.25rem 5vw 3rem;
+  box-sizing: border-box;
 }
 
 @media (max-width: 1024px) {
@@ -72,8 +142,34 @@
   }
 }
 
+@media (max-width: 768px) {
+  .tierInner {
+    padding: 0 4vw;
+  }
+
+  .tierSectionProminent {
+    padding: 1.35rem 0 1.75rem;
+  }
+
+  .tierSectionQuiet {
+    padding: 1.5rem 0 2rem;
+  }
+
+  .emptyState {
+    padding: 0.85rem 4vw 2rem;
+  }
+}
+
 /* Phone: keep 2-up so ~4–5 cards fit in the viewport */
 @media (max-width: 560px) {
+  .tierInner {
+    gap: 0.85rem;
+  }
+
+  .tierSectionProminent .tierInner {
+    gap: 0.9rem;
+  }
+
   .cardGrid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .tierHeading {
@@ -18,21 +18,14 @@
   width: 100%;
 }
 
+/* Match emerging directory card row so InstitutionProviderCard keeps its own sizing. */
 .cardGrid {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: flex-start;
   align-items: stretch;
-  gap: clamp(18px, 3.6vw, 47px);
-  width: 90%;
-  margin-inline: auto;
-}
-
-.cardGrid > * {
-  flex: 0 0 auto;
-  width: 28%;
-  min-width: 260px;
-  max-width: 360px;
+  gap: 36px;
+  width: 100%;
 }
 
 .emptyState {
@@ -45,33 +38,26 @@
 
 @media (max-width: 1024px) {
   .cardGrid {
-    max-width: min(684px, 90%);
-    gap: 29px;
+    max-width: 760px;
+    gap: 32px;
+    margin-inline: auto;
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .cardGrid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 16px;
-    width: min(92vw, 560px);
-    max-width: min(92vw, 560px);
-    margin-inline: auto;
-    justify-content: stretch;
+    gap: 32px 24px;
+    width: 100%;
+    max-width: none;
+    margin-inline: 0;
   }
 
   .cardGrid > * {
     width: 100%;
+    max-width: none;
     min-width: 0;
-    max-width: 100%;
-  }
-
-  /* Odd total: last card alone — slightly larger than half column, centered */
-  .cardGrid > *:last-child:nth-child(odd) {
-    grid-column: 1 / -1;
-    justify-self: center;
-    width: min(340px, calc((100% - 16px) / 2 + 24px));
-    max-width: min(340px, 70%);
+    flex: none;
   }
 }

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -13,6 +13,16 @@
   align-items: flex-start;
 }
 
+@media (max-width: 560px) {
+  .root {
+    gap: 1.5rem;
+  }
+
+  .tierSection {
+    gap: 0.75rem;
+  }
+}
+
 .tierHeading {
   margin: 0;
   width: 100%;
@@ -62,19 +72,21 @@
   }
 }
 
-/* Phone: one full-width card per row — 2-up is too skinny */
+/* Phone: keep 2-up so ~4–5 cards fit in the viewport */
 @media (max-width: 560px) {
   .cardGrid {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 20px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px 10px;
     width: 100%;
+    max-width: none;
+    margin-inline: 0;
   }
 
   .cardGrid > * {
     width: 100%;
     max-width: none;
     min-width: 0;
+    flex: none;
   }
 }

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -1,0 +1,33 @@
+.root {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.tierSection {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.tierHeading {
+  margin: 0;
+}
+
+.cardGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  width: 100%;
+}
+
+.emptyState,
+.emergingFallback {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  width: 100%;
+}

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -30,9 +30,9 @@
 
 .cardGrid > * {
   flex: 0 0 auto;
-  width: 24%;
-  min-width: 240px;
-  max-width: 340px;
+  width: 28%;
+  min-width: 260px;
+  max-width: 360px;
 }
 
 .emptyState {

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -30,9 +30,9 @@
 
 .cardGrid > * {
   flex: 0 0 auto;
-  width: 20%;
-  min-width: 220px;
-  max-width: 274px;
+  width: 24%;
+  min-width: 240px;
+  max-width: 340px;
 }
 
 .emptyState {
@@ -67,11 +67,11 @@
     max-width: 100%;
   }
 
-  /* Odd total: last card alone — match one column width, centered */
+  /* Odd total: last card alone — slightly larger than half column, centered */
   .cardGrid > *:last-child:nth-child(odd) {
     grid-column: 1 / -1;
     justify-self: center;
-    width: calc((100% - 16px) / 2);
-    max-width: calc((100% - 16px) / 2);
+    width: min(340px, calc((100% - 16px) / 2 + 24px));
+    max-width: min(340px, 70%);
   }
 }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -55,8 +55,8 @@
 }
 
 .compact .content > * {
-  width: min(240px, 100%);
-  min-width: 120px;
+  width: auto;
+  min-width: 0;
   flex: 1 1 0;
 }
 

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -85,6 +85,12 @@
   font-size: var(--body3-font-size);
 }
 
+/* Beat ActionButton `.primary { width: var(--primary-button-width) }` */
+.compact .buttonContainer .compactSearchButton {
+  width: calc(var(--primary-button-width) / 2);
+  max-width: 156px;
+}
+
 .compactSearchButton :global(img) {
   width: 16px;
   height: 16px;
@@ -120,9 +126,9 @@
     align-self: center;
   }
 
+  .compact .buttonContainer .compactSearchButton,
   .compact .content > .buttonContainer > button,
-  .compact .content > button,
-  .compactSearchButton {
+  .compact .content > button {
     width: calc(var(--primary-button-width) / 2);
     max-width: 156px;
   }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -76,6 +76,20 @@
   margin: 0;
 }
 
+.compactSearchButton {
+  width: calc(var(--primary-button-width) / 2);
+  max-width: 156px;
+  min-width: 0;
+  padding: 6px 10px;
+  gap: 6px;
+  font-size: var(--body3-font-size);
+}
+
+.compactSearchButton :global(img) {
+  width: 16px;
+  height: 16px;
+}
+
 @media (max-width: 768px) {
   .compact .content {
     display: grid;
@@ -96,11 +110,14 @@
   .compact .content > .buttonContainer {
     grid-column: 1 / -1;
     width: 100%;
+    display: flex;
+    justify-content: center;
   }
 
   .compact .content > .buttonContainer > button,
   .compact .content > button {
-    width: 100%;
+    width: calc(var(--primary-button-width) / 2);
+    max-width: 156px;
   }
 }
 

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -7,8 +7,8 @@
 
 .compact {
   width: 100%;
-  justify-content: stretch;
-  align-items: stretch;
+  justify-content: center;
+  align-items: center;
 }
 
 .buttonContainer {
@@ -54,11 +54,12 @@
 .compact .content {
   gap: 8px 16px;
   padding: 8px 10px;
-  width: 100%;
-  max-width: none;
+  /* 20% shorter than full banner width */
+  width: 80%;
+  max-width: 80%;
   box-sizing: border-box;
   align-items: center;
-  align-self: stretch;
+  align-self: center;
   flex-wrap: nowrap;
 }
 

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -46,20 +46,54 @@
 }
 
 .compact .content {
-  gap: 10px 24px;
-  padding: 10px 12px;
+  gap: 8px 16px;
+  padding: 8px 10px;
   width: 100%;
   box-sizing: border-box;
+  align-items: center;
+  flex-wrap: nowrap;
 }
 
 .compact .content > * {
-  width: min(220px, 100%);
-  min-width: 140px;
+  width: min(240px, 100%);
+  min-width: 120px;
+  flex: 1 1 0;
 }
 
 .compact .content > button,
 .compact .content > .buttonContainer {
   flex: 0 0 auto;
+  width: auto;
+  min-width: 0;
+  margin: 0;
+}
+
+@media (max-width: 768px) {
+  .compact .content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 8px;
+    padding: 6px 8px;
+    align-items: stretch;
+  }
+
+  .compact .content > * {
+    width: 100%;
+    min-width: 0;
+    flex: unset;
+    margin: 0;
+  }
+
+  .compact .content > button,
+  .compact .content > .buttonContainer {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .compact .content > .buttonContainer > button,
+  .compact .content > button {
+    width: 100%;
+  }
 }
 
 @media (max-width: 480px) {
@@ -68,8 +102,12 @@
     width: 100%;
   }
 
-  .compact .content {
-    gap: 8px;
-    padding: 8px 10px;
+  .compact .content > * {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .compact .content > *[role='combobox'] {
+    margin-left: 0;
   }
 }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -54,9 +54,9 @@
 .compact .content {
   gap: 8px 16px;
   padding: 8px 10px;
-  /* 20% shorter than full banner width */
-  width: 80%;
-  max-width: 80%;
+  /* Prior 80% width + 10% horizontal increase */
+  width: 88%;
+  max-width: 88%;
   box-sizing: border-box;
   align-items: flex-start;
   align-self: center;
@@ -75,6 +75,8 @@
   width: auto;
   min-width: 0;
   margin: 0;
+  /* Keep Search aligned with dropdown inputs, not centered against pill stacks */
+  align-self: flex-start;
 }
 
 .compactSearchButton {

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -13,7 +13,7 @@
 
 .buttonContainer {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 }
 
 .content {
@@ -58,7 +58,7 @@
   width: 80%;
   max-width: 80%;
   box-sizing: border-box;
-  align-items: center;
+  align-items: flex-start;
   align-self: center;
   flex-wrap: nowrap;
 }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -90,32 +90,39 @@
   height: 16px;
 }
 
+/* Phone + narrow tablet: stack fields so chips and placeholders stay readable */
 @media (max-width: 768px) {
   .compact .content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 6px 8px;
-    padding: 6px 8px;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    gap: 10px;
+    padding: 12px;
     align-items: stretch;
   }
 
   .compact .content > * {
     width: 100%;
     min-width: 0;
-    flex: unset;
+    flex: 0 0 auto;
     margin: 0;
+  }
+
+  .compact .content > *[role='combobox'] {
+    margin-left: 0;
   }
 
   .compact .content > button,
   .compact .content > .buttonContainer {
-    grid-column: 1 / -1;
     width: 100%;
     display: flex;
     justify-content: center;
+    align-self: center;
   }
 
   .compact .content > .buttonContainer > button,
-  .compact .content > button {
+  .compact .content > button,
+  .compactSearchButton {
     width: calc(var(--primary-button-width) / 2);
     max-width: 156px;
   }
@@ -125,14 +132,5 @@
   .content > * {
     flex-basis: auto;
     width: 100%;
-  }
-
-  .compact .content > * {
-    width: 100%;
-    min-width: 0;
-  }
-
-  .compact .content > *[role='combobox'] {
-    margin-left: 0;
   }
 }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -5,6 +5,12 @@
   margin: 0;
 }
 
+.compact {
+  width: 100%;
+  justify-content: stretch;
+  align-items: stretch;
+}
+
 .buttonContainer {
   display: flex;
   align-items: flex-end;
@@ -49,8 +55,10 @@
   gap: 8px 16px;
   padding: 8px 10px;
   width: 100%;
+  max-width: none;
   box-sizing: border-box;
   align-items: center;
+  align-self: stretch;
   flex-wrap: nowrap;
 }
 

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -1,0 +1,53 @@
+.container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: flex-end;
+}
+
+.content {
+  width: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px 60px;
+  background-color: var(--GhostWhite);
+  flex-direction: row;
+  align-self: center;
+  border-radius: 8px;
+  box-shadow: 0px 8px 20px 0px #0000001f;
+  padding: 15px;
+}
+
+.content > * {
+  width: 260px;
+  flex: 1;
+  align-self: stretch;
+  justify-content: flex-start;
+}
+
+.content > *[role='combobox'] {
+  margin-left: 5px;
+}
+
+.content > button,
+.content > .buttonContainer {
+  flex: 0 0 116px;
+  margin: auto;
+  align-self: center;
+}
+
+.content > *[role='combobox'] label > * {
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .content > * {
+    flex-basis: auto;
+    width: 100%;
+  }
+}

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -45,9 +45,31 @@
   font-weight: 600;
 }
 
+.compact .content {
+  gap: 10px 24px;
+  padding: 10px 12px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.compact .content > * {
+  width: min(220px, 100%);
+  min-width: 140px;
+}
+
+.compact .content > button,
+.compact .content > .buttonContainer {
+  flex: 0 0 auto;
+}
+
 @media (max-width: 480px) {
   .content > * {
     flex-basis: auto;
     width: 100%;
+  }
+
+  .compact .content {
+    gap: 8px;
+    padding: 8px 10px;
   }
 }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -106,6 +106,8 @@
     gap: 10px;
     padding: 12px;
     align-items: stretch;
+    width: 100%;
+    max-width: 100%;
   }
 
   .compact .content > * {

--- a/src/app/endorsedproviders/[slug]/courses/page.tsx
+++ b/src/app/endorsedproviders/[slug]/courses/page.tsx
@@ -1,0 +1,80 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import ProviderCoursesPlaceholder from '@/app/components/providerSearch/ProviderCoursesPlaceholder';
+import {
+  getEndorsedDisplayNameForSlug,
+  hasPromotedCoursesForSlug,
+  isKnownEndorsedSlug,
+  isLiveEndorsedSlug,
+} from '@/app/components/endorsedProviders/endorsedProviderPageData';
+import type { SearchParams } from '@/app/utilities/featureToggle';
+import { EMPTY_SEARCH_PARAMS } from '@/app/utilities/searchParamsReader';
+import { isProviderSearchDemoEnabled } from '@/app/utilities/providerSearch/buildSearchHref';
+import {
+  PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG,
+  PROVIDER_SEARCH_QUERY,
+} from '@/app/utilities/providerSearch/constants';
+import { HOST_URL } from '@/app/utilities/constants';
+
+type RouteParams = {
+  slug: string;
+};
+
+interface PageProps {
+  params: Promise<RouteParams>;
+  searchParams: Promise<SearchParams>;
+}
+
+function canAccessCoursesPage(slug: string, searchDemo: boolean): boolean {
+  if (!isKnownEndorsedSlug(slug) || !isLiveEndorsedSlug(slug)) {
+    return false;
+  }
+  if (hasPromotedCoursesForSlug(slug)) {
+    return true;
+  }
+  return searchDemo && slug === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG;
+}
+
+export async function generateMetadata({ params, searchParams }: PageProps): Promise<Metadata> {
+  const resolvedParams = await params;
+  const resolvedSearchParams = (await searchParams) ?? EMPTY_SEARCH_PARAMS;
+  const searchDemo = isProviderSearchDemoEnabled(
+    resolvedSearchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
+  );
+  const slug = resolvedParams.slug;
+
+  if (!canAccessCoursesPage(slug, searchDemo)) {
+    return { title: 'Not found', robots: { index: false, follow: false } };
+  }
+
+  const displayName = getEndorsedDisplayNameForSlug(slug) ?? slug;
+  return {
+    title: `Courses | ${displayName}`,
+    description: `Courses from ${displayName} are coming soon.`,
+    robots: { index: false, follow: false },
+    alternates: {
+      canonical: `${HOST_URL}/endorsedproviders/${slug}/courses`,
+    },
+  };
+}
+
+export function generateStaticParams(): RouteParams[] {
+  return [];
+}
+
+export default async function EndorsedProviderCoursesPage({ params, searchParams }: PageProps) {
+  const resolvedParams = await params;
+  const resolvedSearchParams = (await searchParams) ?? EMPTY_SEARCH_PARAMS;
+  const searchDemo = isProviderSearchDemoEnabled(
+    resolvedSearchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
+  );
+  const slug = resolvedParams.slug;
+
+  if (!canAccessCoursesPage(slug, searchDemo)) {
+    notFound();
+  }
+
+  const displayName = getEndorsedDisplayNameForSlug(slug) ?? slug;
+
+  return <ProviderCoursesPlaceholder providerSlug={slug} providerName={displayName} />;
+}

--- a/src/app/interfaces/FormElements.ts
+++ b/src/app/interfaces/FormElements.ts
@@ -88,6 +88,10 @@ export interface DropdownProps<TFieldValues extends FieldValues> {
   showInputAsText?: boolean;
   cols?: FORM_ELEMENT_COL_WIDTH;
   multiple?: boolean;
+  /** When true, selected pills render under the field instead of inside the input. */
+  pillsBelow?: boolean;
+  /** Fires as the searchable input text changes (for draft/partial submit). */
+  onDraftChange?: (draft: string) => void;
   rules?: DefaultRules<TFieldValues>;
   onChange?: (selected: SelectOption['value'][]) => void;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,9 @@ import MetaPixel from './components/article/MetaPixel';
 import DeferredTabNavEmbed from './components/tabnav/DeferredTabNavEmbed';
 import DeferredGoogleAnalytics from './components/analytics/DeferredGoogleAnalytics';
 import DeferredVercelInsights from './components/analytics/DeferredVercelInsights';
+import { isProductionAnalyticsEnabled } from './utilities/analyticsEnv';
+
+const isProductionAnalytics = isProductionAnalyticsEnabled();
 
 const poppins = Poppins({
   subsets: ['latin'],
@@ -93,11 +96,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         </NextAuthProvider>
         <Footer />
         <ToasterWrapper />
-        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' && <MetaPixel />}
-        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' && (
-          <DeferredGoogleAnalytics gaId='G-5YMLVTTK45' />
-        )}
-        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' && <DeferredVercelInsights />}
+        {isProductionAnalytics && <MetaPixel />}
+        {isProductionAnalytics && <DeferredGoogleAnalytics gaId='G-5YMLVTTK45' />}
+        {isProductionAnalytics && <DeferredVercelInsights />}
         <DeferredTabNavEmbed />
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -93,12 +93,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         </NextAuthProvider>
         <Footer />
         <ToasterWrapper />
-        {process.env.NODE_ENV === 'production' && <MetaPixel />}
-        <DeferredGoogleAnalytics
-          gaId='G-5YMLVTTK45'
-          debugMode={process.env.NODE_ENV !== 'production'}
-        />
-        <DeferredVercelInsights />
+        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' && <MetaPixel />}
+        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' && (
+          <DeferredGoogleAnalytics gaId='G-5YMLVTTK45' />
+        )}
+        {process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' && <DeferredVercelInsights />}
         <DeferredTabNavEmbed />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,10 +13,7 @@ import EmergingInstitutions from './components/emergingInstitutions/EmergingInst
 import EndorsedProviders from './components/endorsedProviders/EndorsedProviders';
 import { resolveHomeDemoAccess } from './utilities/demoAccess';
 import type { SearchParams } from './utilities/featureToggle';
-import {
-  loadProviderSearchContext,
-  toDropdownOptions,
-} from './utilities/providerSearch/catalog';
+import { loadProviderSearchContext, toDropdownOptions } from './utilities/providerSearch/catalog';
 import { isProviderSearchDemoEnabled } from './utilities/providerSearch/demoFlag';
 import { PROVIDER_SEARCH_QUERY } from './utilities/providerSearch/constants';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,11 +9,17 @@ import HowItWorks from './components/howItWorks/HowItWorks';
 import dynamic from 'next/dynamic';
 
 import StudentFacts from './components/studentFacts/StudentFacts';
-import isFeatureEnabled from './utilities/featureToggle';
 import EmergingInstitutions from './components/emergingInstitutions/EmergingInstitutions';
 import EndorsedProviders from './components/endorsedProviders/EndorsedProviders';
 import { resolveHomeDemoAccess } from './utilities/demoAccess';
 import type { SearchParams } from './utilities/featureToggle';
+import {
+  getProviderSearchInterestAreaCatalog,
+  getProviderSearchLocationCatalog,
+  toDropdownOptions,
+} from './utilities/providerSearch/catalog';
+import { isProviderSearchDemoEnabled } from './utilities/providerSearch/buildSearchHref';
+import { PROVIDER_SEARCH_QUERY } from './utilities/providerSearch/constants';
 
 const ArticleList = dynamic(() => import('./components/articleList/articleList'), {
   loading: () => null,
@@ -63,8 +69,14 @@ export const metadata: Metadata = createMetadata(META_KEY.HOME, {
 
 export default async function Home({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const resolvedSearchParams = await searchParams;
-  const showSearchBar = isFeatureEnabled(resolvedSearchParams, 'searchBar');
   const demoAccess = resolveHomeDemoAccess(resolvedSearchParams);
+  const searchDemo = isProviderSearchDemoEnabled(
+    resolvedSearchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
+  );
+  const interestAreaOptions = toDropdownOptions(
+    getProviderSearchInterestAreaCatalog({ searchDemo }),
+  );
+  const locationOptions = toDropdownOptions(getProviderSearchLocationCatalog({ searchDemo }));
 
   return (
     <main className={styles.main}>
@@ -74,7 +86,10 @@ export default async function Home({ searchParams }: { searchParams: Promise<Sea
         displayBadges={true}
         showButton={false}
         displayFilter={true}
-        showSearchBar={showSearchBar}
+        showSearchBar={true}
+        interestAreaOptions={interestAreaOptions}
+        locationOptions={locationOptions}
+        searchDemo={searchDemo}
       />
       <StudentFacts />
       <EndorsedProviders demoGuid={demoAccess?.demoGuid} demoSlug={demoAccess?.demoSlug} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,11 +14,10 @@ import EndorsedProviders from './components/endorsedProviders/EndorsedProviders'
 import { resolveHomeDemoAccess } from './utilities/demoAccess';
 import type { SearchParams } from './utilities/featureToggle';
 import {
-  getProviderSearchInterestAreaCatalog,
-  getProviderSearchLocationCatalog,
+  loadProviderSearchContext,
   toDropdownOptions,
 } from './utilities/providerSearch/catalog';
-import { isProviderSearchDemoEnabled } from './utilities/providerSearch/buildSearchHref';
+import { isProviderSearchDemoEnabled } from './utilities/providerSearch/demoFlag';
 import { PROVIDER_SEARCH_QUERY } from './utilities/providerSearch/constants';
 
 const ArticleList = dynamic(() => import('./components/articleList/articleList'), {
@@ -73,10 +72,9 @@ export default async function Home({ searchParams }: { searchParams: Promise<Sea
   const searchDemo = isProviderSearchDemoEnabled(
     resolvedSearchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
   );
-  const interestAreaOptions = toDropdownOptions(
-    getProviderSearchInterestAreaCatalog({ searchDemo }),
-  );
-  const locationOptions = toDropdownOptions(getProviderSearchLocationCatalog({ searchDemo }));
+  const searchContext = loadProviderSearchContext({ searchDemo });
+  const interestAreaOptions = toDropdownOptions(searchContext.interestAreaCatalog);
+  const locationOptions = toDropdownOptions(searchContext.locationCatalog);
 
   return (
     <main className={styles.main}>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,12 +4,7 @@ import { TypographyColorToken } from '@/app/components/typography/typographyColo
 import ProviderStudySearch from '@/app/components/providerSearch/ProviderStudySearch';
 import ProviderSearchResults from '@/app/components/providerSearch/ProviderSearchResults';
 import ProviderSearchResultsTracker from '@/app/components/providerSearch/ProviderSearchResultsTracker';
-import {
-  getProviderSearchInterestAreaCatalog,
-  getProviderSearchLocationCatalog,
-  listSearchableProviders,
-  toDropdownOptions,
-} from '@/app/utilities/providerSearch/catalog';
+import { toDropdownOptions } from '@/app/utilities/providerSearch/catalog';
 import { resolveProviderSearchFilters } from '@/app/utilities/providerSearch/resolveFilters';
 import {
   countProviderSearchResults,
@@ -34,19 +29,16 @@ type SearchPageProps = {
 
 export default async function ProviderSearchPage({ searchParams }: SearchPageProps) {
   const resolved = await searchParams;
-  const { filters, searchDemo } = resolveProviderSearchFilters({
+  const { filters, searchDemo, context } = resolveProviderSearchFilters({
     [PROVIDER_SEARCH_QUERY.INTEREST_AREA]: resolved[PROVIDER_SEARCH_QUERY.INTEREST_AREA],
     [PROVIDER_SEARCH_QUERY.LOCATION]: resolved[PROVIDER_SEARCH_QUERY.LOCATION],
     [PROVIDER_SEARCH_QUERY.SEARCH_DEMO]: resolved[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
   });
 
-  const providers = listSearchableProviders({ searchDemo });
-  const results = searchProvidersByFilters(providers, filters);
+  const results = searchProvidersByFilters(context.providers, filters);
   const totalCount = countProviderSearchResults(results);
-  const interestAreaOptions = toDropdownOptions(
-    getProviderSearchInterestAreaCatalog({ searchDemo }),
-  );
-  const locationOptions = toDropdownOptions(getProviderSearchLocationCatalog({ searchDemo }));
+  const interestAreaOptions = toDropdownOptions(context.interestAreaCatalog);
+  const locationOptions = toDropdownOptions(context.locationCatalog);
   const hasQuery = filters.interestAreas.length > 0 || filters.locations.length > 0;
 
   return (

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -51,17 +51,11 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
 
   return (
     <main className={styles.page}>
-      <header className={styles.header}>
-        <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
-          Find providers
-        </Typography>
-        <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-          Search by area of study and location to explore neuro-inclusive education providers.
-        </Typography>
-      </header>
-
-      <div className={styles.filterWrap}>
+      <section className={styles.searchBanner} aria-label='Provider search'>
+        <div className={styles.searchBannerOverlay} aria-hidden='true' />
         <ProviderStudySearch
+          className={styles.searchBannerForm}
+          compact
           surface='search_page'
           interestAreaOptions={interestAreaOptions}
           locationOptions={locationOptions}
@@ -69,38 +63,49 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
           defaultLocations={filters.locations}
           searchDemo={searchDemo}
         />
-      </div>
+      </section>
 
-      {hasQuery ? (
-        <>
-          <ProviderSearchResultsTracker
-            interestAreas={filters.interestAreas}
-            locations={filters.locations}
-            resultCountTotal={totalCount}
-            countCourseEndorsed={results.course_endorsed.length}
-            countStarredEndorsed={results.starred_endorsed.length}
-            countEndorsed={results.endorsed.length}
-            countEmerging={results.emerging.length}
-          />
-          <Typography
-            variant={TypographyVariant.Body2}
-            color={TypographyColorToken.BondBlack}
-            className={styles.summary}
-          >
-            {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
+      <div className={styles.results}>
+        <header className={styles.header}>
+          <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
+            Find providers
           </Typography>
-          <ProviderSearchResults
-            results={results}
-            filters={filters}
-            searchDemo={searchDemo}
-            totalCount={totalCount}
-          />
-        </>
-      ) : (
-        <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-          Choose an area of study and/or location to see matching providers.
-        </Typography>
-      )}
+          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+            Search by area of study and location to explore neuro-inclusive education providers.
+          </Typography>
+        </header>
+
+        {hasQuery ? (
+          <>
+            <ProviderSearchResultsTracker
+              interestAreas={filters.interestAreas}
+              locations={filters.locations}
+              resultCountTotal={totalCount}
+              countCourseEndorsed={results.course_endorsed.length}
+              countStarredEndorsed={results.starred_endorsed.length}
+              countEndorsed={results.endorsed.length}
+              countEmerging={results.emerging.length}
+            />
+            <Typography
+              variant={TypographyVariant.Body2}
+              color={TypographyColorToken.BondBlack}
+              className={styles.summary}
+            >
+              {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
+            </Typography>
+            <ProviderSearchResults
+              results={results}
+              filters={filters}
+              searchDemo={searchDemo}
+              totalCount={totalCount}
+            />
+          </>
+        ) : (
+          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+            Choose an area of study and/or location to see matching providers.
+          </Typography>
+        )}
+      </div>
     </main>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next';
+import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
+import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
+import ProviderStudySearch from '@/app/components/providerSearch/ProviderStudySearch';
+import ProviderSearchResults from '@/app/components/providerSearch/ProviderSearchResults';
+import ProviderSearchResultsTracker from '@/app/components/providerSearch/ProviderSearchResultsTracker';
+import {
+  getProviderSearchInterestAreaCatalog,
+  getProviderSearchLocationCatalog,
+  listSearchableProviders,
+  toDropdownOptions,
+} from '@/app/utilities/providerSearch/catalog';
+import { resolveProviderSearchFilters } from '@/app/utilities/providerSearch/resolveFilters';
+import {
+  countProviderSearchResults,
+  searchProvidersByFilters,
+} from '@/app/utilities/providerSearch/searchProviders';
+import { PROVIDER_SEARCH_QUERY } from '@/app/utilities/providerSearch/constants';
+import type { SearchParams } from '@/app/utilities/featureToggle';
+import styles from './search.module.css';
+
+export const metadata: Metadata = {
+  title: 'Provider search | Neurodiversity Academy',
+  description: 'Find endorsed and emerging education providers by area of study and location.',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+type SearchPageProps = {
+  searchParams: Promise<SearchParams>;
+};
+
+export default async function ProviderSearchPage({ searchParams }: SearchPageProps) {
+  const resolved = await searchParams;
+  const { filters, searchDemo } = resolveProviderSearchFilters({
+    [PROVIDER_SEARCH_QUERY.INTEREST_AREA]: resolved[PROVIDER_SEARCH_QUERY.INTEREST_AREA],
+    [PROVIDER_SEARCH_QUERY.LOCATION]: resolved[PROVIDER_SEARCH_QUERY.LOCATION],
+    [PROVIDER_SEARCH_QUERY.SEARCH_DEMO]: resolved[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
+  });
+
+  const providers = listSearchableProviders({ searchDemo });
+  const results = searchProvidersByFilters(providers, filters);
+  const totalCount = countProviderSearchResults(results);
+  const interestAreaOptions = toDropdownOptions(
+    getProviderSearchInterestAreaCatalog({ searchDemo }),
+  );
+  const locationOptions = toDropdownOptions(getProviderSearchLocationCatalog({ searchDemo }));
+  const hasQuery = filters.interestAreas.length > 0 || filters.locations.length > 0;
+
+  return (
+    <main className={styles.page}>
+      <header className={styles.header}>
+        <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
+          Find providers
+        </Typography>
+        <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+          Search by area of study and location to explore neuro-inclusive education providers.
+        </Typography>
+      </header>
+
+      <div className={styles.filterWrap}>
+        <ProviderStudySearch
+          surface='search_page'
+          interestAreaOptions={interestAreaOptions}
+          locationOptions={locationOptions}
+          defaultInterestAreas={filters.interestAreas}
+          defaultLocations={filters.locations}
+          searchDemo={searchDemo}
+        />
+      </div>
+
+      {hasQuery ? (
+        <>
+          <ProviderSearchResultsTracker
+            interestAreas={filters.interestAreas}
+            locations={filters.locations}
+            resultCountTotal={totalCount}
+            countCourseEndorsed={results.course_endorsed.length}
+            countStarredEndorsed={results.starred_endorsed.length}
+            countEndorsed={results.endorsed.length}
+            countEmerging={results.emerging.length}
+          />
+          <Typography
+            variant={TypographyVariant.Body2}
+            color={TypographyColorToken.BondBlack}
+            className={styles.summary}
+          >
+            {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
+          </Typography>
+          <ProviderSearchResults
+            results={results}
+            filters={filters}
+            searchDemo={searchDemo}
+            totalCount={totalCount}
+          />
+        </>
+      ) : (
+        <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+          Choose an area of study and/or location to see matching providers.
+        </Typography>
+      )}
+    </main>
+  );
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -8,6 +8,7 @@ import { toDropdownOptions } from '@/app/utilities/providerSearch/catalog';
 import { resolveProviderSearchFilters } from '@/app/utilities/providerSearch/resolveFilters';
 import {
   countProviderSearchResults,
+  countStarredEndorsedResults,
   searchProvidersByFilters,
 } from '@/app/utilities/providerSearch/searchProviders';
 import { PROVIDER_SEARCH_QUERY } from '@/app/utilities/providerSearch/constants';
@@ -72,7 +73,7 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
           locations={filters.locations}
           resultCountTotal={totalCount}
           countCourseEndorsed={results.course_endorsed.length}
-          countStarredEndorsed={results.starred_endorsed.length}
+          countStarredEndorsed={countStarredEndorsedResults(results)}
           countEndorsed={results.endorsed.length}
           countEmerging={results.emerging.length}
         />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -51,29 +51,28 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
 
   return (
     <main className={styles.page}>
-      <div className={styles.intro}>
-        <header className={styles.header}>
-          <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
-            Find providers
-          </Typography>
-          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-            Search by area of study and location to explore neuro-inclusive education providers.
-          </Typography>
-        </header>
-      </div>
-
       <section className={styles.searchBanner} aria-label='Provider search'>
         <div className={styles.searchBannerOverlay} aria-hidden='true' />
-        <ProviderStudySearch
-          className={styles.searchBannerForm}
-          compact
-          surface='search_page'
-          interestAreaOptions={interestAreaOptions}
-          locationOptions={locationOptions}
-          defaultInterestAreas={filters.interestAreas}
-          defaultLocations={filters.locations}
-          searchDemo={searchDemo}
-        />
+        <div className={styles.searchBannerInner}>
+          <header className={styles.header}>
+            <Typography variant={TypographyVariant.H1} color={TypographyColorToken.GhostWhite}>
+              Find providers
+            </Typography>
+            <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.GhostWhite}>
+              Search by area of study and location to explore neuro-inclusive education providers.
+            </Typography>
+          </header>
+          <ProviderStudySearch
+            className={styles.searchBannerForm}
+            compact
+            surface='search_page'
+            interestAreaOptions={interestAreaOptions}
+            locationOptions={locationOptions}
+            defaultInterestAreas={filters.interestAreas}
+            defaultLocations={filters.locations}
+            searchDemo={searchDemo}
+          />
+        </div>
       </section>
 
       <div className={styles.results}>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -39,7 +39,6 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
   const totalCount = countProviderSearchResults(results);
   const interestAreaOptions = toDropdownOptions(context.interestAreaCatalog);
   const locationOptions = toDropdownOptions(context.locationCatalog);
-  const hasQuery = filters.interestAreas.length > 0 || filters.locations.length > 0;
 
   return (
     <main className={styles.page}>
@@ -68,36 +67,28 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
       </section>
 
       <div className={styles.results}>
-        {hasQuery ? (
-          <>
-            <ProviderSearchResultsTracker
-              interestAreas={filters.interestAreas}
-              locations={filters.locations}
-              resultCountTotal={totalCount}
-              countCourseEndorsed={results.course_endorsed.length}
-              countStarredEndorsed={results.starred_endorsed.length}
-              countEndorsed={results.endorsed.length}
-              countEmerging={results.emerging.length}
-            />
-            <Typography
-              variant={TypographyVariant.Body2}
-              color={TypographyColorToken.BondBlack}
-              className={styles.summary}
-            >
-              {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
-            </Typography>
-            <ProviderSearchResults
-              results={results}
-              filters={filters}
-              searchDemo={searchDemo}
-              totalCount={totalCount}
-            />
-          </>
-        ) : (
-          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-            Choose an area of study and/or location to see matching providers.
-          </Typography>
-        )}
+        <ProviderSearchResultsTracker
+          interestAreas={filters.interestAreas}
+          locations={filters.locations}
+          resultCountTotal={totalCount}
+          countCourseEndorsed={results.course_endorsed.length}
+          countStarredEndorsed={results.starred_endorsed.length}
+          countEndorsed={results.endorsed.length}
+          countEmerging={results.emerging.length}
+        />
+        <Typography
+          variant={TypographyVariant.Body2}
+          color={TypographyColorToken.BondBlack}
+          className={styles.summary}
+        >
+          {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
+        </Typography>
+        <ProviderSearchResults
+          results={results}
+          filters={filters}
+          searchDemo={searchDemo}
+          totalCount={totalCount}
+        />
       </div>
     </main>
   );

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -77,13 +77,15 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
           countEndorsed={results.endorsed.length}
           countEmerging={results.emerging.length}
         />
-        <Typography
-          variant={TypographyVariant.Body2}
-          color={TypographyColorToken.BondBlack}
-          className={styles.summary}
-        >
-          {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
-        </Typography>
+        <div className={styles.resultsSummary}>
+          <Typography
+            variant={TypographyVariant.Body2}
+            color={TypographyColorToken.BondBlack}
+            className={styles.summary}
+          >
+            {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
+          </Typography>
+        </div>
         <ProviderSearchResults
           results={results}
           filters={filters}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -51,6 +51,17 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
 
   return (
     <main className={styles.page}>
+      <div className={styles.intro}>
+        <header className={styles.header}>
+          <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
+            Find providers
+          </Typography>
+          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
+            Search by area of study and location to explore neuro-inclusive education providers.
+          </Typography>
+        </header>
+      </div>
+
       <section className={styles.searchBanner} aria-label='Provider search'>
         <div className={styles.searchBannerOverlay} aria-hidden='true' />
         <ProviderStudySearch
@@ -66,15 +77,6 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
       </section>
 
       <div className={styles.results}>
-        <header className={styles.header}>
-          <Typography variant={TypographyVariant.H1} color={TypographyColorToken.BondBlack}>
-            Find providers
-          </Typography>
-          <Typography variant={TypographyVariant.Body1} color={TypographyColorToken.BondBlack}>
-            Search by area of study and location to explore neuro-inclusive education providers.
-          </Typography>
-        </header>
-
         {hasQuery ? (
           <>
             <ProviderSearchResultsTracker

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -25,6 +25,20 @@
   background-repeat: no-repeat;
 }
 
+@media (max-width: 768px) {
+  .searchBanner {
+    padding: 1.25rem 4vw 1rem;
+  }
+
+  .searchBannerInner {
+    gap: 0.85rem;
+  }
+
+  .results {
+    padding: 1rem 4vw 2.5rem;
+  }
+}
+
 @media (min-width: 769px) {
   .searchBanner {
     background-image: url('/images/hero-desktop.webp');

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -1,22 +1,71 @@
 .page {
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem 5vw 3rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  align-items: stretch;
+  box-sizing: border-box;
+  background: var(--GhostWhiteVariant);
+  min-height: 100vh;
+}
+
+.searchBanner {
+  position: relative;
+  width: 100%;
+  max-height: 15vh;
+  min-height: 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 5vw;
+  box-sizing: border-box;
+  /* Allow dropdown menus to escape the compact banner */
+  overflow: visible;
+  background-color: #4a2a8a;
+  background-image: url('/images/hero-mobile.webp');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+@media (min-width: 769px) {
+  .searchBanner {
+    background-image: url('/images/hero-desktop.webp');
+  }
+}
+
+.searchBannerOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, #6600cc 40%, transparent),
+    color-mix(in srgb, #4a4aff 40%, transparent)
+  );
+}
+
+.searchBannerForm {
+  position: relative;
+  z-index: 2;
+  width: min(100%, 1100px);
+}
+
+.results {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 5vw 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
   box-sizing: border-box;
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-}
-
-.filterWrap {
-  width: 100%;
+  gap: 0.35rem;
 }
 
 .summary {

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -36,7 +36,8 @@
   }
 
   .results {
-    padding: 1rem 4vw 2.5rem;
+    padding: 0.85rem 4vw 2rem;
+    gap: 0.85rem;
   }
 }
 

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -12,11 +12,11 @@
   position: relative;
   width: 100%;
   max-height: 15vh;
-  min-height: 96px;
+  min-height: 64px;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem 5vw;
+  padding: 0.5rem 5vw;
   box-sizing: border-box;
   /* Allow dropdown menus to escape the compact banner */
   overflow: visible;

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -15,7 +15,7 @@
   min-height: 64px;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: stretch;
   padding: 0.5rem 5vw;
   box-sizing: border-box;
   /* Allow dropdown menus to escape the compact banner */

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -8,25 +8,15 @@
   min-height: 100vh;
 }
 
-.intro {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.5rem 5vw 1rem;
-  box-sizing: border-box;
-}
-
 .searchBanner {
   position: relative;
   width: 100%;
-  max-height: 15vh;
-  min-height: 64px;
   display: flex;
   align-items: center;
   justify-content: stretch;
-  padding: 0.5rem 5vw;
+  padding: 1.5rem 5vw 1.25rem;
   box-sizing: border-box;
-  /* Allow dropdown menus to escape the compact banner */
+  /* Allow dropdown menus to escape the banner */
   overflow: visible;
   background-color: #4a2a8a;
   background-image: url('/images/hero-mobile.webp');
@@ -53,10 +43,26 @@
   );
 }
 
-.searchBannerForm {
+.searchBannerInner {
   position: relative;
   z-index: 2;
   width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-sizing: border-box;
+}
+
+.searchBannerForm {
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
 .results {
@@ -68,12 +74,6 @@
   flex-direction: column;
   gap: 1.25rem;
   box-sizing: border-box;
-}
-
-.header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
 }
 
 .summary {

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -1,0 +1,24 @@
+.page {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 5vw 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  box-sizing: border-box;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filterWrap {
+  width: 100%;
+}
+
+.summary {
+  margin: 0;
+}

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -10,13 +10,14 @@
 
 .searchBanner {
   position: relative;
+  z-index: 5;
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: stretch;
   padding: 1.5rem 5vw 1.25rem;
   box-sizing: border-box;
-  /* Allow dropdown menus to escape the banner */
+  /* Allow dropdown menus to escape the banner above results cards */
   overflow: visible;
   background-color: #4a2a8a;
   background-image: url('/images/hero-mobile.webp');
@@ -80,6 +81,8 @@
 }
 
 .results {
+  position: relative;
+  z-index: 1;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -48,7 +48,7 @@
 .searchBannerForm {
   position: relative;
   z-index: 2;
-  width: min(100%, 1100px);
+  width: 100%;
 }
 
 .results {

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -26,21 +26,6 @@
   background-repeat: no-repeat;
 }
 
-@media (max-width: 768px) {
-  .searchBanner {
-    padding: 1.25rem 4vw 1rem;
-  }
-
-  .searchBannerInner {
-    gap: 0.85rem;
-  }
-
-  .results {
-    padding: 0.85rem 4vw 2rem;
-    gap: 0.85rem;
-  }
-}
-
 @media (min-width: 769px) {
   .searchBanner {
     background-image: url('/images/hero-desktop.webp');
@@ -85,15 +70,41 @@
   position: relative;
   z-index: 1;
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.25rem 5vw 3rem;
+  margin: 0;
+  padding: 1.25rem 0 0;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
+  box-sizing: border-box;
+}
+
+.resultsSummary {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 5vw;
   box-sizing: border-box;
 }
 
 .summary {
   margin: 0;
+}
+
+@media (max-width: 768px) {
+  .searchBanner {
+    padding: 1.25rem 4vw 1rem;
+  }
+
+  .searchBannerInner {
+    gap: 0.85rem;
+  }
+
+  .results {
+    padding: 0.85rem 0 0;
+    gap: 0.75rem;
+  }
+
+  .resultsSummary {
+    padding: 0 4vw;
+  }
 }

--- a/src/app/search/search.module.css
+++ b/src/app/search/search.module.css
@@ -8,6 +8,14 @@
   min-height: 100vh;
 }
 
+.intro {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem 5vw 1rem;
+  box-sizing: border-box;
+}
+
 .searchBanner {
   position: relative;
   width: 100%;
@@ -55,7 +63,7 @@
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 1.5rem 5vw 3rem;
+  padding: 1.25rem 5vw 3rem;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;

--- a/src/app/utilities/__tests__/analyticsEnv.test.ts
+++ b/src/app/utilities/__tests__/analyticsEnv.test.ts
@@ -1,0 +1,29 @@
+import { isProductionAnalyticsEnabled } from '../analyticsEnv';
+
+describe('isProductionAnalyticsEnabled', () => {
+  const original = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_VERCEL_ENV;
+    } else {
+      process.env.NEXT_PUBLIC_VERCEL_ENV = original;
+    }
+  });
+
+  it('is true only for Vercel production', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
+    expect(isProductionAnalyticsEnabled()).toBe(true);
+  });
+
+  it('is false for preview, development, and unset', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    expect(isProductionAnalyticsEnabled()).toBe(false);
+
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'development';
+    expect(isProductionAnalyticsEnabled()).toBe(false);
+
+    delete process.env.NEXT_PUBLIC_VERCEL_ENV;
+    expect(isProductionAnalyticsEnabled()).toBe(false);
+  });
+});

--- a/src/app/utilities/__tests__/gaTracking.test.ts
+++ b/src/app/utilities/__tests__/gaTracking.test.ts
@@ -18,13 +18,31 @@ import { CONVERSION_FORM_NAMES, GA_EVENTS } from '@/app/utilities/constants';
 import { installGtagMock, installTestPagePath } from '@/app/utilities/__tests__/gaTestHelpers';
 
 describe('gaTracking', () => {
+  const originalVercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
   beforeEach(() => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
     installTestPagePath('/endorsedproviders/collarts');
+  });
+
+  afterEach(() => {
+    if (originalVercelEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_VERCEL_ENV;
+    } else {
+      process.env.NEXT_PUBLIC_VERCEL_ENV = originalVercelEnv;
+    }
   });
 
   it('sendGaEvent is a no-op when gtag is missing', () => {
     (window as unknown as { gtag: null }).gtag = null;
     expect(() => sendGaEvent('test_event', { [GA_PARAM.CATEGORY]: 'Test' })).not.toThrow();
+  });
+
+  it('sendGaEvent is a no-op outside Vercel production', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    const mockGtag = installGtagMock();
+    sendGaEvent('test_event', { [GA_PARAM.CATEGORY]: 'Test' });
+    expect(mockGtag).not.toHaveBeenCalled();
   });
 
   it('buildProviderScopedParams includes slug and page path', () => {

--- a/src/app/utilities/analyticsEnv.ts
+++ b/src/app/utilities/analyticsEnv.ts
@@ -1,0 +1,8 @@
+/**
+ * Client/server-safe gate for product analytics.
+ * On Vercel, only the Production environment is enabled (not Preview/Development).
+ * Local and other hosts never emit analytics.
+ */
+export function isProductionAnalyticsEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_VERCEL_ENV === 'production';
+}

--- a/src/app/utilities/gaTracking.ts
+++ b/src/app/utilities/gaTracking.ts
@@ -1,3 +1,4 @@
+import { isProductionAnalyticsEnabled } from '@/app/utilities/analyticsEnv';
 import { CONVERSION_FORM_NAMES, GA_EVENTS } from '@/app/utilities/constants';
 
 export const GA_EVENT_COMMAND = 'event' as const;
@@ -61,6 +62,9 @@ export function buildProviderScopedParams(
 }
 
 export function sendGaEvent(eventName: string, params: GaEventParams): void {
+  if (!isProductionAnalyticsEnabled()) {
+    return;
+  }
   const gtag = resolveGtag();
   if (gtag === null) {
     return;

--- a/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import {
+  buildProviderSearchResultClickAnalytics,
   queueProviderSearchGaEvent,
   resetProviderSearchGaQueueForTests,
   trackProviderCoursesPlaceholderView,
@@ -131,5 +132,30 @@ describe('providerSearchGa queue', () => {
     });
 
     expect(mockGtag).not.toHaveBeenCalled();
+  });
+
+  it('builds card CTA analytics with the same result-click schema', () => {
+    expect(
+      buildProviderSearchResultClickAnalytics({
+        providerSlug: 'collarts',
+        providerTier: 'course_endorsed',
+        resultPosition: 2,
+        interestAreas: ['Music'],
+        locations: ['Sydney'],
+        destinationUrl: '/endorsedproviders/collarts/courses',
+      }),
+    ).toEqual({
+      eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
+      category: PROVIDER_SEARCH_GA.resultClick.category,
+      params: {
+        category: PROVIDER_SEARCH_GA.resultClick.category,
+        provider_slug: 'collarts',
+        provider_tier: 'course_endorsed',
+        result_position: 2,
+        interest_areas: 'Music',
+        locations: 'Sydney',
+        destination_url: '/endorsedproviders/collarts/courses',
+      },
+    });
   });
 });

--- a/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  queueProviderSearchGaEvent,
+  resetProviderSearchGaQueueForTests,
+  trackProviderSearchSubmit,
+} from '../providerSearchGa';
+import { PROVIDER_SEARCH_GA } from '../constants';
+import { installGtagMock, type GtagTestWindow } from '@/app/utilities/__tests__/gaTestHelpers';
+
+describe('providerSearchGa queue', () => {
+  beforeEach(() => {
+    resetProviderSearchGaQueueForTests();
+    (window as unknown as GtagTestWindow).gtag = null;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetProviderSearchGaQueueForTests();
+    jest.useRealTimers();
+  });
+
+  it('queues events until gtag is available then flushes', () => {
+    trackProviderSearchSubmit({
+      surface: 'homepage',
+      interestAreas: ['Music'],
+      locations: ['Sydney'],
+    });
+
+    expect((window as unknown as GtagTestWindow).gtag).toBeNull();
+
+    const mockGtag = installGtagMock();
+    jest.advanceTimersByTime(300);
+
+    expect(mockGtag).toHaveBeenCalledWith(
+      'event',
+      PROVIDER_SEARCH_GA.submit.eventName,
+      expect.objectContaining({
+        category: PROVIDER_SEARCH_GA.submit.category,
+        surface: 'homepage',
+        interest_areas: 'Music',
+        locations: 'Sydney',
+      }),
+    );
+  });
+
+  it('sends immediately when gtag already exists', () => {
+    const mockGtag = installGtagMock();
+    queueProviderSearchGaEvent('custom_event', { category: 'ProviderSearch', foo: 'bar' });
+    expect(mockGtag).toHaveBeenCalledWith(
+      'event',
+      'custom_event',
+      expect.objectContaining({ foo: 'bar' }),
+    );
+  });
+});

--- a/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
@@ -4,6 +4,9 @@
 import {
   queueProviderSearchGaEvent,
   resetProviderSearchGaQueueForTests,
+  trackProviderCoursesPlaceholderView,
+  trackProviderSearchResultClick,
+  trackProviderSearchResultsView,
   trackProviderSearchSubmit,
 } from '../providerSearchGa';
 import { PROVIDER_SEARCH_GA } from '../constants';
@@ -53,5 +56,59 @@ describe('providerSearchGa queue', () => {
       'custom_event',
       expect.objectContaining({ foo: 'bar' }),
     );
+  });
+
+  it('tracks results view, result click, and placeholder view', () => {
+    const mockGtag = installGtagMock();
+
+    trackProviderSearchResultsView({
+      interestAreas: ['Music'],
+      locations: ['Sydney'],
+      resultCountTotal: 3,
+      countCourseEndorsed: 1,
+      countStarredEndorsed: 1,
+      countEndorsed: 1,
+      countEmerging: 0,
+      hasResults: true,
+    });
+    trackProviderSearchResultClick({
+      providerSlug: 'collarts',
+      providerTier: 'course_endorsed',
+      resultPosition: 1,
+      interestAreas: ['Music'],
+      locations: ['Sydney'],
+      destinationUrl: '/endorsedproviders/collarts/courses',
+    });
+    trackProviderCoursesPlaceholderView('collarts');
+
+    expect(mockGtag).toHaveBeenCalledWith(
+      'event',
+      PROVIDER_SEARCH_GA.resultsView.eventName,
+      expect.objectContaining({ result_count_total: 3, has_results: true }),
+    );
+    expect(mockGtag).toHaveBeenCalledWith(
+      'event',
+      PROVIDER_SEARCH_GA.resultClick.eventName,
+      expect.objectContaining({
+        provider_slug: 'collarts',
+        provider_tier: 'course_endorsed',
+        result_position: 1,
+      }),
+    );
+    expect(mockGtag).toHaveBeenCalledWith(
+      'event',
+      PROVIDER_SEARCH_GA.coursesPlaceholderView.eventName,
+      expect.objectContaining({ provider_slug: 'collarts' }),
+    );
+  });
+
+  it('stops flush loop after max attempts when gtag never appears', () => {
+    trackProviderSearchSubmit({
+      surface: 'search_page',
+      interestAreas: ['Nursing'],
+      locations: [],
+    });
+    jest.advanceTimersByTime(250 * 45);
+    expect((window as unknown as GtagTestWindow).gtag).toBeNull();
   });
 });

--- a/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
@@ -13,7 +13,10 @@ import { PROVIDER_SEARCH_GA } from '../constants';
 import { installGtagMock, type GtagTestWindow } from '@/app/utilities/__tests__/gaTestHelpers';
 
 describe('providerSearchGa queue', () => {
+  const originalVercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
   beforeEach(() => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
     resetProviderSearchGaQueueForTests();
     (window as unknown as GtagTestWindow).gtag = null;
     jest.useFakeTimers();
@@ -22,6 +25,11 @@ describe('providerSearchGa queue', () => {
   afterEach(() => {
     resetProviderSearchGaQueueForTests();
     jest.useRealTimers();
+    if (originalVercelEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_VERCEL_ENV;
+    } else {
+      process.env.NEXT_PUBLIC_VERCEL_ENV = originalVercelEnv;
+    }
   });
 
   it('queues events until gtag is available then flushes', () => {
@@ -110,5 +118,18 @@ describe('providerSearchGa queue', () => {
     });
     jest.advanceTimersByTime(250 * 45);
     expect((window as unknown as GtagTestWindow).gtag).toBeNull();
+  });
+
+  it('does not queue or send events outside Vercel production', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    const mockGtag = installGtagMock();
+
+    trackProviderSearchSubmit({
+      surface: 'homepage',
+      interestAreas: ['Music'],
+      locations: [],
+    });
+
+    expect(mockGtag).not.toHaveBeenCalled();
   });
 });

--- a/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/providerSearchGa.test.ts
@@ -3,6 +3,7 @@
  */
 import {
   buildProviderSearchResultClickAnalytics,
+  isProviderSearchGaFlushLoopActiveForTests,
   queueProviderSearchGaEvent,
   resetProviderSearchGaQueueForTests,
   trackProviderCoursesPlaceholderView,
@@ -41,6 +42,7 @@ describe('providerSearchGa queue', () => {
     });
 
     expect((window as unknown as GtagTestWindow).gtag).toBeNull();
+    expect(isProviderSearchGaFlushLoopActiveForTests()).toBe(true);
 
     const mockGtag = installGtagMock();
     jest.advanceTimersByTime(300);
@@ -55,6 +57,7 @@ describe('providerSearchGa queue', () => {
         locations: 'Sydney',
       }),
     );
+    expect(isProviderSearchGaFlushLoopActiveForTests()).toBe(false);
   });
 
   it('sends immediately when gtag already exists', () => {
@@ -65,6 +68,7 @@ describe('providerSearchGa queue', () => {
       'custom_event',
       expect.objectContaining({ foo: 'bar' }),
     );
+    expect(isProviderSearchGaFlushLoopActiveForTests()).toBe(false);
   });
 
   it('tracks results view, result click, and placeholder view', () => {
@@ -117,8 +121,14 @@ describe('providerSearchGa queue', () => {
       interestAreas: ['Nursing'],
       locations: [],
     });
-    jest.advanceTimersByTime(250 * 45);
-    expect((window as unknown as GtagTestWindow).gtag).toBeNull();
+    expect(isProviderSearchGaFlushLoopActiveForTests()).toBe(true);
+
+    jest.advanceTimersByTime(250 * 40);
+    expect(isProviderSearchGaFlushLoopActiveForTests()).toBe(false);
+
+    const lateGtag = installGtagMock();
+    jest.advanceTimersByTime(1000);
+    expect(lateGtag).not.toHaveBeenCalled();
   });
 
   it('does not queue or send events outside Vercel production', () => {
@@ -132,6 +142,7 @@ describe('providerSearchGa queue', () => {
     });
 
     expect(mockGtag).not.toHaveBeenCalled();
+    expect(isProviderSearchGaFlushLoopActiveForTests()).toBe(false);
   });
 
   it('builds card CTA analytics with the same result-click schema', () => {

--- a/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
@@ -1,0 +1,21 @@
+import { resolveProviderSearchFilters } from '../resolveFilters';
+
+describe('resolveProviderSearchFilters', () => {
+  it('keeps only catalog values and detects searchDemo', () => {
+    const { filters, searchDemo } = resolveProviderSearchFilters({
+      InterestArea: ['Music', 'NotARealArea'],
+      Location: ['Sydney', 'Atlantis'],
+      searchDemo: '1',
+    });
+
+    expect(searchDemo).toBe(true);
+    expect(filters.interestAreas).toEqual(['Music']);
+    expect(filters.locations).toEqual(['Sydney']);
+  });
+
+  it('returns empty filters for missing params', () => {
+    const { filters, searchDemo } = resolveProviderSearchFilters({});
+    expect(searchDemo).toBe(false);
+    expect(filters).toEqual({ interestAreas: [], locations: [] });
+  });
+});

--- a/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
@@ -1,7 +1,7 @@
 import { resolveProviderSearchFilters } from '../resolveFilters';
 
 describe('resolveProviderSearchFilters', () => {
-  it('keeps catalog values, free-text partial queries, and detects searchDemo', () => {
+  it('expands partial queries onto catalog labels and detects searchDemo', () => {
     const { filters, searchDemo } = resolveProviderSearchFilters({
       InterestArea: ['Music', 'digital', 'x'],
       Location: ['Sydney', 'pen'],
@@ -9,9 +9,13 @@ describe('resolveProviderSearchFilters', () => {
     });
 
     expect(searchDemo).toBe(true);
-    // Free-text partial queries are kept; tokens shorter than 2 chars are dropped.
-    expect(filters.interestAreas).toEqual(['digital', 'Music']);
-    expect(filters.locations).toEqual(['pen', 'Sydney']);
+    // "digital" expands to catalog study areas; short tokens are dropped.
+    expect(filters.interestAreas).toEqual(
+      expect.arrayContaining(['Digital Skills', 'Digital Technology', 'Music']),
+    );
+    expect(filters.interestAreas).not.toContain('digital');
+    expect(filters.locations).toEqual(expect.arrayContaining(['Penrith', 'Sydney']));
+    expect(filters.locations).not.toContain('pen');
   });
 
   it('returns empty filters for missing params', () => {

--- a/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
@@ -2,20 +2,37 @@ import { resolveProviderSearchFilters } from '../resolveFilters';
 
 describe('resolveProviderSearchFilters', () => {
   it('expands partial queries onto catalog labels and detects searchDemo', () => {
-    const { filters, searchDemo } = resolveProviderSearchFilters({
+    const { filters, searchDemo, context } = resolveProviderSearchFilters({
       InterestArea: ['Music', 'digital', 'x'],
       Location: ['Sydney', 'pen'],
       searchDemo: '1',
     });
 
     expect(searchDemo).toBe(true);
+    expect(context.searchDemo).toBe(true);
+    expect(context.providers.some((provider) => provider.slug === 'collarts')).toBe(true);
+
     // "digital" expands to catalog study areas; short tokens are dropped.
     expect(filters.interestAreas).toEqual(
       expect.arrayContaining(['Digital Skills', 'Digital Technology', 'Music']),
     );
     expect(filters.interestAreas).not.toContain('digital');
+    expect(filters.interestAreas).not.toContain('x');
     expect(filters.locations).toEqual(expect.arrayContaining(['Penrith', 'Sydney']));
     expect(filters.locations).not.toContain('pen');
+
+    // Expanded filters must actually retrieve matching providers.
+    const digitalProviders = context.providers.filter((provider) =>
+      provider.interestAreas.some((area) =>
+        filters.interestAreas.includes(area),
+      ),
+    );
+    expect(digitalProviders.length).toBeGreaterThan(0);
+    expect(
+      digitalProviders.every((provider) =>
+        provider.interestAreas.some((area) => area === 'Digital Skills' || area === 'Digital Technology' || area === 'Music'),
+      ),
+    ).toBe(true);
   });
 
   it('returns empty filters for missing params', () => {

--- a/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
@@ -23,14 +23,14 @@ describe('resolveProviderSearchFilters', () => {
 
     // Expanded filters must actually retrieve matching providers.
     const digitalProviders = context.providers.filter((provider) =>
-      provider.interestAreas.some((area) =>
-        filters.interestAreas.includes(area),
-      ),
+      provider.interestAreas.some((area) => filters.interestAreas.includes(area)),
     );
     expect(digitalProviders.length).toBeGreaterThan(0);
     expect(
       digitalProviders.every((provider) =>
-        provider.interestAreas.some((area) => area === 'Digital Skills' || area === 'Digital Technology' || area === 'Music'),
+        provider.interestAreas.some(
+          (area) => area === 'Digital Skills' || area === 'Digital Technology' || area === 'Music',
+        ),
       ),
     ).toBe(true);
   });

--- a/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
@@ -1,16 +1,17 @@
 import { resolveProviderSearchFilters } from '../resolveFilters';
 
 describe('resolveProviderSearchFilters', () => {
-  it('keeps only catalog values and detects searchDemo', () => {
+  it('keeps catalog values, free-text partial queries, and detects searchDemo', () => {
     const { filters, searchDemo } = resolveProviderSearchFilters({
-      InterestArea: ['Music', 'NotARealArea'],
-      Location: ['Sydney', 'Atlantis'],
+      InterestArea: ['Music', 'digital', 'x'],
+      Location: ['Sydney', 'pen'],
       searchDemo: '1',
     });
 
     expect(searchDemo).toBe(true);
-    expect(filters.interestAreas).toEqual(['Music']);
-    expect(filters.locations).toEqual(['Sydney']);
+    // Free-text partial queries are kept; tokens shorter than 2 chars are dropped.
+    expect(filters.interestAreas).toEqual(['digital', 'Music']);
+    expect(filters.locations).toEqual(['pen', 'Sydney']);
   });
 
   it('returns empty filters for missing params', () => {

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -88,8 +88,17 @@ describe('provider search matching', () => {
       locations: ['Sydney', 'QLD'],
     });
     expect(results.course_endorsed.map((p) => p.slug)).toEqual(['collarts']);
-    expect(results.starred_endorsed.map((p) => p.slug)).toEqual(['nepean-community-college']);
+    expect(results.endorsed.map((p) => p.slug)).toEqual(['nepean-community-college']);
     expect(results.emerging.map((p) => p.slug)).toEqual(['jazz-music-institute']);
+  });
+
+  it('places certified endorsed providers first within the endorsed list', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: [],
+      locations: ['Sydney', 'Perth'],
+    });
+    expect(results.endorsed.map((p) => p.slug)).toEqual(['nepean-community-college', 'hsh']);
+    expect(results.endorsed[0]?.ndaCertified).toBe(true);
   });
 
   it('requires AND when both area and location are selected', () => {
@@ -127,7 +136,7 @@ describe('provider search matching', () => {
     expect(results.endorsed.map((p) => p.name)).toEqual(['AAA Provider', 'Health Science Hub']);
   });
 
-  it('classifies tiers with course-endorsed winning over ndaCertified', () => {
+  it('classifies course-endorsed over plain endorsed; certified stays endorsed', () => {
     expect(
       classifyProviderSearchTier(
         makeProvider({
@@ -148,7 +157,7 @@ describe('provider search matching', () => {
           ndaCertified: true,
         }),
       ),
-    ).toBe('starred_endorsed');
+    ).toBe('endorsed');
   });
 
   it('partial-matches tokens for catalog expansion and provider matching', () => {

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -1,0 +1,222 @@
+import {
+  classifyProviderSearchTier,
+  countProviderSearchResults,
+  matchesProviderSearchFilters,
+  searchProvidersByFilters,
+} from '../searchProviders';
+import type { ProviderSearchRecord } from '../constants';
+import {
+  filterToKnownCatalogValues,
+  parseMultiQueryParam,
+  uniqueSortedStrings,
+} from '../normalize';
+import {
+  buildEndorsedCoursesHref,
+  buildProviderSearchHref,
+  isProviderSearchDemoEnabled,
+} from '../buildSearchHref';
+import {
+  getProviderSearchInterestAreaCatalog,
+  getProviderSearchLocationCatalog,
+  listSearchableProviders,
+} from '../catalog';
+
+function makeProvider(
+  overrides: Partial<ProviderSearchRecord> & Pick<ProviderSearchRecord, 'slug' | 'name' | 'kind'>,
+): ProviderSearchRecord {
+  return {
+    interestAreas: [],
+    locations: [],
+    ndaCertified: false,
+    hasPromotedCourses: false,
+    ...overrides,
+  };
+}
+
+describe('provider search matching', () => {
+  const providers: ProviderSearchRecord[] = [
+    makeProvider({
+      kind: 'endorsed',
+      slug: 'collarts',
+      name: 'Collarts',
+      interestAreas: ['Music', 'Design'],
+      locations: ['Melbourne', 'Sydney'],
+      hasPromotedCourses: true,
+    }),
+    makeProvider({
+      kind: 'endorsed',
+      slug: 'nepean-community-college',
+      name: 'Nepean Community College',
+      locations: ['Penrith', 'Sydney', 'NSW'],
+      ndaCertified: true,
+    }),
+    makeProvider({
+      kind: 'endorsed',
+      slug: 'hsh',
+      name: 'Health Science Hub',
+      interestAreas: ['Nursing'],
+      locations: ['Perth'],
+    }),
+    makeProvider({
+      kind: 'emerging',
+      slug: 'jazz-music-institute',
+      name: 'Jazz Music Institute',
+      interestAreas: ['Music'],
+      locations: ['QLD'],
+      emergingState: 'QLD',
+    }),
+  ];
+
+  it('matches area-only with OR within field', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: ['Music', 'Nursing'],
+      locations: [],
+    });
+    expect(results.course_endorsed.map((p) => p.slug)).toEqual(['collarts']);
+    expect(results.endorsed.map((p) => p.slug)).toEqual(['hsh']);
+    expect(results.emerging.map((p) => p.slug)).toEqual(['jazz-music-institute']);
+  });
+
+  it('matches location-only including emerging state', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: [],
+      locations: ['Sydney', 'QLD'],
+    });
+    expect(results.course_endorsed.map((p) => p.slug)).toEqual(['collarts']);
+    expect(results.starred_endorsed.map((p) => p.slug)).toEqual(['nepean-community-college']);
+    expect(results.emerging.map((p) => p.slug)).toEqual(['jazz-music-institute']);
+  });
+
+  it('requires AND when both area and location are selected', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: ['Music'],
+      locations: ['Melbourne'],
+    });
+    expect(results.course_endorsed.map((p) => p.slug)).toEqual(['collarts']);
+    expect(results.emerging).toEqual([]);
+  });
+
+  it('returns empty results when no filters selected', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: [],
+      locations: [],
+    });
+    expect(countProviderSearchResults(results)).toBe(0);
+  });
+
+  it('sorts alphabetically within a tier', () => {
+    const withExtra = [
+      ...providers,
+      makeProvider({
+        kind: 'endorsed',
+        slug: 'aaa-provider',
+        name: 'AAA Provider',
+        interestAreas: ['Nursing'],
+        locations: ['Perth'],
+      }),
+    ];
+    const results = searchProvidersByFilters(withExtra, {
+      interestAreas: ['Nursing'],
+      locations: [],
+    });
+    expect(results.endorsed.map((p) => p.name)).toEqual(['AAA Provider', 'Health Science Hub']);
+  });
+
+  it('classifies tiers with course-endorsed winning over ndaCertified', () => {
+    expect(
+      classifyProviderSearchTier(
+        makeProvider({
+          kind: 'endorsed',
+          slug: 'x',
+          name: 'X',
+          ndaCertified: true,
+          hasPromotedCourses: true,
+        }),
+      ),
+    ).toBe('course_endorsed');
+    expect(
+      classifyProviderSearchTier(
+        makeProvider({
+          kind: 'endorsed',
+          slug: 'y',
+          name: 'Y',
+          ndaCertified: true,
+        }),
+      ),
+    ).toBe('starred_endorsed');
+  });
+
+  it('ignores unknown catalog values when filtering selected params', () => {
+    expect(filterToKnownCatalogValues(['Music', 'Nope'], ['Music', 'Nursing'])).toEqual(['Music']);
+  });
+
+  it('parses multi query params from repeated and pipe-delimited values', () => {
+    expect(parseMultiQueryParam(['Music|Design', 'Nursing'])).toEqual([
+      'Design',
+      'Music',
+      'Nursing',
+    ]);
+  });
+});
+
+describe('provider search catalog seeds', () => {
+  it('derives interest area catalog from tagged providers only', () => {
+    const catalog = getProviderSearchInterestAreaCatalog();
+    expect(catalog).toContain('Music');
+    expect(catalog).toContain('Nursing');
+    expect(catalog).not.toContain('Veterinary Science');
+  });
+
+  it('includes emerging states in location catalog', () => {
+    const catalog = getProviderSearchLocationCatalog();
+    expect(catalog).toEqual(expect.arrayContaining(['NSW', 'QLD', 'VIC', 'Sydney', 'Melbourne']));
+  });
+
+  it('marks demo course-endorsed provider when searchDemo is enabled', () => {
+    const providers = listSearchableProviders({ searchDemo: true });
+    const collarts = providers.find((provider) => provider.slug === 'collarts');
+    expect(collarts?.hasPromotedCourses).toBe(true);
+  });
+});
+
+describe('provider search href helpers', () => {
+  it('builds search href with area and location params', () => {
+    expect(
+      buildProviderSearchHref({
+        interestAreas: ['Music'],
+        locations: ['Sydney'],
+      }),
+    ).toBe('/search?InterestArea=Music&Location=Sydney');
+  });
+
+  it('builds courses href with optional searchDemo', () => {
+    expect(buildEndorsedCoursesHref('collarts')).toBe('/endorsedproviders/collarts/courses');
+    expect(buildEndorsedCoursesHref('collarts', { searchDemo: true })).toBe(
+      '/endorsedproviders/collarts/courses?searchDemo=1',
+    );
+  });
+
+  it('detects searchDemo flag case-insensitively', () => {
+    expect(isProviderSearchDemoEnabled('1')).toBe(true);
+    expect(isProviderSearchDemoEnabled('true')).toBe(false);
+  });
+
+  it('uniqueSortedStrings normalizes casing for uniqueness but keeps first casing', () => {
+    expect(uniqueSortedStrings(['Sydney', 'sydney', 'Melbourne'])).toEqual(['Melbourne', 'Sydney']);
+  });
+
+  it('matchesProviderSearchFilters is case-insensitive', () => {
+    expect(
+      matchesProviderSearchFilters(
+        makeProvider({
+          kind: 'endorsed',
+          slug: 'x',
+          name: 'X',
+          interestAreas: ['Music'],
+          locations: ['Sydney'],
+        }),
+        { interestAreas: ['music'], locations: ['sydney'] },
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -1,6 +1,7 @@
 import {
   classifyProviderSearchTier,
   countProviderSearchResults,
+  countStarredEndorsedResults,
   listPositionedProviderSearchResults,
   matchesProviderSearchFilters,
   searchProvidersByFilters,
@@ -172,10 +173,41 @@ describe('provider search matching', () => {
       locations: [],
     });
     const positioned = listPositionedProviderSearchResults(results);
-    expect(positioned.map((item) => item.position)).toEqual(
-      positioned.map((_, index) => index + 1),
-    );
-    expect(positioned[0]?.tier).toBe('course_endorsed');
+    expect(positioned).toEqual([
+      {
+        provider: expect.objectContaining({ slug: 'collarts' }),
+        tier: 'course_endorsed',
+        position: 1,
+      },
+      {
+        provider: expect.objectContaining({ slug: 'jazz-music-institute' }),
+        tier: 'emerging',
+        position: 2,
+      },
+    ]);
+  });
+
+  it('rejects providers that fail the AND across fields', () => {
+    expect(
+      matchesProviderSearchFilters(
+        makeProvider({
+          kind: 'emerging',
+          slug: 'jazz-music-institute',
+          name: 'Jazz Music Institute',
+          interestAreas: ['Music'],
+          locations: ['QLD'],
+        }),
+        { interestAreas: ['Music'], locations: ['Melbourne'] },
+      ),
+    ).toBe(false);
+  });
+
+  it('counts starred endorsed providers only inside the endorsed tier', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: [],
+      locations: [],
+    });
+    expect(countStarredEndorsedResults(results)).toBe(1);
   });
 
   it('parses multi query params from repeated and pipe-delimited values', () => {
@@ -199,18 +231,29 @@ describe('provider search catalog seeds', () => {
         'Fine Arts',
       ]),
     );
+    // Catalog must be unique + sorted; soft length guards against empty fixture regressions.
+    expect(catalog).toEqual([...new Set(catalog)].sort((a, b) => a.localeCompare(b)));
     expect(catalog.length).toBeGreaterThan(10);
   });
 
   it('includes emerging states in location catalog', () => {
     const catalog = getProviderSearchLocationCatalog();
     expect(catalog).toEqual(expect.arrayContaining(['NSW', 'QLD', 'VIC', 'Sydney', 'Melbourne']));
+    expect(catalog).toEqual([...new Set(catalog)].sort((a, b) => a.localeCompare(b)));
   });
 
   it('marks demo course-endorsed provider when searchDemo is enabled', () => {
-    const providers = listSearchableProviders({ searchDemo: true });
-    const collarts = providers.find((provider) => provider.slug === 'collarts');
-    expect(collarts?.hasPromotedCourses).toBe(true);
+    const baseline = listSearchableProviders({ searchDemo: false }).find(
+      (provider) => provider.slug === 'collarts',
+    );
+    const demo = listSearchableProviders({ searchDemo: true }).find(
+      (provider) => provider.slug === 'collarts',
+    );
+    expect(demo?.hasPromotedCourses).toBe(true);
+    // Demo flag must be what unlocks promoted courses when the live row has none.
+    if (!baseline?.hasPromotedCourses) {
+      expect(demo?.hasPromotedCourses).not.toBe(baseline?.hasPromotedCourses);
+    }
   });
 });
 
@@ -222,6 +265,16 @@ describe('provider search href helpers', () => {
         locations: ['Sydney'],
       }),
     ).toBe('/search?InterestArea=Music&Location=Sydney');
+  });
+
+  it('builds bare /search when filters are empty', () => {
+    expect(buildProviderSearchHref({ interestAreas: [], locations: [] })).toBe('/search');
+  });
+
+  it('appends searchDemo without inventing empty filter params', () => {
+    expect(buildProviderSearchHref({ interestAreas: [], locations: [] }, { searchDemo: true })).toBe(
+      '/search?searchDemo=1',
+    );
   });
 
   it('builds courses href with optional searchDemo', () => {

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -1,15 +1,16 @@
 import {
   classifyProviderSearchTier,
   countProviderSearchResults,
+  listPositionedProviderSearchResults,
   matchesProviderSearchFilters,
   searchProvidersByFilters,
 } from '../searchProviders';
 import type { ProviderSearchRecord } from '../constants';
 import {
-  filterToKnownCatalogValues,
   matchesSearchToken,
   parseMultiQueryParam,
   resolveSearchFilterValues,
+  tokensPartialMatch,
   uniqueSortedStrings,
 } from '../normalize';
 import {
@@ -21,6 +22,7 @@ import {
   getProviderSearchInterestAreaCatalog,
   getProviderSearchLocationCatalog,
   listSearchableProviders,
+  loadProviderSearchContext,
 } from '../catalog';
 
 function makeProvider(
@@ -148,8 +150,22 @@ describe('provider search matching', () => {
     ).toBe('starred_endorsed');
   });
 
-  it('ignores unknown catalog values when filtering selected params', () => {
-    expect(filterToKnownCatalogValues(['Music', 'Nope'], ['Music', 'Nursing'])).toEqual(['Music']);
+  it('partial-matches tokens for catalog expansion and provider matching', () => {
+    expect(tokensPartialMatch('Digital Skills', 'digital')).toBe(true);
+    expect(tokensPartialMatch('Nursing', 'digital')).toBe(false);
+    expect(tokensPartialMatch('a', 'ab')).toBe(false);
+  });
+
+  it('assigns stable global positions across tiers without render mutation', () => {
+    const results = searchProvidersByFilters(providers, {
+      interestAreas: ['Music'],
+      locations: [],
+    });
+    const positioned = listPositionedProviderSearchResults(results);
+    expect(positioned.map((item) => item.position)).toEqual(
+      positioned.map((_, index) => index + 1),
+    );
+    expect(positioned[0]?.tier).toBe('course_endorsed');
   });
 
   it('parses multi query params from repeated and pipe-delimited values', () => {
@@ -269,5 +285,12 @@ describe('provider search href helpers', () => {
     expect(
       resolveSearchFilterValues(['digital'], ['Digital Skills', 'Digital Technology', 'Nursing']),
     ).toEqual(['Digital Skills', 'Digital Technology']);
+  });
+
+  it('loadProviderSearchContext returns providers and catalogs together', () => {
+    const context = loadProviderSearchContext();
+    expect(context.providers.length).toBeGreaterThan(0);
+    expect(context.interestAreaCatalog).toEqual(getProviderSearchInterestAreaCatalog());
+    expect(context.locationCatalog).toEqual(getProviderSearchLocationCatalog());
   });
 });

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -7,7 +7,9 @@ import {
 import type { ProviderSearchRecord } from '../constants';
 import {
   filterToKnownCatalogValues,
+  matchesSearchToken,
   parseMultiQueryParam,
+  resolveSearchFilterValues,
   uniqueSortedStrings,
 } from '../normalize';
 import {
@@ -225,5 +227,44 @@ describe('provider search href helpers', () => {
         { interestAreas: ['music'], locations: ['sydney'] },
       ),
     ).toBe(true);
+  });
+
+  it('partial-matches interest areas so digital finds Digital Skills and Digital Technology', () => {
+    const withDigital = [
+      makeProvider({
+        kind: 'endorsed',
+        slug: 'skills-uni',
+        name: 'Skills Uni',
+        interestAreas: ['Digital Skills'],
+      }),
+      makeProvider({
+        kind: 'endorsed',
+        slug: 'tech-uni',
+        name: 'Tech Uni',
+        interestAreas: ['Digital Technology'],
+      }),
+      makeProvider({
+        kind: 'endorsed',
+        slug: 'nursing-uni',
+        name: 'Nursing Uni',
+        interestAreas: ['Nursing'],
+      }),
+    ];
+
+    expect(matchesSearchToken(['Digital Skills', 'Digital Technology'], 'digital')).toBe(true);
+    expect(matchesSearchToken(['Nursing'], 'digital')).toBe(false);
+
+    const results = searchProvidersByFilters(withDigital, {
+      interestAreas: ['digital'],
+      locations: [],
+    });
+    expect(results.endorsed.map((p) => p.slug).sort()).toEqual(['skills-uni', 'tech-uni']);
+  });
+
+  it('resolveSearchFilterValues keeps free-text partial queries', () => {
+    expect(resolveSearchFilterValues(['digital', 'Music', 'a'], ['Music', 'Nursing'])).toEqual([
+      'digital',
+      'Music',
+    ]);
   });
 });

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -162,9 +162,16 @@ describe('provider search matching', () => {
 describe('provider search catalog seeds', () => {
   it('derives interest area catalog from tagged providers only', () => {
     const catalog = getProviderSearchInterestAreaCatalog();
-    expect(catalog).toContain('Music');
-    expect(catalog).toContain('Nursing');
-    expect(catalog).not.toContain('Veterinary Science');
+    expect(catalog).toEqual(
+      expect.arrayContaining([
+        'Music & Audio',
+        'Nursing',
+        'Accredited Qualifications',
+        'Training & Assessment (TAE)',
+        'Fine Arts',
+      ]),
+    );
+    expect(catalog.length).toBeGreaterThan(10);
   });
 
   it('includes emerging states in location catalog', () => {

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -261,10 +261,13 @@ describe('provider search href helpers', () => {
     expect(results.endorsed.map((p) => p.slug).sort()).toEqual(['skills-uni', 'tech-uni']);
   });
 
-  it('resolveSearchFilterValues keeps free-text partial queries', () => {
+  it('resolveSearchFilterValues expands free-text partial queries onto catalog labels', () => {
     expect(resolveSearchFilterValues(['digital', 'Music', 'a'], ['Music', 'Nursing'])).toEqual([
       'digital',
       'Music',
     ]);
+    expect(
+      resolveSearchFilterValues(['digital'], ['Digital Skills', 'Digital Technology', 'Nursing']),
+    ).toEqual(['Digital Skills', 'Digital Technology']);
   });
 });

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -272,9 +272,9 @@ describe('provider search href helpers', () => {
   });
 
   it('appends searchDemo without inventing empty filter params', () => {
-    expect(buildProviderSearchHref({ interestAreas: [], locations: [] }, { searchDemo: true })).toBe(
-      '/search?searchDemo=1',
-    );
+    expect(
+      buildProviderSearchHref({ interestAreas: [], locations: [] }, { searchDemo: true }),
+    ).toBe('/search?searchDemo=1');
   });
 
   it('builds courses href with optional searchDemo', () => {

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -8,6 +8,7 @@ import {
 import type { ProviderSearchRecord } from '../constants';
 import {
   matchesSearchToken,
+  mergeSearchTokens,
   parseMultiQueryParam,
   resolveSearchFilterValues,
   tokensPartialMatch,
@@ -100,12 +101,12 @@ describe('provider search matching', () => {
     expect(results.emerging).toEqual([]);
   });
 
-  it('returns empty results when no filters selected', () => {
+  it('returns all providers when no filters selected', () => {
     const results = searchProvidersByFilters(providers, {
       interestAreas: [],
       locations: [],
     });
-    expect(countProviderSearchResults(results)).toBe(0);
+    expect(countProviderSearchResults(results)).toBe(providers.length);
   });
 
   it('sorts alphabetically within a tier', () => {
@@ -285,6 +286,12 @@ describe('provider search href helpers', () => {
     expect(
       resolveSearchFilterValues(['digital'], ['Digital Skills', 'Digital Technology', 'Nursing']),
     ).toEqual(['Digital Skills', 'Digital Technology']);
+  });
+
+  it('mergeSearchTokens includes typed draft text with selected values', () => {
+    expect(mergeSearchTokens(['Music'], 'business')).toEqual(['business', 'Music']);
+    expect(mergeSearchTokens([], '  business  ')).toEqual(['business']);
+    expect(mergeSearchTokens(['Music'], '   ')).toEqual(['Music']);
   });
 
   it('loadProviderSearchContext returns providers and catalogs together', () => {

--- a/src/app/utilities/providerSearch/buildSearchHref.ts
+++ b/src/app/utilities/providerSearch/buildSearchHref.ts
@@ -36,12 +36,4 @@ export function buildEndorsedCoursesHref(slug: string, options?: { searchDemo?: 
   return `${base}?${PROVIDER_SEARCH_QUERY.SEARCH_DEMO}=${PROVIDER_SEARCH_DEMO_PARAM_VALUE}`;
 }
 
-export function isProviderSearchDemoEnabled(
-  searchDemoParam: string | string[] | undefined,
-): boolean {
-  if (searchDemoParam === undefined) {
-    return false;
-  }
-  const value = Array.isArray(searchDemoParam) ? searchDemoParam[0] : searchDemoParam;
-  return value?.toLowerCase() === PROVIDER_SEARCH_DEMO_PARAM_VALUE;
-}
+export { isProviderSearchDemoEnabled } from './demoFlag';

--- a/src/app/utilities/providerSearch/buildSearchHref.ts
+++ b/src/app/utilities/providerSearch/buildSearchHref.ts
@@ -1,0 +1,47 @@
+import {
+  PROVIDER_SEARCH_PATH,
+  PROVIDER_SEARCH_QUERY,
+  PROVIDER_SEARCH_DEMO_PARAM_VALUE,
+  type ProviderSearchFilters,
+} from './constants';
+
+function appendMultiParam(params: URLSearchParams, key: string, values: readonly string[]): void {
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed !== '') {
+      params.append(key, trimmed);
+    }
+  }
+}
+
+export function buildProviderSearchHref(
+  filters: ProviderSearchFilters,
+  options?: { searchDemo?: boolean },
+): string {
+  const params = new URLSearchParams();
+  appendMultiParam(params, PROVIDER_SEARCH_QUERY.INTEREST_AREA, filters.interestAreas);
+  appendMultiParam(params, PROVIDER_SEARCH_QUERY.LOCATION, filters.locations);
+  if (options?.searchDemo) {
+    params.set(PROVIDER_SEARCH_QUERY.SEARCH_DEMO, PROVIDER_SEARCH_DEMO_PARAM_VALUE);
+  }
+  const query = params.toString();
+  return query === '' ? PROVIDER_SEARCH_PATH : `${PROVIDER_SEARCH_PATH}?${query}`;
+}
+
+export function buildEndorsedCoursesHref(slug: string, options?: { searchDemo?: boolean }): string {
+  const base = `/endorsedproviders/${slug}/courses`;
+  if (!options?.searchDemo) {
+    return base;
+  }
+  return `${base}?${PROVIDER_SEARCH_QUERY.SEARCH_DEMO}=${PROVIDER_SEARCH_DEMO_PARAM_VALUE}`;
+}
+
+export function isProviderSearchDemoEnabled(
+  searchDemoParam: string | string[] | undefined,
+): boolean {
+  if (searchDemoParam === undefined) {
+    return false;
+  }
+  const value = Array.isArray(searchDemoParam) ? searchDemoParam[0] : searchDemoParam;
+  return value?.toLowerCase() === PROVIDER_SEARCH_DEMO_PARAM_VALUE;
+}

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -63,46 +63,72 @@ function buildEmergingRecord(institution: EmergingInstitution): ProviderSearchRe
   };
 }
 
+function withDemoPromotedCourses(row: EndorsedJsonRow): EndorsedPromotedCourse[] {
+  const existing = row.promotedCourses ?? [];
+  const hasDemo = existing.some((course) => course.id === PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.id);
+  if (hasDemo) {
+    return existing;
+  }
+  return [
+    ...existing,
+    {
+      id: PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.id,
+      title: PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.title,
+      interestAreas: [...PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.interestAreas],
+    },
+  ];
+}
+
+function toEndorsedSearchRecord(row: EndorsedJsonRow, searchDemo: boolean): ProviderSearchRecord {
+  const isDemoTarget = slugify(row.id) === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG;
+  if (searchDemo && isDemoTarget) {
+    return buildEndorsedRecord(row, withDemoPromotedCourses(row));
+  }
+  return buildEndorsedRecord(row);
+}
+
+export type ProviderSearchContext = {
+  searchDemo: boolean;
+  providers: ProviderSearchRecord[];
+  interestAreaCatalog: string[];
+  locationCatalog: string[];
+};
+
 export function listSearchableProviders(options?: {
   searchDemo?: boolean;
 }): ProviderSearchRecord[] {
   const searchDemo = options?.searchDemo === true;
-  const endorsedRows = getEndorsedJsonRows().filter((row) => row.live === true);
-  const endorsed = endorsedRows.map((row) => {
-    if (searchDemo && slugify(row.id) === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG) {
-      const existing = row.promotedCourses ?? [];
-      const hasDemo = existing.some(
-        (course) => course.id === PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.id,
-      );
-      const promotedCourses = hasDemo
-        ? existing
-        : [
-            ...existing,
-            {
-              id: PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.id,
-              title: PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.title,
-              interestAreas: [...PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.interestAreas],
-            },
-          ];
-      return buildEndorsedRecord(row, promotedCourses);
-    }
-    return buildEndorsedRecord(row);
-  });
-
+  const endorsed = getEndorsedJsonRows()
+    .filter((row) => row.live === true)
+    .map((row) => toEndorsedSearchRecord(row, searchDemo));
   const emerging = (emergingInstitutions as EmergingInstitution[]).map(buildEmergingRecord);
   return [...endorsed, ...emerging];
 }
 
-export function getProviderSearchInterestAreaCatalog(options?: { searchDemo?: boolean }): string[] {
-  return uniqueSortedStrings(
-    listSearchableProviders(options).flatMap((provider) => provider.interestAreas),
-  );
+/** One catalog pass shared by pages and filter resolution. */
+export function loadProviderSearchContext(options?: {
+  searchDemo?: boolean;
+}): ProviderSearchContext {
+  const searchDemo = options?.searchDemo === true;
+  const providers = listSearchableProviders({ searchDemo });
+  return {
+    searchDemo,
+    providers,
+    interestAreaCatalog: uniqueSortedStrings(
+      providers.flatMap((provider) => provider.interestAreas),
+    ),
+    locationCatalog: uniqueSortedStrings(providers.flatMap((provider) => provider.locations)),
+  };
+}
+
+export function getProviderSearchInterestAreaCatalog(options?: {
+  searchDemo?: boolean;
+}): string[] {
+  return loadProviderSearchContext(options).interestAreaCatalog;
 }
 
 export function getProviderSearchLocationCatalog(options?: { searchDemo?: boolean }): string[] {
-  return uniqueSortedStrings(
-    listSearchableProviders(options).flatMap((provider) => provider.locations),
-  );
+  return loadProviderSearchContext(options).locationCatalog;
 }
 
 export function toDropdownOptions(values: readonly string[]): { label: string; value: string }[] {

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -19,6 +19,14 @@ function endorsedDisplayName(row: EndorsedJsonRow): string {
   return getEndorsedDisplayNameForSlug(slugify(row.id)) ?? row.id;
 }
 
+function optionalTrimmed(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 function resolveEndorsedInterestAreas(
   row: EndorsedJsonRow,
   promotedCourses: EndorsedPromotedCourse[],
@@ -32,10 +40,9 @@ function resolveEndorsedInterestAreas(
 
 function buildEndorsedRecord(
   row: EndorsedJsonRow,
-  promotedCoursesOverride?: EndorsedPromotedCourse[],
+  promotedCourses: EndorsedPromotedCourse[],
 ): ProviderSearchRecord {
   const slug = slugify(row.id);
-  const promotedCourses = promotedCoursesOverride ?? row.promotedCourses ?? [];
   return {
     kind: 'endorsed',
     slug,
@@ -44,8 +51,8 @@ function buildEndorsedRecord(
     locations: row.locations ?? [],
     ndaCertified: row.ndaCertified === true,
     hasPromotedCourses: promotedCourses.length > 0,
-    logoSrc: row.logo?.trim() || undefined,
-    topBackgroundImage: row.topBackgroundImage?.trim() || undefined,
+    logoSrc: optionalTrimmed(row.logo),
+    topBackgroundImage: optionalTrimmed(row.topBackgroundImage),
   };
 }
 
@@ -79,12 +86,20 @@ function withDemoPromotedCourses(row: EndorsedJsonRow): EndorsedPromotedCourse[]
   ];
 }
 
-function toEndorsedSearchRecord(row: EndorsedJsonRow, searchDemo: boolean): ProviderSearchRecord {
+function promotedCoursesForRow(row: EndorsedJsonRow, searchDemo: boolean): EndorsedPromotedCourse[] {
+  const existing = row.promotedCourses ?? [];
   const isDemoTarget = slugify(row.id) === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG;
-  if (searchDemo && isDemoTarget) {
-    return buildEndorsedRecord(row, withDemoPromotedCourses(row));
+  if (!searchDemo) {
+    return existing;
   }
-  return buildEndorsedRecord(row);
+  if (!isDemoTarget) {
+    return existing;
+  }
+  return withDemoPromotedCourses(row);
+}
+
+function toEndorsedSearchRecord(row: EndorsedJsonRow, searchDemo: boolean): ProviderSearchRecord {
+  return buildEndorsedRecord(row, promotedCoursesForRow(row, searchDemo));
 }
 
 export type ProviderSearchContext = {

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -86,7 +86,10 @@ function withDemoPromotedCourses(row: EndorsedJsonRow): EndorsedPromotedCourse[]
   ];
 }
 
-function promotedCoursesForRow(row: EndorsedJsonRow, searchDemo: boolean): EndorsedPromotedCourse[] {
+function promotedCoursesForRow(
+  row: EndorsedJsonRow,
+  searchDemo: boolean,
+): EndorsedPromotedCourse[] {
   const existing = row.promotedCourses ?? [];
   const isDemoTarget = slugify(row.id) === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG;
   if (!searchDemo) {

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -1,0 +1,100 @@
+import emergingInstitutions from '@/app/components/emergingInstitutions/emergingInstitutions.json';
+import type { EmergingInstitution } from '@/app/components/emergingInstitutions/emergingInstitutionTypes';
+import {
+  getEndorsedDisplayNameForSlug,
+  getEndorsedJsonRows,
+  type EndorsedJsonRow,
+  type EndorsedPromotedCourse,
+} from '@/app/components/endorsedProviders/endorsedProviderPageData';
+import { slugify } from '@/app/utilities/common';
+import {
+  PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG,
+  PROVIDER_SEARCH_DEMO_PROMOTED_COURSE,
+  type ProviderSearchRecord,
+} from './constants';
+import { uniqueSortedStrings } from './normalize';
+
+function endorsedDisplayName(row: EndorsedJsonRow): string {
+  return getEndorsedDisplayNameForSlug(slugify(row.id)) ?? row.id;
+}
+
+function buildEndorsedRecord(
+  row: EndorsedJsonRow,
+  promotedCoursesOverride?: EndorsedPromotedCourse[],
+): ProviderSearchRecord {
+  const slug = slugify(row.id);
+  const promotedCourses = promotedCoursesOverride ?? row.promotedCourses ?? [];
+  return {
+    kind: 'endorsed',
+    slug,
+    name: endorsedDisplayName(row),
+    interestAreas: row.interestAreas ?? [],
+    locations: row.locations ?? [],
+    ndaCertified: row.ndaCertified === true,
+    hasPromotedCourses: promotedCourses.length > 0,
+    logoSrc: row.logo?.trim() || undefined,
+    topBackgroundImage: row.topBackgroundImage?.trim() || undefined,
+  };
+}
+
+function buildEmergingRecord(institution: EmergingInstitution): ProviderSearchRecord {
+  const locations = uniqueSortedStrings([institution.state, ...(institution.locations ?? [])]);
+  return {
+    kind: 'emerging',
+    slug: slugify(institution.name),
+    name: institution.name,
+    interestAreas: institution.interestAreas ?? [],
+    locations,
+    ndaCertified: false,
+    hasPromotedCourses: false,
+    emergingState: institution.state,
+  };
+}
+
+export function listSearchableProviders(options?: {
+  searchDemo?: boolean;
+}): ProviderSearchRecord[] {
+  const searchDemo = options?.searchDemo === true;
+  const endorsedRows = getEndorsedJsonRows().filter((row) => row.live === true);
+  const endorsed = endorsedRows.map((row) => {
+    if (searchDemo && slugify(row.id) === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG) {
+      const existing = row.promotedCourses ?? [];
+      const hasDemo = existing.some(
+        (course) => course.id === PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.id,
+      );
+      const promotedCourses = hasDemo
+        ? existing
+        : [
+            ...existing,
+            {
+              id: PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.id,
+              title: PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.title,
+              interestAreas: [...PROVIDER_SEARCH_DEMO_PROMOTED_COURSE.interestAreas],
+            },
+          ];
+      return buildEndorsedRecord(row, promotedCourses);
+    }
+    return buildEndorsedRecord(row);
+  });
+
+  const emerging = (emergingInstitutions as EmergingInstitution[]).map(buildEmergingRecord);
+  return [...endorsed, ...emerging];
+}
+
+export function getProviderSearchInterestAreaCatalog(options?: {
+  searchDemo?: boolean;
+}): string[] {
+  return uniqueSortedStrings(
+    listSearchableProviders(options).flatMap((provider) => provider.interestAreas),
+  );
+}
+
+export function getProviderSearchLocationCatalog(options?: { searchDemo?: boolean }): string[] {
+  return uniqueSortedStrings(
+    listSearchableProviders(options).flatMap((provider) => provider.locations),
+  );
+}
+
+export function toDropdownOptions(values: readonly string[]): { label: string; value: string }[] {
+  return values.map((value) => ({ label: value, value }));
+}

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -81,9 +81,7 @@ export function listSearchableProviders(options?: {
   return [...endorsed, ...emerging];
 }
 
-export function getProviderSearchInterestAreaCatalog(options?: {
-  searchDemo?: boolean;
-}): string[] {
+export function getProviderSearchInterestAreaCatalog(options?: { searchDemo?: boolean }): string[] {
   return uniqueSortedStrings(
     listSearchableProviders(options).flatMap((provider) => provider.interestAreas),
   );

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -121,9 +121,7 @@ export function loadProviderSearchContext(options?: {
   };
 }
 
-export function getProviderSearchInterestAreaCatalog(options?: {
-  searchDemo?: boolean;
-}): string[] {
+export function getProviderSearchInterestAreaCatalog(options?: { searchDemo?: boolean }): string[] {
   return loadProviderSearchContext(options).interestAreaCatalog;
 }
 

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -3,6 +3,7 @@ import type { EmergingInstitution } from '@/app/components/emergingInstitutions/
 import {
   getEndorsedDisplayNameForSlug,
   getEndorsedJsonRows,
+  getStudyAreasForSlug,
   type EndorsedJsonRow,
   type EndorsedPromotedCourse,
 } from '@/app/components/endorsedProviders/endorsedProviderPageData';
@@ -18,6 +19,17 @@ function endorsedDisplayName(row: EndorsedJsonRow): string {
   return getEndorsedDisplayNameForSlug(slugify(row.id)) ?? row.id;
 }
 
+function resolveEndorsedInterestAreas(
+  row: EndorsedJsonRow,
+  promotedCourses: EndorsedPromotedCourse[],
+): string[] {
+  const slug = slugify(row.id);
+  const profileAreas = getStudyAreasForSlug(slug);
+  const taggedAreas = row.interestAreas ?? [];
+  const promotedAreas = promotedCourses.flatMap((course) => course.interestAreas);
+  return uniqueSortedStrings([...profileAreas, ...taggedAreas, ...promotedAreas]);
+}
+
 function buildEndorsedRecord(
   row: EndorsedJsonRow,
   promotedCoursesOverride?: EndorsedPromotedCourse[],
@@ -28,7 +40,7 @@ function buildEndorsedRecord(
     kind: 'endorsed',
     slug,
     name: endorsedDisplayName(row),
-    interestAreas: row.interestAreas ?? [],
+    interestAreas: resolveEndorsedInterestAreas(row, promotedCourses),
     locations: row.locations ?? [],
     ndaCertified: row.ndaCertified === true,
     hasPromotedCourses: promotedCourses.length > 0,

--- a/src/app/utilities/providerSearch/constants.ts
+++ b/src/app/utilities/providerSearch/constants.ts
@@ -17,18 +17,16 @@ export const PROVIDER_SEARCH_DEMO_PROMOTED_COURSE = {
   interestAreas: ['Music'],
 } as const;
 
-export type ProviderSearchTier = 'course_endorsed' | 'starred_endorsed' | 'endorsed' | 'emerging';
+export type ProviderSearchTier = 'course_endorsed' | 'endorsed' | 'emerging';
 
 export const PROVIDER_SEARCH_TIER_ORDER: readonly ProviderSearchTier[] = [
   'course_endorsed',
-  'starred_endorsed',
   'endorsed',
   'emerging',
 ] as const;
 
 export const PROVIDER_SEARCH_TIER_HEADING: Record<ProviderSearchTier, string> = {
   course_endorsed: 'Providers with courses',
-  starred_endorsed: 'NDA Certified providers',
   endorsed: 'Endorsed providers',
   emerging: 'Emerging providers',
 };

--- a/src/app/utilities/providerSearch/constants.ts
+++ b/src/app/utilities/providerSearch/constants.ts
@@ -31,6 +31,33 @@ export const PROVIDER_SEARCH_TIER_HEADING: Record<ProviderSearchTier, string> = 
   emerging: 'Emerging providers',
 };
 
+export type ProviderSearchTierEmphasis = 'endorsed' | 'emerging';
+
+export const PROVIDER_SEARCH_TIER_META: Record<
+  ProviderSearchTier,
+  {
+    eyebrow: string;
+    subtitle: string;
+    emphasis: ProviderSearchTierEmphasis;
+  }
+> = {
+  course_endorsed: {
+    eyebrow: 'NDA ENDORSED',
+    subtitle: 'Neuro-inclusive institutions with courses to explore',
+    emphasis: 'endorsed',
+  },
+  endorsed: {
+    eyebrow: 'NDA ENDORSED',
+    subtitle: 'Neuro-inclusive institutions verified by NDA',
+    emphasis: 'endorsed',
+  },
+  emerging: {
+    eyebrow: 'EXPLORING',
+    subtitle: 'Building neuro-inclusion — not yet endorsed',
+    emphasis: 'emerging',
+  },
+};
+
 export const PROVIDER_SEARCH_GA_CATEGORY = 'ProviderSearch' as const;
 
 export const PROVIDER_SEARCH_GA = {

--- a/src/app/utilities/providerSearch/constants.ts
+++ b/src/app/utilities/providerSearch/constants.ts
@@ -17,11 +17,7 @@ export const PROVIDER_SEARCH_DEMO_PROMOTED_COURSE = {
   interestAreas: ['Music'],
 } as const;
 
-export type ProviderSearchTier =
-  | 'course_endorsed'
-  | 'starred_endorsed'
-  | 'endorsed'
-  | 'emerging';
+export type ProviderSearchTier = 'course_endorsed' | 'starred_endorsed' | 'endorsed' | 'emerging';
 
 export const PROVIDER_SEARCH_TIER_ORDER: readonly ProviderSearchTier[] = [
   'course_endorsed',

--- a/src/app/utilities/providerSearch/constants.ts
+++ b/src/app/utilities/providerSearch/constants.ts
@@ -27,7 +27,7 @@ export const PROVIDER_SEARCH_TIER_ORDER: readonly ProviderSearchTier[] = [
 ] as const;
 
 export const PROVIDER_SEARCH_TIER_HEADING: Record<ProviderSearchTier, string> = {
-  course_endorsed: 'Courses from endorsed providers',
+  course_endorsed: 'Providers with courses',
   starred_endorsed: 'NDA Certified providers',
   endorsed: 'Endorsed providers',
   emerging: 'Emerging providers',

--- a/src/app/utilities/providerSearch/constants.ts
+++ b/src/app/utilities/providerSearch/constants.ts
@@ -1,0 +1,88 @@
+export const PROVIDER_SEARCH_PATH = '/search' as const;
+
+export const PROVIDER_SEARCH_QUERY = {
+  INTEREST_AREA: 'InterestArea',
+  LOCATION: 'Location',
+  SEARCH_DEMO: 'searchDemo',
+} as const;
+
+export const PROVIDER_SEARCH_DEMO_PARAM_VALUE = '1' as const;
+
+/** Fixture slug used when `?searchDemo=1` unlocks course-endorsed preview. */
+export const PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG = 'collarts' as const;
+
+export const PROVIDER_SEARCH_DEMO_PROMOTED_COURSE = {
+  id: 'search-demo-course',
+  title: 'Demo promoted course',
+  interestAreas: ['Music'],
+} as const;
+
+export type ProviderSearchTier =
+  | 'course_endorsed'
+  | 'starred_endorsed'
+  | 'endorsed'
+  | 'emerging';
+
+export const PROVIDER_SEARCH_TIER_ORDER: readonly ProviderSearchTier[] = [
+  'course_endorsed',
+  'starred_endorsed',
+  'endorsed',
+  'emerging',
+] as const;
+
+export const PROVIDER_SEARCH_TIER_HEADING: Record<ProviderSearchTier, string> = {
+  course_endorsed: 'Courses from endorsed providers',
+  starred_endorsed: 'NDA Certified providers',
+  endorsed: 'Endorsed providers',
+  emerging: 'Emerging providers',
+};
+
+export const PROVIDER_SEARCH_GA_CATEGORY = 'ProviderSearch' as const;
+
+export const PROVIDER_SEARCH_GA = {
+  submit: {
+    eventName: 'provider_search_submit',
+    category: PROVIDER_SEARCH_GA_CATEGORY,
+  },
+  resultsView: {
+    eventName: 'provider_search_results_view',
+    category: PROVIDER_SEARCH_GA_CATEGORY,
+  },
+  resultClick: {
+    eventName: 'provider_search_result_click',
+    category: PROVIDER_SEARCH_GA_CATEGORY,
+  },
+  coursesPlaceholderView: {
+    eventName: 'provider_courses_placeholder_view',
+    category: PROVIDER_SEARCH_GA_CATEGORY,
+  },
+} as const;
+
+export type ProviderSearchSurface = 'homepage' | 'search_page';
+
+export type ProviderSearchKind = 'endorsed' | 'emerging';
+
+export type ProviderSearchRecord = {
+  kind: ProviderSearchKind;
+  slug: string;
+  name: string;
+  interestAreas: string[];
+  locations: string[];
+  ndaCertified: boolean;
+  hasPromotedCourses: boolean;
+  logoSrc?: string;
+  topBackgroundImage?: string;
+  emergingState?: string;
+};
+
+export type ProviderSearchFilters = {
+  interestAreas: string[];
+  locations: string[];
+};
+
+export type ProviderSearchTierResults = Record<ProviderSearchTier, ProviderSearchRecord[]>;
+
+export type ProviderStudySearchFormValues = {
+  InterestArea: string[];
+  Location: string[];
+};

--- a/src/app/utilities/providerSearch/demoFlag.ts
+++ b/src/app/utilities/providerSearch/demoFlag.ts
@@ -1,0 +1,11 @@
+import { PROVIDER_SEARCH_DEMO_PARAM_VALUE } from './constants';
+
+export function isProviderSearchDemoEnabled(
+  searchDemoParam: string | string[] | undefined,
+): boolean {
+  if (searchDemoParam === undefined) {
+    return false;
+  }
+  const value = Array.isArray(searchDemoParam) ? searchDemoParam[0] : searchDemoParam;
+  return value?.toLowerCase() === PROVIDER_SEARCH_DEMO_PARAM_VALUE;
+}

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -44,35 +44,43 @@ export function joinGaMultiValue(values: readonly string[]): string {
     .join('|');
 }
 
-/** Exact case-insensitive equality. */
-export function includesNormalized(haystack: readonly string[], needle: string): boolean {
-  const normalizedNeedle = normalizeSearchToken(needle);
-  return haystack.some((item) => normalizeSearchToken(item) === normalizedNeedle);
-}
-
 const MIN_PARTIAL_QUERY_LENGTH = 2;
+
+/** Shared partial/exact token compare used by matching and catalog expansion. */
+export function tokensPartialMatch(left: string, right: string): boolean {
+  const a = normalizeSearchToken(left);
+  const b = normalizeSearchToken(right);
+  if (a.length < MIN_PARTIAL_QUERY_LENGTH || b.length < MIN_PARTIAL_QUERY_LENGTH) {
+    return false;
+  }
+  return a === b || a.includes(b) || b.includes(a);
+}
 
 /**
  * Partial match: "digital" matches "Digital Skills" and "Digital Technology".
- * Exact matches still work. Reverse contains only when the catalog token is long enough.
+ * Exact matches still work.
  */
 export function matchesSearchToken(haystack: readonly string[], needle: string): boolean {
-  const normalizedNeedle = normalizeSearchToken(needle);
-  if (normalizedNeedle.length < MIN_PARTIAL_QUERY_LENGTH) {
-    return false;
+  return haystack.some((item) => tokensPartialMatch(item, needle));
+}
+
+function expandSelectedValue(value: string, catalog: readonly string[]): string[] {
+  const normalized = normalizeSearchToken(value);
+  if (normalized.length < MIN_PARTIAL_QUERY_LENGTH) {
+    return [];
   }
-  return haystack.some((item) => {
-    const normalizedItem = normalizeSearchToken(item);
-    if (normalizedItem === normalizedNeedle) {
-      return true;
-    }
-    if (normalizedItem.includes(normalizedNeedle)) {
-      return true;
-    }
-    return (
-      normalizedItem.length >= MIN_PARTIAL_QUERY_LENGTH && normalizedNeedle.includes(normalizedItem)
-    );
-  });
+
+  const exact = catalog.find((item) => normalizeSearchToken(item) === normalized);
+  if (exact) {
+    return [exact];
+  }
+
+  const partialMatches = catalog.filter((item) => tokensPartialMatch(item, value));
+  if (partialMatches.length > 0) {
+    return partialMatches;
+  }
+
+  return [value.trim()];
 }
 
 /** Expand free-text / partial queries onto catalog labels when possible. */
@@ -80,44 +88,5 @@ export function resolveSearchFilterValues(
   selected: readonly string[],
   catalog: readonly string[],
 ): string[] {
-  const resolved: string[] = [];
-
-  for (const value of selected) {
-    const normalized = normalizeSearchToken(value);
-    if (normalized.length < MIN_PARTIAL_QUERY_LENGTH) {
-      continue;
-    }
-
-    const exact = catalog.find((item) => normalizeSearchToken(item) === normalized);
-    if (exact) {
-      resolved.push(exact);
-      continue;
-    }
-
-    const partialMatches = catalog.filter((item) => {
-      const itemNorm = normalizeSearchToken(item);
-      return (
-        itemNorm.includes(normalized) ||
-        (itemNorm.length >= MIN_PARTIAL_QUERY_LENGTH && normalized.includes(itemNorm))
-      );
-    });
-
-    if (partialMatches.length > 0) {
-      resolved.push(...partialMatches);
-      continue;
-    }
-
-    // Keep free-text so provider-tag partial matching still works.
-    resolved.push(value.trim());
-  }
-
-  return uniqueSortedStrings(resolved);
-}
-
-/** @deprecated Prefer resolveSearchFilterValues for partial/creatable queries. */
-export function filterToKnownCatalogValues(
-  selected: readonly string[],
-  catalog: readonly string[],
-): string[] {
-  return uniqueSortedStrings(selected.filter((value) => includesNormalized(catalog, value)));
+  return uniqueSortedStrings(selected.flatMap((value) => expandSelectedValue(value, catalog)));
 }

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -44,11 +44,58 @@ export function joinGaMultiValue(values: readonly string[]): string {
     .join('|');
 }
 
+/** Exact case-insensitive equality. */
 export function includesNormalized(haystack: readonly string[], needle: string): boolean {
   const normalizedNeedle = normalizeSearchToken(needle);
   return haystack.some((item) => normalizeSearchToken(item) === normalizedNeedle);
 }
 
+const MIN_PARTIAL_QUERY_LENGTH = 2;
+
+/**
+ * Partial match: "digital" matches "Digital Skills" and "Digital Technology".
+ * Exact matches still work. Reverse contains only when the catalog token is long enough.
+ */
+export function matchesSearchToken(haystack: readonly string[], needle: string): boolean {
+  const normalizedNeedle = normalizeSearchToken(needle);
+  if (normalizedNeedle.length < MIN_PARTIAL_QUERY_LENGTH) {
+    return false;
+  }
+  return haystack.some((item) => {
+    const normalizedItem = normalizeSearchToken(item);
+    if (normalizedItem === normalizedNeedle) {
+      return true;
+    }
+    if (normalizedItem.includes(normalizedNeedle)) {
+      return true;
+    }
+    return (
+      normalizedItem.length >= MIN_PARTIAL_QUERY_LENGTH && normalizedNeedle.includes(normalizedItem)
+    );
+  });
+}
+
+/** Keep catalog values and free-text queries long enough for partial matching. */
+export function resolveSearchFilterValues(
+  selected: readonly string[],
+  catalog: readonly string[],
+): string[] {
+  return uniqueSortedStrings(
+    selected.filter((value) => {
+      const normalized = normalizeSearchToken(value);
+      if (normalized.length < MIN_PARTIAL_QUERY_LENGTH) {
+        return false;
+      }
+      if (includesNormalized(catalog, value)) {
+        return true;
+      }
+      // Free-text / creatable partial query
+      return true;
+    }),
+  );
+}
+
+/** @deprecated Prefer resolveSearchFilterValues for partial/creatable queries. */
 export function filterToKnownCatalogValues(
   selected: readonly string[],
   catalog: readonly string[],

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -1,0 +1,54 @@
+export function normalizeSearchToken(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function uniqueSortedStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    const key = normalizeSearchToken(trimmed);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(trimmed);
+  }
+  return result.sort((a, b) => a.localeCompare(b));
+}
+
+export function parseMultiQueryParam(value: string | string[] | undefined): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  const rawValues = Array.isArray(value) ? value : [value];
+  const tokens: string[] = [];
+  for (const raw of rawValues) {
+    for (const part of raw.split('|')) {
+      const trimmed = part.trim();
+      if (trimmed !== '') {
+        tokens.push(trimmed);
+      }
+    }
+  }
+  return uniqueSortedStrings(tokens);
+}
+
+export function joinGaMultiValue(values: readonly string[]): string {
+  return values.map((value) => value.trim()).filter(Boolean).join('|');
+}
+
+export function includesNormalized(haystack: readonly string[], needle: string): boolean {
+  const normalizedNeedle = normalizeSearchToken(needle);
+  return haystack.some((item) => normalizeSearchToken(item) === normalizedNeedle);
+}
+
+export function filterToKnownCatalogValues(
+  selected: readonly string[],
+  catalog: readonly string[],
+): string[] {
+  return uniqueSortedStrings(selected.filter((value) => includesNormalized(catalog, value)));
+}

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -20,6 +20,18 @@ export function uniqueSortedStrings(values: readonly string[]): string[] {
   return result.sort((a, b) => a.localeCompare(b));
 }
 
+function splitPipeDelimited(raw: string): string[] {
+  const tokens: string[] = [];
+  for (const part of raw.split('|')) {
+    const trimmed = part.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    tokens.push(trimmed);
+  }
+  return tokens;
+}
+
 export function parseMultiQueryParam(value: string | string[] | undefined): string[] {
   if (value === undefined) {
     return [];
@@ -27,12 +39,7 @@ export function parseMultiQueryParam(value: string | string[] | undefined): stri
   const rawValues = Array.isArray(value) ? value : [value];
   const tokens: string[] = [];
   for (const raw of rawValues) {
-    for (const part of raw.split('|')) {
-      const trimmed = part.trim();
-      if (trimmed !== '') {
-        tokens.push(trimmed);
-      }
-    }
+    tokens.push(...splitPipeDelimited(raw));
   }
   return uniqueSortedStrings(tokens);
 }
@@ -46,14 +53,30 @@ export function joinGaMultiValue(values: readonly string[]): string {
 
 const MIN_PARTIAL_QUERY_LENGTH = 2;
 
+function isTooShortForPartialMatch(token: string): boolean {
+  return token.length < MIN_PARTIAL_QUERY_LENGTH;
+}
+
 /** Shared partial/exact token compare used by matching and catalog expansion. */
 export function tokensPartialMatch(left: string, right: string): boolean {
   const a = normalizeSearchToken(left);
   const b = normalizeSearchToken(right);
-  if (a.length < MIN_PARTIAL_QUERY_LENGTH || b.length < MIN_PARTIAL_QUERY_LENGTH) {
+  if (isTooShortForPartialMatch(a)) {
     return false;
   }
-  return a === b || a.includes(b) || b.includes(a);
+  if (isTooShortForPartialMatch(b)) {
+    return false;
+  }
+  if (a === b) {
+    return true;
+  }
+  if (a.includes(b)) {
+    return true;
+  }
+  if (b.includes(a)) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -66,7 +89,7 @@ export function matchesSearchToken(haystack: readonly string[], needle: string):
 
 function expandSelectedValue(value: string, catalog: readonly string[]): string[] {
   const normalized = normalizeSearchToken(value);
-  if (normalized.length < MIN_PARTIAL_QUERY_LENGTH) {
+  if (isTooShortForPartialMatch(normalized)) {
     return [];
   }
 

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -90,3 +90,12 @@ export function resolveSearchFilterValues(
 ): string[] {
   return uniqueSortedStrings(selected.flatMap((value) => expandSelectedValue(value, catalog)));
 }
+
+/** Merge committed selections with in-progress typed draft (e.g. "business"). */
+export function mergeSearchTokens(selected: readonly string[], draft: string): string[] {
+  const trimmed = draft.trim();
+  if (trimmed === '') {
+    return uniqueSortedStrings(selected);
+  }
+  return uniqueSortedStrings([...selected, trimmed]);
+}

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -75,24 +75,43 @@ export function matchesSearchToken(haystack: readonly string[], needle: string):
   });
 }
 
-/** Keep catalog values and free-text queries long enough for partial matching. */
+/** Expand free-text / partial queries onto catalog labels when possible. */
 export function resolveSearchFilterValues(
   selected: readonly string[],
   catalog: readonly string[],
 ): string[] {
-  return uniqueSortedStrings(
-    selected.filter((value) => {
-      const normalized = normalizeSearchToken(value);
-      if (normalized.length < MIN_PARTIAL_QUERY_LENGTH) {
-        return false;
-      }
-      if (includesNormalized(catalog, value)) {
-        return true;
-      }
-      // Free-text / creatable partial query
-      return true;
-    }),
-  );
+  const resolved: string[] = [];
+
+  for (const value of selected) {
+    const normalized = normalizeSearchToken(value);
+    if (normalized.length < MIN_PARTIAL_QUERY_LENGTH) {
+      continue;
+    }
+
+    const exact = catalog.find((item) => normalizeSearchToken(item) === normalized);
+    if (exact) {
+      resolved.push(exact);
+      continue;
+    }
+
+    const partialMatches = catalog.filter((item) => {
+      const itemNorm = normalizeSearchToken(item);
+      return (
+        itemNorm.includes(normalized) ||
+        (itemNorm.length >= MIN_PARTIAL_QUERY_LENGTH && normalized.includes(itemNorm))
+      );
+    });
+
+    if (partialMatches.length > 0) {
+      resolved.push(...partialMatches);
+      continue;
+    }
+
+    // Keep free-text so provider-tag partial matching still works.
+    resolved.push(value.trim());
+  }
+
+  return uniqueSortedStrings(resolved);
 }
 
 /** @deprecated Prefer resolveSearchFilterValues for partial/creatable queries. */

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -38,7 +38,10 @@ export function parseMultiQueryParam(value: string | string[] | undefined): stri
 }
 
 export function joinGaMultiValue(values: readonly string[]): string {
-  return values.map((value) => value.trim()).filter(Boolean).join('|');
+  return values
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join('|');
 }
 
 export function includesNormalized(haystack: readonly string[], needle: string): boolean {

--- a/src/app/utilities/providerSearch/providerSearchGa.ts
+++ b/src/app/utilities/providerSearch/providerSearchGa.ts
@@ -1,5 +1,6 @@
 import { isProductionAnalyticsEnabled } from '@/app/utilities/analyticsEnv';
 import { sendGaEvent, type GaEventParams } from '@/app/utilities/gaTracking';
+import type { InstitutionCtaAnalytics } from '@/app/components/emergingInstitutions/EmergingInstitutionCtaButton';
 import {
   PROVIDER_SEARCH_GA,
   type ProviderSearchSurface,
@@ -126,26 +127,43 @@ export function trackProviderSearchResultsView(params: {
   );
 }
 
-export function trackProviderSearchResultClick(params: {
+type ResultClickParams = {
   providerSlug: string;
   providerTier: ProviderSearchTier;
   resultPosition: number;
   interestAreas: readonly string[];
   locations: readonly string[];
   destinationUrl: string;
-}): void {
+};
+
+function buildResultClickParams(params: ResultClickParams): GaEventParams {
+  return {
+    category: PROVIDER_SEARCH_GA.resultClick.category,
+    provider_slug: params.providerSlug,
+    provider_tier: params.providerTier,
+    result_position: params.resultPosition,
+    interest_areas: joinGaMultiValue(params.interestAreas),
+    locations: joinGaMultiValue(params.locations),
+    destination_url: params.destinationUrl,
+  };
+}
+
+export function trackProviderSearchResultClick(params: ResultClickParams): void {
   queueProviderSearchGaEvent(
     PROVIDER_SEARCH_GA.resultClick.eventName,
-    withPagePath({
-      category: PROVIDER_SEARCH_GA.resultClick.category,
-      provider_slug: params.providerSlug,
-      provider_tier: params.providerTier,
-      result_position: params.resultPosition,
-      interest_areas: joinGaMultiValue(params.interestAreas),
-      locations: joinGaMultiValue(params.locations),
-      destination_url: params.destinationUrl,
-    }),
+    withPagePath(buildResultClickParams(params)),
   );
+}
+
+/** Card CTA analytics — same schema as trackProviderSearchResultClick. */
+export function buildProviderSearchResultClickAnalytics(
+  params: ResultClickParams,
+): InstitutionCtaAnalytics {
+  return {
+    eventName: PROVIDER_SEARCH_GA.resultClick.eventName,
+    category: PROVIDER_SEARCH_GA.resultClick.category,
+    params: buildResultClickParams(params),
+  };
 }
 
 export function trackProviderCoursesPlaceholderView(providerSlug: string): void {

--- a/src/app/utilities/providerSearch/providerSearchGa.ts
+++ b/src/app/utilities/providerSearch/providerSearchGa.ts
@@ -1,3 +1,4 @@
+import { isProductionAnalyticsEnabled } from '@/app/utilities/analyticsEnv';
 import { sendGaEvent, type GaEventParams } from '@/app/utilities/gaTracking';
 import {
   PROVIDER_SEARCH_GA,
@@ -56,7 +57,7 @@ function ensureFlushLoop(): void {
 }
 
 export function queueProviderSearchGaEvent(eventName: string, params: GaEventParams): void {
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || !isProductionAnalyticsEnabled()) {
     return;
   }
   if (hasGtag()) {

--- a/src/app/utilities/providerSearch/providerSearchGa.ts
+++ b/src/app/utilities/providerSearch/providerSearchGa.ts
@@ -25,6 +25,14 @@ function hasGtag(): boolean {
   return typeof (window as unknown as { gtag?: unknown }).gtag === 'function';
 }
 
+function stopFlushLoop(): void {
+  if (flushTimerId === null) {
+    return;
+  }
+  clearInterval(flushTimerId);
+  flushTimerId = null;
+}
+
 function flushPendingGaEvents(): void {
   if (!hasGtag()) {
     return;
@@ -36,29 +44,34 @@ function flushPendingGaEvents(): void {
     }
     sendGaEvent(next.eventName, next.params);
   }
-  if (flushTimerId !== null && pendingEvents.length === 0) {
-    clearInterval(flushTimerId);
-    flushTimerId = null;
+  if (pendingEvents.length === 0) {
+    stopFlushLoop();
   }
 }
 
 function ensureFlushLoop(): void {
-  if (typeof window === 'undefined' || flushTimerId !== null) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (flushTimerId !== null) {
     return;
   }
   let attempts = 0;
   flushTimerId = setInterval(() => {
     attempts += 1;
     flushPendingGaEvents();
-    if (attempts >= FLUSH_MAX_ATTEMPTS && flushTimerId !== null) {
-      clearInterval(flushTimerId);
-      flushTimerId = null;
+    if (attempts < FLUSH_MAX_ATTEMPTS) {
+      return;
     }
+    stopFlushLoop();
   }, FLUSH_INTERVAL_MS);
 }
 
 export function queueProviderSearchGaEvent(eventName: string, params: GaEventParams): void {
-  if (typeof window === 'undefined' || !isProductionAnalyticsEnabled()) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (!isProductionAnalyticsEnabled()) {
     return;
   }
   if (hasGtag()) {
@@ -72,10 +85,12 @@ export function queueProviderSearchGaEvent(eventName: string, params: GaEventPar
 /** Test helper — clears queued events and flush timer. */
 export function resetProviderSearchGaQueueForTests(): void {
   pendingEvents.length = 0;
-  if (flushTimerId !== null) {
-    clearInterval(flushTimerId);
-    flushTimerId = null;
-  }
+  stopFlushLoop();
+}
+
+/** Test helper — whether the retry flush interval is still scheduled. */
+export function isProviderSearchGaFlushLoopActiveForTests(): boolean {
+  return flushTimerId !== null;
 }
 
 function withPagePath(params: GaEventParams): GaEventParams {

--- a/src/app/utilities/providerSearch/providerSearchGa.ts
+++ b/src/app/utilities/providerSearch/providerSearchGa.ts
@@ -1,0 +1,158 @@
+import { sendGaEvent, type GaEventParams } from '@/app/utilities/gaTracking';
+import {
+  PROVIDER_SEARCH_GA,
+  type ProviderSearchSurface,
+  type ProviderSearchTier,
+} from './constants';
+import { joinGaMultiValue } from './normalize';
+
+type PendingGaEvent = {
+  eventName: string;
+  params: GaEventParams;
+};
+
+const pendingEvents: PendingGaEvent[] = [];
+let flushTimerId: ReturnType<typeof setInterval> | null = null;
+const FLUSH_INTERVAL_MS = 250;
+const FLUSH_MAX_ATTEMPTS = 40;
+
+function hasGtag(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return typeof (window as unknown as { gtag?: unknown }).gtag === 'function';
+}
+
+function flushPendingGaEvents(): void {
+  if (!hasGtag()) {
+    return;
+  }
+  while (pendingEvents.length > 0) {
+    const next = pendingEvents.shift();
+    if (!next) {
+      break;
+    }
+    sendGaEvent(next.eventName, next.params);
+  }
+  if (flushTimerId !== null && pendingEvents.length === 0) {
+    clearInterval(flushTimerId);
+    flushTimerId = null;
+  }
+}
+
+function ensureFlushLoop(): void {
+  if (typeof window === 'undefined' || flushTimerId !== null) {
+    return;
+  }
+  let attempts = 0;
+  flushTimerId = setInterval(() => {
+    attempts += 1;
+    flushPendingGaEvents();
+    if (attempts >= FLUSH_MAX_ATTEMPTS && flushTimerId !== null) {
+      clearInterval(flushTimerId);
+      flushTimerId = null;
+    }
+  }, FLUSH_INTERVAL_MS);
+}
+
+export function queueProviderSearchGaEvent(eventName: string, params: GaEventParams): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (hasGtag()) {
+    sendGaEvent(eventName, params);
+    return;
+  }
+  pendingEvents.push({ eventName, params });
+  ensureFlushLoop();
+}
+
+/** Test helper — clears queued events and flush timer. */
+export function resetProviderSearchGaQueueForTests(): void {
+  pendingEvents.length = 0;
+  if (flushTimerId !== null) {
+    clearInterval(flushTimerId);
+    flushTimerId = null;
+  }
+}
+
+function withPagePath(params: GaEventParams): GaEventParams {
+  return {
+    ...params,
+    page_path: window.location.pathname,
+  };
+}
+
+export function trackProviderSearchSubmit(params: {
+  surface: ProviderSearchSurface;
+  interestAreas: readonly string[];
+  locations: readonly string[];
+}): void {
+  queueProviderSearchGaEvent(
+    PROVIDER_SEARCH_GA.submit.eventName,
+    withPagePath({
+      category: PROVIDER_SEARCH_GA.submit.category,
+      surface: params.surface,
+      interest_areas: joinGaMultiValue(params.interestAreas),
+      locations: joinGaMultiValue(params.locations),
+    }),
+  );
+}
+
+export function trackProviderSearchResultsView(params: {
+  interestAreas: readonly string[];
+  locations: readonly string[];
+  resultCountTotal: number;
+  countCourseEndorsed: number;
+  countStarredEndorsed: number;
+  countEndorsed: number;
+  countEmerging: number;
+  hasResults: boolean;
+}): void {
+  queueProviderSearchGaEvent(
+    PROVIDER_SEARCH_GA.resultsView.eventName,
+    withPagePath({
+      category: PROVIDER_SEARCH_GA.resultsView.category,
+      interest_areas: joinGaMultiValue(params.interestAreas),
+      locations: joinGaMultiValue(params.locations),
+      result_count_total: params.resultCountTotal,
+      count_course_endorsed: params.countCourseEndorsed,
+      count_starred_endorsed: params.countStarredEndorsed,
+      count_endorsed: params.countEndorsed,
+      count_emerging: params.countEmerging,
+      has_results: params.hasResults,
+    }),
+  );
+}
+
+export function trackProviderSearchResultClick(params: {
+  providerSlug: string;
+  providerTier: ProviderSearchTier;
+  resultPosition: number;
+  interestAreas: readonly string[];
+  locations: readonly string[];
+  destinationUrl: string;
+}): void {
+  queueProviderSearchGaEvent(
+    PROVIDER_SEARCH_GA.resultClick.eventName,
+    withPagePath({
+      category: PROVIDER_SEARCH_GA.resultClick.category,
+      provider_slug: params.providerSlug,
+      provider_tier: params.providerTier,
+      result_position: params.resultPosition,
+      interest_areas: joinGaMultiValue(params.interestAreas),
+      locations: joinGaMultiValue(params.locations),
+      destination_url: params.destinationUrl,
+    }),
+  );
+}
+
+export function trackProviderCoursesPlaceholderView(providerSlug: string): void {
+  queueProviderSearchGaEvent(
+    PROVIDER_SEARCH_GA.coursesPlaceholderView.eventName,
+    withPagePath({
+      category: PROVIDER_SEARCH_GA.coursesPlaceholderView.category,
+      provider_slug: providerSlug,
+    }),
+  );
+}

--- a/src/app/utilities/providerSearch/resolveFilters.ts
+++ b/src/app/utilities/providerSearch/resolveFilters.ts
@@ -1,7 +1,7 @@
-import { getProviderSearchInterestAreaCatalog, getProviderSearchLocationCatalog } from './catalog';
+import { loadProviderSearchContext, type ProviderSearchContext } from './catalog';
 import { PROVIDER_SEARCH_QUERY, type ProviderSearchFilters } from './constants';
+import { isProviderSearchDemoEnabled } from './demoFlag';
 import { parseMultiQueryParam, resolveSearchFilterValues } from './normalize';
-import { isProviderSearchDemoEnabled } from './buildSearchHref';
 
 export type ProviderSearchPageParams = {
   [PROVIDER_SEARCH_QUERY.INTEREST_AREA]?: string | string[];
@@ -12,21 +12,21 @@ export type ProviderSearchPageParams = {
 export function resolveProviderSearchFilters(searchParams: ProviderSearchPageParams): {
   filters: ProviderSearchFilters;
   searchDemo: boolean;
+  context: ProviderSearchContext;
 } {
   const searchDemo = isProviderSearchDemoEnabled(searchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO]);
-  const areaCatalog = getProviderSearchInterestAreaCatalog({ searchDemo });
-  const locationCatalog = getProviderSearchLocationCatalog({ searchDemo });
+  const context = loadProviderSearchContext({ searchDemo });
 
   const filters: ProviderSearchFilters = {
     interestAreas: resolveSearchFilterValues(
       parseMultiQueryParam(searchParams[PROVIDER_SEARCH_QUERY.INTEREST_AREA]),
-      areaCatalog,
+      context.interestAreaCatalog,
     ),
     locations: resolveSearchFilterValues(
       parseMultiQueryParam(searchParams[PROVIDER_SEARCH_QUERY.LOCATION]),
-      locationCatalog,
+      context.locationCatalog,
     ),
   };
 
-  return { filters, searchDemo };
+  return { filters, searchDemo, context };
 }

--- a/src/app/utilities/providerSearch/resolveFilters.ts
+++ b/src/app/utilities/providerSearch/resolveFilters.ts
@@ -1,6 +1,6 @@
 import { getProviderSearchInterestAreaCatalog, getProviderSearchLocationCatalog } from './catalog';
 import { PROVIDER_SEARCH_QUERY, type ProviderSearchFilters } from './constants';
-import { filterToKnownCatalogValues, parseMultiQueryParam } from './normalize';
+import { parseMultiQueryParam, resolveSearchFilterValues } from './normalize';
 import { isProviderSearchDemoEnabled } from './buildSearchHref';
 
 export type ProviderSearchPageParams = {
@@ -18,11 +18,11 @@ export function resolveProviderSearchFilters(searchParams: ProviderSearchPagePar
   const locationCatalog = getProviderSearchLocationCatalog({ searchDemo });
 
   const filters: ProviderSearchFilters = {
-    interestAreas: filterToKnownCatalogValues(
+    interestAreas: resolveSearchFilterValues(
       parseMultiQueryParam(searchParams[PROVIDER_SEARCH_QUERY.INTEREST_AREA]),
       areaCatalog,
     ),
-    locations: filterToKnownCatalogValues(
+    locations: resolveSearchFilterValues(
       parseMultiQueryParam(searchParams[PROVIDER_SEARCH_QUERY.LOCATION]),
       locationCatalog,
     ),

--- a/src/app/utilities/providerSearch/resolveFilters.ts
+++ b/src/app/utilities/providerSearch/resolveFilters.ts
@@ -1,15 +1,6 @@
-import {
-  getProviderSearchInterestAreaCatalog,
-  getProviderSearchLocationCatalog,
-} from './catalog';
-import {
-  PROVIDER_SEARCH_QUERY,
-  type ProviderSearchFilters,
-} from './constants';
-import {
-  filterToKnownCatalogValues,
-  parseMultiQueryParam,
-} from './normalize';
+import { getProviderSearchInterestAreaCatalog, getProviderSearchLocationCatalog } from './catalog';
+import { PROVIDER_SEARCH_QUERY, type ProviderSearchFilters } from './constants';
+import { filterToKnownCatalogValues, parseMultiQueryParam } from './normalize';
 import { isProviderSearchDemoEnabled } from './buildSearchHref';
 
 export type ProviderSearchPageParams = {
@@ -18,12 +9,11 @@ export type ProviderSearchPageParams = {
   [PROVIDER_SEARCH_QUERY.SEARCH_DEMO]?: string | string[];
 };
 
-export function resolveProviderSearchFilters(
-  searchParams: ProviderSearchPageParams,
-): { filters: ProviderSearchFilters; searchDemo: boolean } {
-  const searchDemo = isProviderSearchDemoEnabled(
-    searchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
-  );
+export function resolveProviderSearchFilters(searchParams: ProviderSearchPageParams): {
+  filters: ProviderSearchFilters;
+  searchDemo: boolean;
+} {
+  const searchDemo = isProviderSearchDemoEnabled(searchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO]);
   const areaCatalog = getProviderSearchInterestAreaCatalog({ searchDemo });
   const locationCatalog = getProviderSearchLocationCatalog({ searchDemo });
 

--- a/src/app/utilities/providerSearch/resolveFilters.ts
+++ b/src/app/utilities/providerSearch/resolveFilters.ts
@@ -1,0 +1,42 @@
+import {
+  getProviderSearchInterestAreaCatalog,
+  getProviderSearchLocationCatalog,
+} from './catalog';
+import {
+  PROVIDER_SEARCH_QUERY,
+  type ProviderSearchFilters,
+} from './constants';
+import {
+  filterToKnownCatalogValues,
+  parseMultiQueryParam,
+} from './normalize';
+import { isProviderSearchDemoEnabled } from './buildSearchHref';
+
+export type ProviderSearchPageParams = {
+  [PROVIDER_SEARCH_QUERY.INTEREST_AREA]?: string | string[];
+  [PROVIDER_SEARCH_QUERY.LOCATION]?: string | string[];
+  [PROVIDER_SEARCH_QUERY.SEARCH_DEMO]?: string | string[];
+};
+
+export function resolveProviderSearchFilters(
+  searchParams: ProviderSearchPageParams,
+): { filters: ProviderSearchFilters; searchDemo: boolean } {
+  const searchDemo = isProviderSearchDemoEnabled(
+    searchParams[PROVIDER_SEARCH_QUERY.SEARCH_DEMO],
+  );
+  const areaCatalog = getProviderSearchInterestAreaCatalog({ searchDemo });
+  const locationCatalog = getProviderSearchLocationCatalog({ searchDemo });
+
+  const filters: ProviderSearchFilters = {
+    interestAreas: filterToKnownCatalogValues(
+      parseMultiQueryParam(searchParams[PROVIDER_SEARCH_QUERY.INTEREST_AREA]),
+      areaCatalog,
+    ),
+    locations: filterToKnownCatalogValues(
+      parseMultiQueryParam(searchParams[PROVIDER_SEARCH_QUERY.LOCATION]),
+      locationCatalog,
+    ),
+  };
+
+  return { filters, searchDemo };
+}

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -5,7 +5,7 @@ import {
   type ProviderSearchTier,
   type ProviderSearchTierResults,
 } from './constants';
-import { includesNormalized } from './normalize';
+import { matchesSearchToken } from './normalize';
 
 export function matchesProviderSearchFilters(
   provider: ProviderSearchRecord,
@@ -16,10 +16,10 @@ export function matchesProviderSearchFilters(
 
   const areaOk =
     selectedAreas.length === 0 ||
-    selectedAreas.some((area) => includesNormalized(provider.interestAreas, area));
+    selectedAreas.some((area) => matchesSearchToken(provider.interestAreas, area));
   const locationOk =
     selectedLocations.length === 0 ||
-    selectedLocations.some((location) => includesNormalized(provider.locations, location));
+    selectedLocations.some((location) => matchesSearchToken(provider.locations, location));
 
   return areaOk && locationOk;
 }

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -55,13 +55,10 @@ export function searchProvidersByFilters(
   filters: ProviderSearchFilters,
 ): ProviderSearchTierResults {
   const results = emptyProviderSearchTierResults();
-
-  if (filters.interestAreas.length === 0 && filters.locations.length === 0) {
-    return results;
-  }
+  const browseAll = filters.interestAreas.length === 0 && filters.locations.length === 0;
 
   for (const provider of providers) {
-    if (!matchesProviderSearchFilters(provider, filters)) {
+    if (!browseAll && !matchesProviderSearchFilters(provider, filters)) {
       continue;
     }
     results[classifyProviderSearchTier(provider)].push(provider);

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -31,9 +31,6 @@ export function classifyProviderSearchTier(provider: ProviderSearchRecord): Prov
   if (provider.hasPromotedCourses) {
     return 'course_endorsed';
   }
-  if (provider.ndaCertified) {
-    return 'starred_endorsed';
-  }
   return 'endorsed';
 }
 
@@ -41,10 +38,19 @@ function sortProvidersByName(providers: ProviderSearchRecord[]): ProviderSearchR
   return [...providers].sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** Certified endorsed providers always lead the endorsed list. */
+function sortEndorsedProviders(providers: ProviderSearchRecord[]): ProviderSearchRecord[] {
+  return [...providers].sort((a, b) => {
+    if (a.ndaCertified !== b.ndaCertified) {
+      return a.ndaCertified ? -1 : 1;
+    }
+    return a.name.localeCompare(b.name);
+  });
+}
+
 export function emptyProviderSearchTierResults(): ProviderSearchTierResults {
   return {
     course_endorsed: [],
-    starred_endorsed: [],
     endorsed: [],
     emerging: [],
   };
@@ -64,15 +70,19 @@ export function searchProvidersByFilters(
     results[classifyProviderSearchTier(provider)].push(provider);
   }
 
-  for (const tier of PROVIDER_SEARCH_TIER_ORDER) {
-    results[tier] = sortProvidersByName(results[tier]);
-  }
+  results.course_endorsed = sortProvidersByName(results.course_endorsed);
+  results.endorsed = sortEndorsedProviders(results.endorsed);
+  results.emerging = sortProvidersByName(results.emerging);
 
   return results;
 }
 
 export function countProviderSearchResults(results: ProviderSearchTierResults): number {
   return PROVIDER_SEARCH_TIER_ORDER.reduce((total, tier) => total + results[tier].length, 0);
+}
+
+export function countStarredEndorsedResults(results: ProviderSearchTierResults): number {
+  return results.endorsed.filter((provider) => provider.ndaCertified).length;
 }
 
 export type PositionedProviderSearchResult = {

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -7,21 +7,29 @@ import {
 } from './constants';
 import { matchesSearchToken } from './normalize';
 
+function fieldAllowsEmptyOrMatch(
+  selected: readonly string[],
+  haystack: readonly string[],
+): boolean {
+  if (selected.length === 0) {
+    return true;
+  }
+  return selected.some((token) => matchesSearchToken(haystack, token));
+}
+
 export function matchesProviderSearchFilters(
   provider: ProviderSearchRecord,
   filters: ProviderSearchFilters,
 ): boolean {
-  const selectedAreas = filters.interestAreas;
-  const selectedLocations = filters.locations;
-
-  const areaOk =
-    selectedAreas.length === 0 ||
-    selectedAreas.some((area) => matchesSearchToken(provider.interestAreas, area));
-  const locationOk =
-    selectedLocations.length === 0 ||
-    selectedLocations.some((location) => matchesSearchToken(provider.locations, location));
-
-  return areaOk && locationOk;
+  const areaOk = fieldAllowsEmptyOrMatch(filters.interestAreas, provider.interestAreas);
+  const locationOk = fieldAllowsEmptyOrMatch(filters.locations, provider.locations);
+  if (!areaOk) {
+    return false;
+  }
+  if (!locationOk) {
+    return false;
+  }
+  return true;
 }
 
 export function classifyProviderSearchTier(provider: ProviderSearchRecord): ProviderSearchTier {
@@ -38,14 +46,19 @@ function sortProvidersByName(providers: ProviderSearchRecord[]): ProviderSearchR
   return [...providers].sort((a, b) => a.name.localeCompare(b.name));
 }
 
+function compareCertifiedFirst(a: ProviderSearchRecord, b: ProviderSearchRecord): number {
+  if (a.ndaCertified === b.ndaCertified) {
+    return a.name.localeCompare(b.name);
+  }
+  if (a.ndaCertified) {
+    return -1;
+  }
+  return 1;
+}
+
 /** Certified endorsed providers always lead the endorsed list. */
 function sortEndorsedProviders(providers: ProviderSearchRecord[]): ProviderSearchRecord[] {
-  return [...providers].sort((a, b) => {
-    if (a.ndaCertified !== b.ndaCertified) {
-      return a.ndaCertified ? -1 : 1;
-    }
-    return a.name.localeCompare(b.name);
-  });
+  return [...providers].sort(compareCertifiedFirst);
 }
 
 export function emptyProviderSearchTierResults(): ProviderSearchTierResults {
@@ -56,12 +69,22 @@ export function emptyProviderSearchTierResults(): ProviderSearchTierResults {
   };
 }
 
+function hasActiveFilters(filters: ProviderSearchFilters): boolean {
+  if (filters.interestAreas.length > 0) {
+    return true;
+  }
+  if (filters.locations.length > 0) {
+    return true;
+  }
+  return false;
+}
+
 export function searchProvidersByFilters(
   providers: readonly ProviderSearchRecord[],
   filters: ProviderSearchFilters,
 ): ProviderSearchTierResults {
   const results = emptyProviderSearchTierResults();
-  const browseAll = filters.interestAreas.length === 0 && filters.locations.length === 0;
+  const browseAll = !hasActiveFilters(filters);
 
   for (const provider of providers) {
     if (!browseAll && !matchesProviderSearchFilters(provider, filters)) {

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -24,9 +24,7 @@ export function matchesProviderSearchFilters(
   return areaOk && locationOk;
 }
 
-export function classifyProviderSearchTier(
-  provider: ProviderSearchRecord,
-): ProviderSearchTier | null {
+export function classifyProviderSearchTier(provider: ProviderSearchRecord): ProviderSearchTier {
   if (provider.kind === 'emerging') {
     return 'emerging';
   }
@@ -36,10 +34,7 @@ export function classifyProviderSearchTier(
   if (provider.ndaCertified) {
     return 'starred_endorsed';
   }
-  if (provider.kind === 'endorsed') {
-    return 'endorsed';
-  }
-  return null;
+  return 'endorsed';
 }
 
 function sortProvidersByName(providers: ProviderSearchRecord[]): ProviderSearchRecord[] {
@@ -69,11 +64,7 @@ export function searchProvidersByFilters(
     if (!matchesProviderSearchFilters(provider, filters)) {
       continue;
     }
-    const tier = classifyProviderSearchTier(provider);
-    if (tier === null) {
-      continue;
-    }
-    results[tier].push(provider);
+    results[classifyProviderSearchTier(provider)].push(provider);
   }
 
   for (const tier of PROVIDER_SEARCH_TIER_ORDER) {
@@ -85,4 +76,25 @@ export function searchProvidersByFilters(
 
 export function countProviderSearchResults(results: ProviderSearchTierResults): number {
   return PROVIDER_SEARCH_TIER_ORDER.reduce((total, tier) => total + results[tier].length, 0);
+}
+
+export type PositionedProviderSearchResult = {
+  provider: ProviderSearchRecord;
+  tier: ProviderSearchTier;
+  position: number;
+};
+
+/** Pure position assignment for result cards (no render-time mutation). */
+export function listPositionedProviderSearchResults(
+  results: ProviderSearchTierResults,
+): PositionedProviderSearchResult[] {
+  const positioned: PositionedProviderSearchResult[] = [];
+  let position = 0;
+  for (const tier of PROVIDER_SEARCH_TIER_ORDER) {
+    for (const provider of results[tier]) {
+      position += 1;
+      positioned.push({ provider, tier, position });
+    }
+  }
+  return positioned;
 }

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -1,0 +1,88 @@
+import {
+  PROVIDER_SEARCH_TIER_ORDER,
+  type ProviderSearchFilters,
+  type ProviderSearchRecord,
+  type ProviderSearchTier,
+  type ProviderSearchTierResults,
+} from './constants';
+import { includesNormalized } from './normalize';
+
+export function matchesProviderSearchFilters(
+  provider: ProviderSearchRecord,
+  filters: ProviderSearchFilters,
+): boolean {
+  const selectedAreas = filters.interestAreas;
+  const selectedLocations = filters.locations;
+
+  const areaOk =
+    selectedAreas.length === 0 ||
+    selectedAreas.some((area) => includesNormalized(provider.interestAreas, area));
+  const locationOk =
+    selectedLocations.length === 0 ||
+    selectedLocations.some((location) => includesNormalized(provider.locations, location));
+
+  return areaOk && locationOk;
+}
+
+export function classifyProviderSearchTier(
+  provider: ProviderSearchRecord,
+): ProviderSearchTier | null {
+  if (provider.kind === 'emerging') {
+    return 'emerging';
+  }
+  if (provider.hasPromotedCourses) {
+    return 'course_endorsed';
+  }
+  if (provider.ndaCertified) {
+    return 'starred_endorsed';
+  }
+  if (provider.kind === 'endorsed') {
+    return 'endorsed';
+  }
+  return null;
+}
+
+function sortProvidersByName(providers: ProviderSearchRecord[]): ProviderSearchRecord[] {
+  return [...providers].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function emptyProviderSearchTierResults(): ProviderSearchTierResults {
+  return {
+    course_endorsed: [],
+    starred_endorsed: [],
+    endorsed: [],
+    emerging: [],
+  };
+}
+
+export function searchProvidersByFilters(
+  providers: readonly ProviderSearchRecord[],
+  filters: ProviderSearchFilters,
+): ProviderSearchTierResults {
+  const results = emptyProviderSearchTierResults();
+
+  if (filters.interestAreas.length === 0 && filters.locations.length === 0) {
+    return results;
+  }
+
+  for (const provider of providers) {
+    if (!matchesProviderSearchFilters(provider, filters)) {
+      continue;
+    }
+    const tier = classifyProviderSearchTier(provider);
+    if (tier === null) {
+      continue;
+    }
+    results[tier].push(provider);
+  }
+
+  for (const tier of PROVIDER_SEARCH_TIER_ORDER) {
+    results[tier] = sortProvidersByName(results[tier]);
+  }
+
+  return results;
+}
+
+export function countProviderSearchResults(results: ProviderSearchTierResults): number {
+  return PROVIDER_SEARCH_TIER_ORDER.reduce((total, tier) => total + results[tier].length, 0);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds provider study search on the homepage and `/search`: area of study + location, partial matching, creatable dropdowns, tiered results, shared provider cards, and production-only analytics.

### Search behaviour
- OR within a field, AND across fields
- Empty Search is allowed and browses all providers on `/search`
- Typed drafts merge into submit without requiring Enter/Add
- Per-field clear (×) on each dropdown
- Compact search bar (~88% width); Search button top-aligned with dropdowns
- Pills render below inputs so the placeholder does not shift

### Results
- Tiers: course_endorsed → endorsed → emerging
- Certified providers stay under **Endorsed** (sorted first), with badge retained — no separate “NDA Certified” section
- Endorsed/course sections: soft purple band, `NDA ENDORSED` eyebrow, stronger title, purple rule
- Emerging: plain background, `EXPLORING` eyebrow, quieter muted title
- Mobile results: denser 2-up cards

### Review hardening
- CC &lt; 7 across changed modules; SOLID extractions helpers; one-logic-per-line; real tests

### Vercel build fix
- Preview deploys set `NEXT_PUBLIC_VERCEL_ENV=preview`, which no-oped `sendGaEvent` during `test:ci` and failed engagement suites. `jest.setup` now forces production for the analytics gate (suites that assert the gate still override).

## Test plan
- [x] `NEXT_PUBLIC_VERCEL_ENV=preview VERCEL=1 npm run vercel:build`
- [x] Engagement / accordion / cover-hero GA tests under preview env
- [x] Full `vercel:build` green locally (1391 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce7030a7-d2fb-4474-8837-ba63e1e45add?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce7030a7-d2fb-4474-8837-ba63e1e45add&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

