### PR TITLE
fix: provider search review findings (SOLID/DRY/bugs)

### DIFF
--- a/src/app/components/banner/HomeBanner.tsx
+++ b/src/app/components/banner/HomeBanner.tsx
@@ -21,8 +21,7 @@ interface PropType {
 
 const DEFAULT_TITLE = 'We endorse Neuro-inclusion in tertiary education';
 const DEFAULT_SUBTITLE =
-  'Reach out to learn more about our endorsements and the \
-              impact we are creating for Neurodivergent students.';
+  'Reach out to learn more about our endorsements and the impact we are creating for Neurodivergent students.';
 
 function BannerCopy({
   title,

--- a/src/app/components/course/CoursePrimaryFilter/coursePrimaryFilter.module.css
+++ b/src/app/components/course/CoursePrimaryFilter/coursePrimaryFilter.module.css
@@ -1,57 +1,17 @@
 .container {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  margin: 0;
+  composes: container from '../searchForm/searchFormShell.module.css';
 }
 
 .buttonContainer {
-  display: flex;
+  composes: buttonContainer from '../searchForm/searchFormShell.module.css';
   align-items: flex-end;
 }
 
 .content {
-  width: auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px 60px;
-  background-color: var(--GhostWhite);
-  flex-direction: row;
-  align-self: center;
-  border-radius: 8px;
-  box-shadow: 0px 8px 20px 0px #0000001f;
-  padding: 15px;
-}
-
-.content > * {
-  width: 260px;
-  flex: 1;
-  align-self: stretch;
-  justify-content: flex-start;
-}
-
-.content > *[role='combobox'] {
-  margin-left: 5px;
-}
-
-.content > button {
-  flex: 0 0 116px;
-  margin: auto;
-  align-self: center;
-}
-
-.content > *[role='combobox'] label > * {
-  font-weight: 600;
+  composes: content from '../searchForm/searchFormShell.module.css';
 }
 
 .container.disabled :global(.dropdown-input-wrapper) {
   pointer-events: none;
   opacity: 0.6;
-}
-
-@media (max-width: 480px) {
-  .content > * {
-    flex-basis: auto;
-    width: 100%;
-  }
 }

--- a/src/app/components/course/CoursePrimaryFilter/coursePrimaryFilter.module.css
+++ b/src/app/components/course/CoursePrimaryFilter/coursePrimaryFilter.module.css
@@ -1,14 +1,14 @@
 .container {
-  composes: container from '../searchForm/searchFormShell.module.css';
+  composes: container from '../../searchForm/searchFormShell.module.css';
 }
 
 .buttonContainer {
-  composes: buttonContainer from '../searchForm/searchFormShell.module.css';
+  composes: buttonContainer from '../../searchForm/searchFormShell.module.css';
   align-items: flex-end;
 }
 
 .content {
-  composes: content from '../searchForm/searchFormShell.module.css';
+  composes: content from '../../searchForm/searchFormShell.module.css';
 }
 
 .container.disabled :global(.dropdown-input-wrapper) {

--- a/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
+++ b/src/app/components/emergingInstitutions/EmergingInstitutionCard.tsx
@@ -4,11 +4,10 @@ import styles from '../institutionProviderCard/institutionProviderCard.module.cs
 import Typography, { TypographyVariant } from '../typography/Typography';
 import { TypographyColorToken } from '../typography/typographyColorToken';
 import type { AustralianState } from './emergingInstitutionTypes';
-import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
 import { slugify } from '@/app/utilities/common';
 import { buildEmergingExploreMoreAnalytics } from './emergingProvidersGa';
-import { hasEmergingProviderProfile } from './emergingProviderProfileSlugs';
 import type { InstitutionCtaAnalytics } from './EmergingInstitutionCtaButton';
+import { resolveEmergingProviderHref } from './resolveEmergingProviderHref';
 
 type EmergingInstitutionCardProps = {
   name: string;
@@ -30,10 +29,8 @@ function resolveEmergingCta(params: {
   comingSoonLabel: string | undefined;
   gaEvent: InstitutionCtaAnalytics | undefined;
 } {
-  const providerSlug = slugify(params.name);
-  const missingProfile = !hasEmergingProviderProfile(providerSlug);
-  const isComingSoon = params.demo || missingProfile;
-  if (isComingSoon) {
+  const href = resolveEmergingProviderHref({ name: params.name, demo: params.demo });
+  if (!href) {
     return {
       href: undefined,
       comingSoonLabel: 'Coming soon',
@@ -41,10 +38,9 @@ function resolveEmergingCta(params: {
     };
   }
 
-  const href = buildEmergingProviderDetailHref(providerSlug);
   const defaultGaEvent = buildEmergingExploreMoreAnalytics({
     providerName: params.name,
-    providerSlug,
+    providerSlug: slugify(params.name),
     state: params.state,
     destinationPath: href,
   });

--- a/src/app/components/emergingInstitutions/resolveEmergingProviderHref.ts
+++ b/src/app/components/emergingInstitutions/resolveEmergingProviderHref.ts
@@ -1,0 +1,15 @@
+import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
+import { slugify } from '@/app/utilities/common';
+import { hasEmergingProviderProfile } from './emergingProviderProfileSlugs';
+
+/** Shared emerging CTA destination — used by the card and search GA. */
+export function resolveEmergingProviderHref(params: {
+  name: string;
+  demo?: boolean;
+}): string | undefined {
+  const providerSlug = slugify(params.name);
+  if (params.demo || !hasEmergingProviderProfile(providerSlug)) {
+    return undefined;
+  }
+  return buildEmergingProviderDetailHref(providerSlug);
+}

--- a/src/app/components/endorsedProviders/EndorsedProviders.tsx
+++ b/src/app/components/endorsedProviders/EndorsedProviders.tsx
@@ -1,4 +1,4 @@
-import Image, { type StaticImageData } from 'next/image';
+import Image from 'next/image';
 import classNames from 'classnames';
 import InstitutionProviderCard from '../institutionProviderCard/InstitutionProviderCard';
 import cardStyles from '../institutionProviderCard/institutionProviderCard.module.css';
@@ -24,20 +24,7 @@ import { ENDORSED_PROVIDER_LOGO_BY_SLUG } from './endorsedProviderBrandAssets';
 import EndorsedCertifiedBadge from './EndorsedCertifiedBadge';
 import endorsedData from './endorsedProviders.json';
 import { providerNameFromId } from './providerName';
-
-/** Intrinsic size for public fallback `/images/AcademiaLogoLong.png`. */
-const FALLBACK_LOGO_WIDTH = 921;
-const FALLBACK_LOGO_HEIGHT = 271;
-
-const getLogoDimensions = (
-  logoSrc: string | StaticImageData,
-): { width: number; height: number } => {
-  if (typeof logoSrc === 'string') {
-    return { width: FALLBACK_LOGO_WIDTH, height: FALLBACK_LOGO_HEIGHT };
-  }
-
-  return { width: logoSrc.width, height: logoSrc.height };
-};
+import { getEndorsedLogoDimensions } from '@/app/utilities/endorsedProviderLogo';
 
 type EndorsedProviderRawRow = {
   id: string;
@@ -160,7 +147,7 @@ export default function EndorsedProviders({
               provider.logo,
               ENDORSED_PROVIDER_LOGO_BY_SLUG,
             );
-            const { width: logoWidth, height: logoHeight } = getLogoDimensions(cardLogoSrc);
+            const { width: logoWidth, height: logoHeight } = getEndorsedLogoDimensions(cardLogoSrc);
             const ctaHref = buildEndorsedProviderDetailHref(providerSlug, demoGuid);
 
             return (

--- a/src/app/components/endorsedProviders/endorsedProviderPageData.ts
+++ b/src/app/components/endorsedProviders/endorsedProviderPageData.ts
@@ -1427,16 +1427,6 @@ export function hasPromotedCoursesForSlug(slug: string): boolean {
   return getPromotedCoursesForSlug(slug).length > 0;
 }
 
-export function getEndorsedInterestAreasForSlug(slug: string): string[] {
-  const row = rows.find((item) => slugify(item.id) === slug);
-  return row?.interestAreas ?? [];
-}
-
-export function getEndorsedLocationsForSlug(slug: string): string[] {
-  const row = rows.find((item) => slugify(item.id) === slug);
-  return row?.locations ?? [];
-}
-
 const INSTITUTION_COURSES_URL_BY_SLUG: Record<string, string> = Object.fromEntries(
   rows.map((row) => [slugify(row.id), row.institutionCoursesUrl.trim()]),
 );

--- a/src/app/components/endorsedProviders/endorsedProviders.json
+++ b/src/app/components/endorsedProviders/endorsedProviders.json
@@ -15,7 +15,7 @@
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/HSHCover.webp",
     "institutionCoursesUrl": "https://www.hsh.edu.au",
-    "locations": ["Perth"],
+    "locations": ["Perth", "WA"],
     "interestAreas": ["Nursing", "Education", "Public Health"]
   },
   {
@@ -23,7 +23,7 @@
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/AcademiaCover.webp",
     "institutionCoursesUrl": "https://www.studyacademia.edu.au",
-    "locations": ["Brisbane"],
+    "locations": ["Brisbane", "QLD"],
     "interestAreas": []
   },
   {
@@ -32,7 +32,7 @@
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/BlueprintCover.webp",
     "institutionCoursesUrl": "https://www.blueprintcd.com.au/",
-    "locations": ["Brisbane"],
+    "locations": ["Brisbane", "QLD"],
     "interestAreas": ["Business Administration", "Sport and Exercise Science"]
   },
   {
@@ -41,7 +41,7 @@
     "logo": "/images/AcademiaLogoLong.png",
     "topBackgroundImage": "/images/CollartsCover.webp",
     "institutionCoursesUrl": "https://www.collarts.edu.au/courses",
-    "locations": ["Melbourne", "Sydney"],
+    "locations": ["Melbourne", "Sydney", "VIC", "NSW"],
     "interestAreas": ["Music", "Media and Communication", "Design", "Fine Arts"]
   }
 ]

--- a/src/app/components/formElements/ClearButton/ClearButton.tsx
+++ b/src/app/components/formElements/ClearButton/ClearButton.tsx
@@ -14,6 +14,25 @@ interface ClearButtonProps<
   methods: UseFormReturn<TFieldValues>;
   value: PathValue<TFieldValues, Path<TFieldValues>>;
   disabled?: boolean;
+  /** When true, show even if `value` is empty (e.g. typed draft text). */
+  forceVisible?: boolean;
+}
+
+function hasClearableValue(value: unknown): boolean {
+  if (value == null) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return String(value).length > 0;
+}
+
+function emptyFieldValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return [];
+  }
+  return '';
 }
 
 const ClearButton = <TFieldValues extends FieldValues>({
@@ -22,26 +41,33 @@ const ClearButton = <TFieldValues extends FieldValues>({
   value,
   methods,
   disabled,
+  forceVisible = false,
   onClick,
   ...rest
 }: ClearButtonProps<TFieldValues>) => {
+  const visible = !disabled && (forceVisible || hasClearableValue(value));
+  if (!visible) {
+    return null;
+  }
+
   return (
-    !disabled &&
-    !!value?.toString()?.length && (
-      <CloseButton
-        className={classNames(styles.clearBtn, className)}
-        onClick={(e) => {
-          methods.setValue(name, '' as TFieldValues[typeof name], {
+    <CloseButton
+      className={classNames(styles.clearBtn, className)}
+      onClick={(e) => {
+        methods.setValue(
+          name,
+          emptyFieldValue(value) as PathValue<TFieldValues, Path<TFieldValues>>,
+          {
             shouldValidate: true,
             shouldDirty: true,
-          });
-          methods.setFocus(name);
-          onClick?.(e);
-        }}
-        aria-label='Clear'
-        {...rest}
-      />
-    )
+          },
+        );
+        methods.setFocus(name);
+        onClick?.(e);
+      }}
+      aria-label='Clear'
+      {...rest}
+    />
   );
 };
 

--- a/src/app/components/formElements/ClearButton/__tests__/ClearButton.test.tsx
+++ b/src/app/components/formElements/ClearButton/__tests__/ClearButton.test.tsx
@@ -93,4 +93,46 @@ describe('ClearButton', () => {
     fireEvent.click(screen.getByLabelText('Clear'));
     expect(onClick).toHaveBeenCalled();
   });
+
+  it('clears multi-select arrays to [] instead of empty string', () => {
+    interface MultiValues {
+      tags: string[];
+    }
+
+    function Harness() {
+      const methods = useForm<MultiValues>({
+        defaultValues: { tags: ['Music', 'Nursing'] },
+      });
+      const value = useWatch({ control: methods.control, name: 'tags' });
+
+      return (
+        <FormProvider {...methods}>
+          <ClearButton name='tags' value={value} methods={methods} />
+          <span data-testid='tags-json'>{JSON.stringify(value)}</span>
+        </FormProvider>
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByLabelText('Clear'));
+    expect(screen.getByTestId('tags-json')).toHaveTextContent('[]');
+  });
+
+  it('renders when forceVisible even if value is empty', () => {
+    function Harness() {
+      const methods = useForm<FormValues>({
+        defaultValues: { name: '' },
+      });
+      const value = useWatch({ control: methods.control, name: 'name' });
+
+      return (
+        <FormProvider {...methods}>
+          <ClearButton name='name' value={value} methods={methods} forceVisible />
+        </FormProvider>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByLabelText('Clear')).toBeInTheDocument();
+  });
 });

--- a/src/app/components/formElements/Dropdown/DropdownFieldControls.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownFieldControls.tsx
@@ -143,6 +143,7 @@ export default function DropdownFieldControls<TFieldValues extends FieldValues>(
           methods={methods}
           className={styles.clearBtn}
           disabled={disabled}
+          forceVisible={inputValue.trim().length > 0}
           onClick={onClearDraft}
         />
       ) : null}

--- a/src/app/components/formElements/Dropdown/DropdownInput.tsx
+++ b/src/app/components/formElements/Dropdown/DropdownInput.tsx
@@ -5,6 +5,7 @@ import Pill from '../Pill/Pill';
 import { DropdownInputProps } from '@/app/interfaces/FormElements';
 import DropdownComboboxView from './DropdownComboboxView';
 import { useDropdownInputState } from './useDropdownInputState';
+import { boolProp } from './boolProp';
 
 const BUTTON_ARIA_LABEL = 'Clear';
 
@@ -13,10 +14,7 @@ function shouldShowPillsBelow(
   pillsBelow: boolean,
   selectedCount: number,
 ): boolean {
-  if (!multiple) {
-    return false;
-  }
-  if (!pillsBelow) {
+  if (!multiple || !pillsBelow) {
     return false;
   }
   return selectedCount > 0;
@@ -27,10 +25,7 @@ function resolveInlinePills(
   pillsBelow: boolean,
   selectedPills: React.ReactNode,
 ): React.ReactNode {
-  if (!multiple) {
-    return null;
-  }
-  if (pillsBelow) {
+  if (!multiple || pillsBelow) {
     return null;
   }
   return selectedPills;
@@ -41,13 +36,6 @@ function shouldShowTextControl(disabled: boolean | undefined, selectedCount: num
     return true;
   }
   return selectedCount === 0;
-}
-
-function boolProp(value: boolean | undefined, fallback: boolean): boolean {
-  if (value === undefined) {
-    return fallback;
-  }
-  return value;
 }
 
 function isSearchableEnabled(searchable: boolean | undefined): boolean {

--- a/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
+++ b/src/app/components/formElements/Dropdown/__tests__/DropdownInput.test.tsx
@@ -66,10 +66,31 @@ describe('DropdownInput advanced behaviour', () => {
     const input = screen.getByPlaceholderText('Search');
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: 'Dragonfruit' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
+    // false means preventDefault ran — stops the parent form from submitting
+    expect(fireEvent.keyDown(input, { key: 'Enter' })).toBe(false);
 
     expect(document.querySelector('input[type="hidden"][name="fruit"]')).toHaveValue('Dragonfruit');
     expect(handleChange).toHaveBeenCalledWith(['Dragonfruit']);
+  });
+
+  it('does not offer create for a case-variant of an existing option', () => {
+    render(
+      <TestWrapper>
+        <Dropdown
+          name='fruit'
+          label='Fruit'
+          options={options}
+          placeholder='Search'
+          creatable
+          multiple
+        />
+      </TestWrapper>,
+    );
+
+    const input = screen.getByPlaceholderText('Search');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'APPLE' } });
+    expect(screen.queryByText('Add "APPLE"')).not.toBeInTheDocument();
   });
 
   it('trims whitespace when creating a creatable option', () => {

--- a/src/app/components/formElements/Dropdown/__tests__/dropdownSelection.test.ts
+++ b/src/app/components/formElements/Dropdown/__tests__/dropdownSelection.test.ts
@@ -132,6 +132,13 @@ describe('dropdownSelection', () => {
       expect(exists('unknown')).toBe(false);
     });
 
+    it('matches option existence case-insensitively', () => {
+      const { getLabel, exists } = buildOptionLookup([{ label: 'Sydney', value: 'Sydney' }]);
+      expect(exists('sydney')).toBe(true);
+      expect(exists('SYDNEY')).toBe(true);
+      expect(getLabel('sydney')).toBe('Sydney');
+    });
+
     it('matches selected values case-insensitively', () => {
       const isSelected = buildSelectedLookup(['Music']);
       expect(isSelected('music')).toBe(true);

--- a/src/app/components/formElements/Dropdown/boolProp.ts
+++ b/src/app/components/formElements/Dropdown/boolProp.ts
@@ -1,0 +1,6 @@
+export function boolProp(value: boolean | undefined, fallback: boolean): boolean {
+  if (value === undefined) {
+    return fallback;
+  }
+  return value;
+}

--- a/src/app/components/formElements/Dropdown/dropdownSelection.ts
+++ b/src/app/components/formElements/Dropdown/dropdownSelection.ts
@@ -24,17 +24,17 @@ export function toSelectedOptions(value: unknown): SelectValue[] {
 export function buildOptionLookup(options: readonly SelectOption[]) {
   const byValue: Record<string, SelectOption> = {};
   for (const item of options) {
-    byValue[String(item.value)] = item;
+    byValue[String(item.value).toLowerCase()] = item;
   }
   return {
     getLabel: (val: SelectValue): SelectOption['label'] => {
-      const match = byValue[String(val)];
+      const match = byValue[String(val).toLowerCase()];
       if (match) {
         return match.label;
       }
       return String(val);
     },
-    exists: (val: SelectValue): boolean => String(val) in byValue,
+    exists: (val: SelectValue): boolean => String(val).toLowerCase() in byValue,
   };
 }
 

--- a/src/app/components/formElements/Dropdown/useDropdownInputState.ts
+++ b/src/app/components/formElements/Dropdown/useDropdownInputState.ts
@@ -25,6 +25,7 @@ import {
   toSelectedOptions,
   type SelectValue,
 } from './dropdownSelection';
+import { boolProp } from './boolProp';
 
 type UseDropdownInputStateParams<TFieldValues extends FieldValues> = Pick<
   DropdownInputProps<TFieldValues>,
@@ -40,13 +41,6 @@ type UseDropdownInputStateParams<TFieldValues extends FieldValues> = Pick<
   | 'onDraftChange'
   | 'methods'
 >;
-
-function boolProp(value: boolean | undefined, fallback: boolean): boolean {
-  if (value === undefined) {
-    return fallback;
-  }
-  return value;
-}
 
 type DropdownCore<TFieldValues extends FieldValues> = {
   params: UseDropdownInputStateParams<TFieldValues>;
@@ -207,6 +201,7 @@ function useDropdownHandlers<TFieldValues extends FieldValues>(core: DropdownCor
     if (!core.hasCreateItem) {
       return;
     }
+    e.preventDefault();
     createItem(core.inputValue);
   };
 

--- a/src/app/components/providerSearch/ProviderSearchResults.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResults.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import Image, { type StaticImageData } from 'next/image';
+import Image from 'next/image';
 import classNames from 'classnames';
 import InstitutionProviderCard from '@/app/components/institutionProviderCard/InstitutionProviderCard';
 import { INSTITUTION_PROVIDER_HEADER_KIND } from '@/app/components/institutionProviderCard/institutionProviderHeader';
 import cardStyles from '@/app/components/institutionProviderCard/institutionProviderCard.module.css';
 import EmergingInstitutionCard from '@/app/components/emergingInstitutions/EmergingInstitutionCard';
-import { hasEmergingProviderProfile } from '@/app/components/emergingInstitutions/emergingProviderProfileSlugs';
+import { resolveEmergingProviderHref } from '@/app/components/emergingInstitutions/resolveEmergingProviderHref';
 import EndorsedCertifiedBadge from '@/app/components/endorsedProviders/EndorsedCertifiedBadge';
 import Typography, { TypographyVariant } from '@/app/components/typography/Typography';
 import { TypographyColorToken } from '@/app/components/typography/typographyColorToken';
@@ -14,12 +14,14 @@ import {
   buildEndorsedProviderDetailHref,
   resolveEndorsedProviderLogoSrc,
 } from '@/app/utilities/endorsedProvidersDemo';
-import { buildEmergingProviderDetailHref } from '@/app/emergingproviders/emergingProviderMetadata';
+import {
+  ENDORSED_FALLBACK_LOGO_SRC,
+  getEndorsedLogoDimensions,
+} from '@/app/utilities/endorsedProviderLogo';
 import { ENDORSED_PROVIDER_LOGO_BY_SLUG } from '@/app/components/endorsedProviders/endorsedProviderBrandAssets';
 import {
   PROVIDER_SEARCH_TIER_HEADING,
   PROVIDER_SEARCH_TIER_META,
-  PROVIDER_SEARCH_TIER_ORDER,
   type ProviderSearchFilters,
   type ProviderSearchRecord,
   type ProviderSearchTier,
@@ -28,28 +30,18 @@ import {
 import { buildEndorsedCoursesHref } from '@/app/utilities/providerSearch/buildSearchHref';
 import { buildProviderSearchResultClickAnalytics } from '@/app/utilities/providerSearch/providerSearchGa';
 import {
-  listPositionedProviderSearchResults,
+  countProviderSearchResults,
+  listProviderSearchTierGroups,
   type PositionedProviderSearchResult,
 } from '@/app/utilities/providerSearch/searchProviders';
 import type { AustralianState } from '@/app/components/emergingInstitutions/emergingInstitutionTypes';
 import styles from './providerSearchResults.module.css';
 
-const FALLBACK_LOGO_WIDTH = 921;
-const FALLBACK_LOGO_HEIGHT = 271;
-
 type ProviderSearchResultsProps = {
   results: ProviderSearchTierResults;
   filters: ProviderSearchFilters;
   searchDemo: boolean;
-  totalCount: number;
 };
-
-function getLogoDimensions(logoSrc: string | StaticImageData): { width: number; height: number } {
-  if (typeof logoSrc === 'string') {
-    return { width: FALLBACK_LOGO_WIDTH, height: FALLBACK_LOGO_HEIGHT };
-  }
-  return { width: logoSrc.width, height: logoSrc.height };
-}
 
 function resolveEndorsedHref(
   provider: ProviderSearchRecord,
@@ -86,10 +78,10 @@ function renderEndorsedCard(
   const href = resolveEndorsedHref(provider, tier, searchDemo);
   const logoSrc = resolveEndorsedProviderLogoSrc(
     provider.slug,
-    provider.logoSrc || '/images/AcademiaLogoLong.png',
+    provider.logoSrc || ENDORSED_FALLBACK_LOGO_SRC,
     ENDORSED_PROVIDER_LOGO_BY_SLUG,
   );
-  const logoDimensions = getLogoDimensions(logoSrc);
+  const logoDimensions = getEndorsedLogoDimensions(logoSrc);
 
   return (
     <InstitutionProviderCard
@@ -123,9 +115,8 @@ function renderEndorsedCard(
 
 function renderEmergingCard(item: PositionedProviderSearchResult, filters: ProviderSearchFilters) {
   const { provider } = item;
-  const state = provider.emergingState as AustralianState;
-  const hasProfile = hasEmergingProviderProfile(provider.slug);
-  const destinationUrl = hasProfile ? buildEmergingProviderDetailHref(provider.slug) : undefined;
+  const state = (provider.emergingState ?? 'NSW') as AustralianState;
+  const destinationUrl = resolveEmergingProviderHref({ name: provider.name });
 
   return (
     <EmergingInstitutionCard
@@ -149,19 +140,6 @@ function renderProviderCard(
   return renderEndorsedCard(item, searchDemo, filters);
 }
 
-function groupPositionedByTier(items: PositionedProviderSearchResult[]) {
-  const byTier = new Map<ProviderSearchTier, PositionedProviderSearchResult[]>();
-  for (const item of items) {
-    const bucket = byTier.get(item.tier) ?? [];
-    bucket.push(item);
-    byTier.set(item.tier, bucket);
-  }
-  return PROVIDER_SEARCH_TIER_ORDER.filter((tier) => byTier.has(tier)).map((tier) => ({
-    tier,
-    items: byTier.get(tier) ?? [],
-  }));
-}
-
 function TierSectionHeader({ tier }: { tier: ProviderSearchTier }) {
   const meta = PROVIDER_SEARCH_TIER_META[tier];
   const isProminent = meta.emphasis === 'endorsed';
@@ -169,9 +147,6 @@ function TierSectionHeader({ tier }: { tier: ProviderSearchTier }) {
     ? TypographyColorToken.CherryPie
     : TypographyColorToken.BondBlackVariant;
   const titleVariant = isProminent ? TypographyVariant.H2 : TypographyVariant.H3;
-  const titleColor = isProminent
-    ? TypographyColorToken.BondBlack
-    : TypographyColorToken.BondBlackVariant;
 
   return (
     <header className={styles.tierHeader}>
@@ -185,7 +160,6 @@ function TierSectionHeader({ tier }: { tier: ProviderSearchTier }) {
       <Typography
         id={`provider-search-tier-${tier}`}
         variant={titleVariant}
-        color={titleColor}
         className={classNames(
           styles.tierHeading,
           isProminent ? styles.tierHeadingProminent : styles.tierHeadingQuiet,
@@ -212,10 +186,9 @@ export default function ProviderSearchResults({
   results,
   filters,
   searchDemo,
-  totalCount,
 }: ProviderSearchResultsProps) {
-  const positioned = listPositionedProviderSearchResults(results);
-  const tierGroups = groupPositionedByTier(positioned);
+  const totalCount = countProviderSearchResults(results);
+  const tierGroups = listProviderSearchTierGroups(results);
 
   return (
     <div className={styles.root}>

--- a/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
+++ b/src/app/components/providerSearch/ProviderSearchResultsTracker.tsx
@@ -1,59 +1,50 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import type { ProviderSearchFilters } from '@/app/utilities/providerSearch/constants';
+import type {
+  ProviderSearchFilters,
+  ProviderSearchTierResults,
+} from '@/app/utilities/providerSearch/constants';
 import { trackProviderSearchResultsView } from '@/app/utilities/providerSearch/providerSearchGa';
+import {
+  countProviderSearchResults,
+  countStarredEndorsedResults,
+} from '@/app/utilities/providerSearch/searchProviders';
+import { joinGaMultiValue } from '@/app/utilities/providerSearch/normalize';
 
 type ProviderSearchResultsTrackerProps = {
-  interestAreas: string[];
-  locations: string[];
-  resultCountTotal: number;
-  countCourseEndorsed: number;
-  countStarredEndorsed: number;
-  countEndorsed: number;
-  countEmerging: number;
+  filters: ProviderSearchFilters;
+  results: ProviderSearchTierResults;
 };
 
 function queryKey(filters: ProviderSearchFilters): string {
-  return `${filters.interestAreas.join('|')}::${filters.locations.join('|')}`;
+  return `${joinGaMultiValue(filters.interestAreas)}::${joinGaMultiValue(filters.locations)}`;
 }
 
 export default function ProviderSearchResultsTracker({
-  interestAreas,
-  locations,
-  resultCountTotal,
-  countCourseEndorsed,
-  countStarredEndorsed,
-  countEndorsed,
-  countEmerging,
+  filters,
+  results,
 }: ProviderSearchResultsTrackerProps) {
   const lastKeyRef = useRef<string>('');
 
   useEffect(() => {
-    const key = queryKey({ interestAreas, locations });
+    const key = queryKey(filters);
     if (lastKeyRef.current === key) {
       return;
     }
     lastKeyRef.current = key;
+    const resultCountTotal = countProviderSearchResults(results);
     trackProviderSearchResultsView({
-      interestAreas,
-      locations,
+      interestAreas: filters.interestAreas,
+      locations: filters.locations,
       resultCountTotal,
-      countCourseEndorsed,
-      countStarredEndorsed,
-      countEndorsed,
-      countEmerging,
+      countCourseEndorsed: results.course_endorsed.length,
+      countStarredEndorsed: countStarredEndorsedResults(results),
+      countEndorsed: results.endorsed.length,
+      countEmerging: results.emerging.length,
       hasResults: resultCountTotal > 0,
     });
-  }, [
-    interestAreas,
-    locations,
-    resultCountTotal,
-    countCourseEndorsed,
-    countStarredEndorsed,
-    countEndorsed,
-    countEmerging,
-  ]);
+  }, [filters, results]);
 
   return null;
 }

--- a/src/app/components/providerSearch/ProviderStudySearch.tsx
+++ b/src/app/components/providerSearch/ProviderStudySearch.tsx
@@ -111,7 +111,9 @@ const ProviderStudySearch: React.FC<ProviderStudySearchProps> = ({
           locationDraft,
           surface,
           searchDemo,
-          push: router.push,
+          push: (href) => {
+            router.push(href);
+          },
         });
       })}
       aria-label='Search providers by area of study and location'

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResults.test.tsx
@@ -80,7 +80,6 @@ describe('ProviderSearchResults', () => {
         results={emptyResults()}
         filters={{ interestAreas: ['Music'], locations: [] }}
         searchDemo={false}
-        totalCount={0}
       />,
     );
 
@@ -133,7 +132,6 @@ describe('ProviderSearchResults', () => {
         results={results}
         filters={{ interestAreas: ['Music'], locations: [] }}
         searchDemo
-        totalCount={3}
       />,
     );
 
@@ -180,7 +178,6 @@ describe('ProviderSearchResults', () => {
         results={results}
         filters={{ interestAreas: [], locations: [] }}
         searchDemo={false}
-        totalCount={1}
       />,
     );
 

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
@@ -11,7 +11,9 @@ jest.mock('@/app/utilities/providerSearch/providerSearchGa', () => ({
   trackProviderSearchResultsView: (...args: unknown[]) => trackMock(...args),
 }));
 
-function makeResults(overrides: Partial<ProviderSearchTierResults> = {}): ProviderSearchTierResults {
+function makeResults(
+  overrides: Partial<ProviderSearchTierResults> = {},
+): ProviderSearchTierResults {
   return {
     course_endorsed: [],
     endorsed: [],

--- a/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
+++ b/src/app/components/providerSearch/__tests__/ProviderSearchResultsTracker.test.tsx
@@ -3,6 +3,7 @@
  */
 import { render } from '@testing-library/react';
 import ProviderSearchResultsTracker from '../ProviderSearchResultsTracker';
+import type { ProviderSearchTierResults } from '@/app/utilities/providerSearch/constants';
 
 const trackMock = jest.fn();
 
@@ -10,21 +11,29 @@ jest.mock('@/app/utilities/providerSearch/providerSearchGa', () => ({
   trackProviderSearchResultsView: (...args: unknown[]) => trackMock(...args),
 }));
 
+function makeResults(overrides: Partial<ProviderSearchTierResults> = {}): ProviderSearchTierResults {
+  return {
+    course_endorsed: [],
+    endorsed: [],
+    emerging: [],
+    ...overrides,
+  };
+}
+
 describe('ProviderSearchResultsTracker', () => {
   beforeEach(() => {
     trackMock.mockClear();
   });
 
   it('fires results_view once per distinct query', () => {
+    const musicResults = makeResults({
+      course_endorsed: [{ slug: 'a' } as never],
+      endorsed: [{ slug: 'b' } as never],
+    });
     const { rerender } = render(
       <ProviderSearchResultsTracker
-        interestAreas={['Music']}
-        locations={['Sydney']}
-        resultCountTotal={2}
-        countCourseEndorsed={1}
-        countStarredEndorsed={0}
-        countEndorsed={1}
-        countEmerging={0}
+        filters={{ interestAreas: ['Music'], locations: ['Sydney'] }}
+        results={musicResults}
       />,
     );
 
@@ -32,26 +41,16 @@ describe('ProviderSearchResultsTracker', () => {
 
     rerender(
       <ProviderSearchResultsTracker
-        interestAreas={['Music']}
-        locations={['Sydney']}
-        resultCountTotal={2}
-        countCourseEndorsed={1}
-        countStarredEndorsed={0}
-        countEndorsed={1}
-        countEmerging={0}
+        filters={{ interestAreas: ['Music'], locations: ['Sydney'] }}
+        results={musicResults}
       />,
     );
     expect(trackMock).toHaveBeenCalledTimes(1);
 
     rerender(
       <ProviderSearchResultsTracker
-        interestAreas={['Nursing']}
-        locations={[]}
-        resultCountTotal={0}
-        countCourseEndorsed={0}
-        countStarredEndorsed={0}
-        countEndorsed={0}
-        countEmerging={0}
+        filters={{ interestAreas: ['Nursing'], locations: [] }}
+        results={makeResults()}
       />,
     );
     expect(trackMock).toHaveBeenCalledTimes(2);
@@ -66,20 +65,25 @@ describe('ProviderSearchResultsTracker', () => {
   it('fires browse-all results_view when filters are empty', () => {
     render(
       <ProviderSearchResultsTracker
-        interestAreas={[]}
-        locations={[]}
-        resultCountTotal={12}
-        countCourseEndorsed={1}
-        countStarredEndorsed={2}
-        countEndorsed={4}
-        countEmerging={5}
+        filters={{ interestAreas: [], locations: [] }}
+        results={makeResults({
+          course_endorsed: [{ slug: 'a' } as never],
+          endorsed: [
+            { slug: 'b', ndaCertified: true } as never,
+            { slug: 'c', ndaCertified: true } as never,
+            { slug: 'd' } as never,
+            { slug: 'e' } as never,
+          ],
+          emerging: Array.from({ length: 5 }, (_, i) => ({ slug: `e${i}` }) as never),
+        })}
       />,
     );
     expect(trackMock).toHaveBeenCalledWith(
       expect.objectContaining({
         interestAreas: [],
         locations: [],
-        resultCountTotal: 12,
+        resultCountTotal: 10,
+        countStarredEndorsed: 2,
         hasResults: true,
       }),
     );

--- a/src/app/components/providerSearch/providerSearchResults.module.css
+++ b/src/app/components/providerSearch/providerSearchResults.module.css
@@ -2,14 +2,12 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 0;
 }
 
 .tierSection {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
   align-items: stretch;
   box-sizing: border-box;
 }
@@ -35,7 +33,6 @@
   );
   border-block: 1px solid color-mix(in srgb, var(--cherryPie) 14%, transparent);
   padding: 1.75rem 0 2.25rem;
-  gap: 0;
 }
 
 .tierSectionProminent .tierInner {
@@ -46,7 +43,6 @@
 .tierSectionQuiet {
   background: transparent;
   padding: 2rem 0 2.5rem;
-  gap: 0;
 }
 
 .tierHeader {
@@ -171,18 +167,6 @@
   }
 
   .cardGrid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px 10px;
-    width: 100%;
-    max-width: none;
-    margin-inline: 0;
-  }
-
-  .cardGrid > * {
-    width: 100%;
-    max-width: none;
-    min-width: 0;
-    flex: none;
   }
 }

--- a/src/app/components/providerSearch/providerStudySearch.module.css
+++ b/src/app/components/providerSearch/providerStudySearch.module.css
@@ -1,8 +1,5 @@
 .container {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  margin: 0;
+  composes: container from '../searchForm/searchFormShell.module.css';
 }
 
 .compact {
@@ -12,43 +9,11 @@
 }
 
 .buttonContainer {
-  display: flex;
-  align-items: center;
+  composes: buttonContainer from '../searchForm/searchFormShell.module.css';
 }
 
 .content {
-  width: auto;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px 60px;
-  background-color: var(--GhostWhite);
-  flex-direction: row;
-  align-self: center;
-  border-radius: 8px;
-  box-shadow: 0px 8px 20px 0px #0000001f;
-  padding: 15px;
-}
-
-.content > * {
-  width: 260px;
-  flex: 1;
-  align-self: stretch;
-  justify-content: flex-start;
-}
-
-.content > *[role='combobox'] {
-  margin-left: 5px;
-}
-
-.content > button,
-.content > .buttonContainer {
-  flex: 0 0 116px;
-  margin: auto;
-  align-self: center;
-}
-
-.content > *[role='combobox'] label > * {
-  font-weight: 600;
+  composes: content from '../searchForm/searchFormShell.module.css';
 }
 
 .compact .content {
@@ -80,7 +45,8 @@
 }
 
 .compactSearchButton {
-  width: calc(var(--primary-button-width) / 2);
+  --compact-search-btn-width: calc(var(--primary-button-width) / 2);
+  width: var(--compact-search-btn-width);
   max-width: 156px;
   min-width: 0;
   padding: 6px 10px;
@@ -90,7 +56,7 @@
 
 /* Beat ActionButton `.primary { width: var(--primary-button-width) }` */
 .compact .buttonContainer .compactSearchButton {
-  width: calc(var(--primary-button-width) / 2);
+  width: var(--compact-search-btn-width);
   max-width: 156px;
 }
 
@@ -134,14 +100,7 @@
   .compact .buttonContainer .compactSearchButton,
   .compact .content > .buttonContainer > button,
   .compact .content > button {
-    width: calc(var(--primary-button-width) / 2);
+    width: var(--compact-search-btn-width);
     max-width: 156px;
-  }
-}
-
-@media (max-width: 480px) {
-  .content > * {
-    flex-basis: auto;
-    width: 100%;
   }
 }

--- a/src/app/components/searchForm/searchFormShell.module.css
+++ b/src/app/components/searchForm/searchFormShell.module.css
@@ -1,0 +1,55 @@
+/* Shared shell for provider + course primary search forms. */
+
+.container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+
+.buttonContainer {
+  display: flex;
+  align-items: center;
+}
+
+.content {
+  width: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px 60px;
+  background-color: var(--GhostWhite);
+  flex-direction: row;
+  align-self: center;
+  border-radius: 8px;
+  box-shadow: 0px 8px 20px 0px #0000001f;
+  padding: 15px;
+}
+
+.content > * {
+  width: 260px;
+  flex: 1;
+  align-self: stretch;
+  justify-content: flex-start;
+}
+
+.content > *[role='combobox'] {
+  margin-left: 5px;
+}
+
+.content > button,
+.content > .buttonContainer {
+  flex: 0 0 116px;
+  margin: auto;
+  align-self: center;
+}
+
+.content > *[role='combobox'] label > * {
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .content > * {
+    flex-basis: auto;
+    width: 100%;
+  }
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -8,10 +8,10 @@ import { toDropdownOptions } from '@/app/utilities/providerSearch/catalog';
 import { resolveProviderSearchFilters } from '@/app/utilities/providerSearch/resolveFilters';
 import {
   countProviderSearchResults,
-  countStarredEndorsedResults,
   searchProvidersByFilters,
 } from '@/app/utilities/providerSearch/searchProviders';
 import { PROVIDER_SEARCH_QUERY } from '@/app/utilities/providerSearch/constants';
+import { joinGaMultiValue } from '@/app/utilities/providerSearch/normalize';
 import type { SearchParams } from '@/app/utilities/featureToggle';
 import styles from './search.module.css';
 
@@ -40,6 +40,11 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
   const totalCount = countProviderSearchResults(results);
   const interestAreaOptions = toDropdownOptions(context.interestAreaCatalog);
   const locationOptions = toDropdownOptions(context.locationCatalog);
+  const searchFormKey = [
+    joinGaMultiValue(filters.interestAreas),
+    joinGaMultiValue(filters.locations),
+    searchDemo ? '1' : '0',
+  ].join('::');
 
   return (
     <main className={styles.page}>
@@ -55,6 +60,7 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
             </Typography>
           </header>
           <ProviderStudySearch
+            key={searchFormKey}
             className={styles.searchBannerForm}
             compact
             surface='search_page'
@@ -68,16 +74,8 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
       </section>
 
       <div className={styles.results}>
-        <ProviderSearchResultsTracker
-          interestAreas={filters.interestAreas}
-          locations={filters.locations}
-          resultCountTotal={totalCount}
-          countCourseEndorsed={results.course_endorsed.length}
-          countStarredEndorsed={countStarredEndorsedResults(results)}
-          countEndorsed={results.endorsed.length}
-          countEmerging={results.emerging.length}
-        />
-        <div className={styles.resultsSummary}>
+        <ProviderSearchResultsTracker filters={filters} results={results} />
+        <div className={styles.resultsSummary} aria-live='polite'>
           <Typography
             variant={TypographyVariant.Body2}
             color={TypographyColorToken.BondBlack}
@@ -86,12 +84,7 @@ export default async function ProviderSearchPage({ searchParams }: SearchPagePro
             {totalCount === 1 ? '1 provider found' : `${totalCount} providers found`}
           </Typography>
         </div>
-        <ProviderSearchResults
-          results={results}
-          filters={filters}
-          searchDemo={searchDemo}
-          totalCount={totalCount}
-        />
+        <ProviderSearchResults results={results} filters={filters} searchDemo={searchDemo} />
       </div>
     </main>
   );

--- a/src/app/utilities/endorsedProviderLogo.ts
+++ b/src/app/utilities/endorsedProviderLogo.ts
@@ -1,0 +1,15 @@
+import type { StaticImageData } from 'next/image';
+
+/** Intrinsic size for public fallback `/images/AcademiaLogoLong.png`. */
+export const ENDORSED_FALLBACK_LOGO_WIDTH = 921;
+export const ENDORSED_FALLBACK_LOGO_HEIGHT = 271;
+export const ENDORSED_FALLBACK_LOGO_SRC = '/images/AcademiaLogoLong.png';
+
+export function getEndorsedLogoDimensions(
+  logoSrc: string | StaticImageData,
+): { width: number; height: number } {
+  if (typeof logoSrc === 'string') {
+    return { width: ENDORSED_FALLBACK_LOGO_WIDTH, height: ENDORSED_FALLBACK_LOGO_HEIGHT };
+  }
+  return { width: logoSrc.width, height: logoSrc.height };
+}

--- a/src/app/utilities/endorsedProviderLogo.ts
+++ b/src/app/utilities/endorsedProviderLogo.ts
@@ -5,9 +5,10 @@ export const ENDORSED_FALLBACK_LOGO_WIDTH = 921;
 export const ENDORSED_FALLBACK_LOGO_HEIGHT = 271;
 export const ENDORSED_FALLBACK_LOGO_SRC = '/images/AcademiaLogoLong.png';
 
-export function getEndorsedLogoDimensions(
-  logoSrc: string | StaticImageData,
-): { width: number; height: number } {
+export function getEndorsedLogoDimensions(logoSrc: string | StaticImageData): {
+  width: number;
+  height: number;
+} {
   if (typeof logoSrc === 'string') {
     return { width: ENDORSED_FALLBACK_LOGO_WIDTH, height: ENDORSED_FALLBACK_LOGO_HEIGHT };
   }

--- a/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/resolveFilters.test.ts
@@ -1,9 +1,14 @@
+import { resetProviderSearchContextCacheForTests } from '../catalog';
 import { resolveProviderSearchFilters } from '../resolveFilters';
 
 describe('resolveProviderSearchFilters', () => {
-  it('expands partial queries onto catalog labels and detects searchDemo', () => {
+  beforeEach(() => {
+    resetProviderSearchContextCacheForTests();
+  });
+
+  it('expands partial queries onto curated catalog labels and detects searchDemo', () => {
     const { filters, searchDemo, context } = resolveProviderSearchFilters({
-      InterestArea: ['Music', 'digital', 'x'],
+      InterestArea: ['Music', 'nurs', 'x'],
       Location: ['Sydney', 'pen'],
       searchDemo: '1',
     });
@@ -12,27 +17,19 @@ describe('resolveProviderSearchFilters', () => {
     expect(context.searchDemo).toBe(true);
     expect(context.providers.some((provider) => provider.slug === 'collarts')).toBe(true);
 
-    // "digital" expands to catalog study areas; short tokens are dropped.
-    expect(filters.interestAreas).toEqual(
-      expect.arrayContaining(['Digital Skills', 'Digital Technology', 'Music']),
-    );
-    expect(filters.interestAreas).not.toContain('digital');
-    expect(filters.interestAreas).not.toContain('x');
+    // "nurs" expands onto Nursing; short free-text "x" is kept as-is (not partial-expanded).
+    expect(filters.interestAreas).toEqual(expect.arrayContaining(['Music', 'Nursing', 'x']));
+    expect(filters.interestAreas).not.toContain('nurs');
     expect(filters.locations).toEqual(expect.arrayContaining(['Penrith', 'Sydney']));
     expect(filters.locations).not.toContain('pen');
 
-    // Expanded filters must actually retrieve matching providers.
-    const digitalProviders = context.providers.filter((provider) =>
-      provider.interestAreas.some((area) => filters.interestAreas.includes(area)),
+    // Catalog no longer includes profile marketing labels like "Digital Skills".
+    expect(context.interestAreaCatalog).not.toEqual(expect.arrayContaining(['Digital Skills']));
+
+    const musicProviders = context.providers.filter((provider) =>
+      provider.interestAreas.includes('Music'),
     );
-    expect(digitalProviders.length).toBeGreaterThan(0);
-    expect(
-      digitalProviders.every((provider) =>
-        provider.interestAreas.some(
-          (area) => area === 'Digital Skills' || area === 'Digital Technology' || area === 'Music',
-        ),
-      ),
-    ).toBe(true);
+    expect(musicProviders.length).toBeGreaterThan(0);
   });
 
   it('returns empty filters for missing params', () => {

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -243,7 +243,16 @@ describe('provider search catalog seeds', () => {
   it('includes emerging states and derived endorsed states in location catalog', () => {
     const catalog = loadProviderSearchContext().locationCatalog;
     expect(catalog).toEqual(
-      expect.arrayContaining(['NSW', 'QLD', 'VIC', 'WA', 'Sydney', 'Melbourne', 'Brisbane', 'Perth']),
+      expect.arrayContaining([
+        'NSW',
+        'QLD',
+        'VIC',
+        'WA',
+        'Sydney',
+        'Melbourne',
+        'Brisbane',
+        'Perth',
+      ]),
     );
     expect(catalog).toEqual([...new Set(catalog)].sort((a, b) => a.localeCompare(b)));
   });

--- a/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
+++ b/src/app/utilities/providerSearch/__tests__/searchProviders.test.ts
@@ -20,12 +20,8 @@ import {
   buildProviderSearchHref,
   isProviderSearchDemoEnabled,
 } from '../buildSearchHref';
-import {
-  getProviderSearchInterestAreaCatalog,
-  getProviderSearchLocationCatalog,
-  listSearchableProviders,
-  loadProviderSearchContext,
-} from '../catalog';
+import { loadProviderSearchContext, resetProviderSearchContextCacheForTests } from '../catalog';
+import { withDerivedLocationStates } from '../locationState';
 
 function makeProvider(
   overrides: Partial<ProviderSearchRecord> & Pick<ProviderSearchRecord, 'slug' | 'name' | 'kind'>,
@@ -38,6 +34,10 @@ function makeProvider(
     ...overrides,
   };
 }
+
+beforeEach(() => {
+  resetProviderSearchContextCacheForTests();
+});
 
 describe('provider search matching', () => {
   const providers: ProviderSearchRecord[] = [
@@ -161,9 +161,12 @@ describe('provider search matching', () => {
     ).toBe('endorsed');
   });
 
-  it('partial-matches tokens for catalog expansion and provider matching', () => {
+  it('partial-matches tokens of length 3+; exact still works for short tokens', () => {
     expect(tokensPartialMatch('Digital Skills', 'digital')).toBe(true);
     expect(tokensPartialMatch('Nursing', 'digital')).toBe(false);
+    expect(tokensPartialMatch('Digital Technology', 'it')).toBe(false);
+    expect(tokensPartialMatch('Media and Communication', 'ed')).toBe(false);
+    expect(tokensPartialMatch('AI', 'AI')).toBe(true);
     expect(tokensPartialMatch('a', 'ab')).toBe(false);
   });
 
@@ -220,40 +223,50 @@ describe('provider search matching', () => {
 });
 
 describe('provider search catalog seeds', () => {
-  it('derives interest area catalog from tagged providers only', () => {
-    const catalog = getProviderSearchInterestAreaCatalog();
+  it('derives interest area catalog from curated tags only (not profile prose)', () => {
+    const catalog = loadProviderSearchContext().interestAreaCatalog;
     expect(catalog).toEqual(
       expect.arrayContaining([
-        'Music & Audio',
+        'Music',
         'Nursing',
-        'Accredited Qualifications',
-        'Training & Assessment (TAE)',
         'Fine Arts',
+        'Media and Communication',
+        'Business Administration',
       ]),
     );
-    // Catalog must be unique + sorted; soft length guards against empty fixture regressions.
+    expect(catalog).not.toEqual(expect.arrayContaining(['Music & Audio']));
+    expect(catalog).not.toEqual(expect.arrayContaining(['Accredited Qualifications']));
     expect(catalog).toEqual([...new Set(catalog)].sort((a, b) => a.localeCompare(b)));
-    expect(catalog.length).toBeGreaterThan(10);
+    expect(catalog.length).toBeGreaterThan(5);
   });
 
-  it('includes emerging states in location catalog', () => {
-    const catalog = getProviderSearchLocationCatalog();
-    expect(catalog).toEqual(expect.arrayContaining(['NSW', 'QLD', 'VIC', 'Sydney', 'Melbourne']));
+  it('includes emerging states and derived endorsed states in location catalog', () => {
+    const catalog = loadProviderSearchContext().locationCatalog;
+    expect(catalog).toEqual(
+      expect.arrayContaining(['NSW', 'QLD', 'VIC', 'WA', 'Sydney', 'Melbourne', 'Brisbane', 'Perth']),
+    );
     expect(catalog).toEqual([...new Set(catalog)].sort((a, b) => a.localeCompare(b)));
   });
 
   it('marks demo course-endorsed provider when searchDemo is enabled', () => {
-    const baseline = listSearchableProviders({ searchDemo: false }).find(
+    const baseline = loadProviderSearchContext({ searchDemo: false }).providers.find(
       (provider) => provider.slug === 'collarts',
     );
-    const demo = listSearchableProviders({ searchDemo: true }).find(
+    const demo = loadProviderSearchContext({ searchDemo: true }).providers.find(
       (provider) => provider.slug === 'collarts',
     );
+    expect(baseline?.hasPromotedCourses).toBe(false);
     expect(demo?.hasPromotedCourses).toBe(true);
-    // Demo flag must be what unlocks promoted courses when the live row has none.
-    if (!baseline?.hasPromotedCourses) {
-      expect(demo?.hasPromotedCourses).not.toBe(baseline?.hasPromotedCourses);
-    }
+  });
+
+  it('derives AU state from city location tags', () => {
+    expect(withDerivedLocationStates(['Brisbane'])).toEqual(['Brisbane', 'QLD']);
+    expect(withDerivedLocationStates(['Melbourne', 'Sydney'])).toEqual([
+      'Melbourne',
+      'NSW',
+      'Sydney',
+      'VIC',
+    ]);
   });
 });
 
@@ -284,7 +297,7 @@ describe('provider search href helpers', () => {
     );
   });
 
-  it('detects searchDemo flag case-insensitively', () => {
+  it('detects searchDemo flag exactly as 1', () => {
     expect(isProviderSearchDemoEnabled('1')).toBe(true);
     expect(isProviderSearchDemoEnabled('true')).toBe(false);
   });
@@ -341,7 +354,8 @@ describe('provider search href helpers', () => {
   });
 
   it('resolveSearchFilterValues expands free-text partial queries onto catalog labels', () => {
-    expect(resolveSearchFilterValues(['digital', 'Music', 'a'], ['Music', 'Nursing'])).toEqual([
+    expect(resolveSearchFilterValues(['digital', 'Music', 'ab'], ['Music', 'Nursing'])).toEqual([
+      'ab',
       'digital',
       'Music',
     ]);
@@ -359,7 +373,7 @@ describe('provider search href helpers', () => {
   it('loadProviderSearchContext returns providers and catalogs together', () => {
     const context = loadProviderSearchContext();
     expect(context.providers.length).toBeGreaterThan(0);
-    expect(context.interestAreaCatalog).toEqual(getProviderSearchInterestAreaCatalog());
-    expect(context.locationCatalog).toEqual(getProviderSearchLocationCatalog());
+    expect(context.interestAreaCatalog.length).toBeGreaterThan(0);
+    expect(context.locationCatalog.length).toBeGreaterThan(0);
   });
 });

--- a/src/app/utilities/providerSearch/catalog.ts
+++ b/src/app/utilities/providerSearch/catalog.ts
@@ -3,7 +3,6 @@ import type { EmergingInstitution } from '@/app/components/emergingInstitutions/
 import {
   getEndorsedDisplayNameForSlug,
   getEndorsedJsonRows,
-  getStudyAreasForSlug,
   type EndorsedJsonRow,
   type EndorsedPromotedCourse,
 } from '@/app/components/endorsedProviders/endorsedProviderPageData';
@@ -13,6 +12,7 @@ import {
   PROVIDER_SEARCH_DEMO_PROMOTED_COURSE,
   type ProviderSearchRecord,
 } from './constants';
+import { withDerivedLocationStates } from './locationState';
 import { uniqueSortedStrings } from './normalize';
 
 function endorsedDisplayName(row: EndorsedJsonRow): string {
@@ -27,15 +27,14 @@ function optionalTrimmed(value: string | undefined): string | undefined {
   return trimmed;
 }
 
+/** Curated JSON tags + promoted courses only — not profile marketing study-area prose. */
 function resolveEndorsedInterestAreas(
   row: EndorsedJsonRow,
   promotedCourses: EndorsedPromotedCourse[],
 ): string[] {
-  const slug = slugify(row.id);
-  const profileAreas = getStudyAreasForSlug(slug);
   const taggedAreas = row.interestAreas ?? [];
   const promotedAreas = promotedCourses.flatMap((course) => course.interestAreas);
-  return uniqueSortedStrings([...profileAreas, ...taggedAreas, ...promotedAreas]);
+  return uniqueSortedStrings([...taggedAreas, ...promotedAreas]);
 }
 
 function buildEndorsedRecord(
@@ -48,7 +47,7 @@ function buildEndorsedRecord(
     slug,
     name: endorsedDisplayName(row),
     interestAreas: resolveEndorsedInterestAreas(row, promotedCourses),
-    locations: row.locations ?? [],
+    locations: withDerivedLocationStates(row.locations ?? []),
     ndaCertified: row.ndaCertified === true,
     hasPromotedCourses: promotedCourses.length > 0,
     logoSrc: optionalTrimmed(row.logo),
@@ -57,7 +56,10 @@ function buildEndorsedRecord(
 }
 
 function buildEmergingRecord(institution: EmergingInstitution): ProviderSearchRecord {
-  const locations = uniqueSortedStrings([institution.state, ...(institution.locations ?? [])]);
+  const locations = withDerivedLocationStates([
+    institution.state,
+    ...(institution.locations ?? []),
+  ]);
   return {
     kind: 'emerging',
     slug: slugify(institution.name),
@@ -92,10 +94,7 @@ function promotedCoursesForRow(
 ): EndorsedPromotedCourse[] {
   const existing = row.promotedCourses ?? [];
   const isDemoTarget = slugify(row.id) === PROVIDER_SEARCH_DEMO_COURSE_ENDORSED_SLUG;
-  if (!searchDemo) {
-    return existing;
-  }
-  if (!isDemoTarget) {
+  if (!searchDemo || !isDemoTarget) {
     return existing;
   }
   return withDemoPromotedCourses(row);
@@ -112,10 +111,9 @@ export type ProviderSearchContext = {
   locationCatalog: string[];
 };
 
-export function listSearchableProviders(options?: {
-  searchDemo?: boolean;
-}): ProviderSearchRecord[] {
-  const searchDemo = options?.searchDemo === true;
+const contextCache = new Map<string, ProviderSearchContext>();
+
+function listSearchableProviders(searchDemo: boolean): ProviderSearchRecord[] {
   const endorsed = getEndorsedJsonRows()
     .filter((row) => row.live === true)
     .map((row) => toEndorsedSearchRecord(row, searchDemo));
@@ -123,13 +121,19 @@ export function listSearchableProviders(options?: {
   return [...endorsed, ...emerging];
 }
 
-/** One catalog pass shared by pages and filter resolution. */
+/** One catalog pass shared by pages and filter resolution (memoised per demo flag). */
 export function loadProviderSearchContext(options?: {
   searchDemo?: boolean;
 }): ProviderSearchContext {
   const searchDemo = options?.searchDemo === true;
-  const providers = listSearchableProviders({ searchDemo });
-  return {
+  const cacheKey = searchDemo ? 'demo' : 'live';
+  const cached = contextCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const providers = listSearchableProviders(searchDemo);
+  const context: ProviderSearchContext = {
     searchDemo,
     providers,
     interestAreaCatalog: uniqueSortedStrings(
@@ -137,14 +141,13 @@ export function loadProviderSearchContext(options?: {
     ),
     locationCatalog: uniqueSortedStrings(providers.flatMap((provider) => provider.locations)),
   };
+  contextCache.set(cacheKey, context);
+  return context;
 }
 
-export function getProviderSearchInterestAreaCatalog(options?: { searchDemo?: boolean }): string[] {
-  return loadProviderSearchContext(options).interestAreaCatalog;
-}
-
-export function getProviderSearchLocationCatalog(options?: { searchDemo?: boolean }): string[] {
-  return loadProviderSearchContext(options).locationCatalog;
+/** Test helper — clears the module-level catalog memo. */
+export function resetProviderSearchContextCacheForTests(): void {
+  contextCache.clear();
 }
 
 export function toDropdownOptions(values: readonly string[]): { label: string; value: string }[] {

--- a/src/app/utilities/providerSearch/demoFlag.ts
+++ b/src/app/utilities/providerSearch/demoFlag.ts
@@ -7,5 +7,5 @@ export function isProviderSearchDemoEnabled(
     return false;
   }
   const value = Array.isArray(searchDemoParam) ? searchDemoParam[0] : searchDemoParam;
-  return value?.toLowerCase() === PROVIDER_SEARCH_DEMO_PARAM_VALUE;
+  return value === PROVIDER_SEARCH_DEMO_PARAM_VALUE;
 }

--- a/src/app/utilities/providerSearch/locationState.ts
+++ b/src/app/utilities/providerSearch/locationState.ts
@@ -1,0 +1,43 @@
+import { uniqueSortedStrings } from './normalize';
+
+/** City → AU state for search location enrichment. */
+const CITY_TO_STATE: Record<string, string> = {
+  adelaide: 'SA',
+  brisbane: 'QLD',
+  canberra: 'ACT',
+  darwin: 'NT',
+  hobart: 'TAS',
+  melbourne: 'VIC',
+  newcastle: 'NSW',
+  penrith: 'NSW',
+  perth: 'WA',
+  sydney: 'NSW',
+  townsville: 'QLD',
+  woolloongabba: 'QLD',
+};
+
+const AU_STATES = new Set(['ACT', 'NSW', 'NT', 'QLD', 'SA', 'TAS', 'VIC', 'WA']);
+
+function stateForLocationToken(token: string): string | undefined {
+  const trimmed = token.trim();
+  if (trimmed === '') {
+    return undefined;
+  }
+  const upper = trimmed.toUpperCase();
+  if (AU_STATES.has(upper)) {
+    return upper;
+  }
+  return CITY_TO_STATE[trimmed.toLowerCase()];
+}
+
+/** Ensure city tags also expose their AU state for state-level search. */
+export function withDerivedLocationStates(locations: readonly string[]): string[] {
+  const withStates: string[] = [...locations];
+  for (const location of locations) {
+    const state = stateForLocationToken(location);
+    if (state) {
+      withStates.push(state);
+    }
+  }
+  return uniqueSortedStrings(withStates);
+}

--- a/src/app/utilities/providerSearch/normalize.ts
+++ b/src/app/utilities/providerSearch/normalize.ts
@@ -51,29 +51,23 @@ export function joinGaMultiValue(values: readonly string[]): string {
     .join('|');
 }
 
-const MIN_PARTIAL_QUERY_LENGTH = 2;
+const MIN_PARTIAL_QUERY_LENGTH = 3;
 
 function isTooShortForPartialMatch(token: string): boolean {
   return token.length < MIN_PARTIAL_QUERY_LENGTH;
 }
 
-/** Shared partial/exact token compare used by matching and catalog expansion. */
+/** Shared exact/partial token compare used by matching and catalog expansion. */
 export function tokensPartialMatch(left: string, right: string): boolean {
   const a = normalizeSearchToken(left);
   const b = normalizeSearchToken(right);
-  if (isTooShortForPartialMatch(a)) {
-    return false;
-  }
-  if (isTooShortForPartialMatch(b)) {
-    return false;
-  }
   if (a === b) {
     return true;
   }
-  if (a.includes(b)) {
-    return true;
+  if (isTooShortForPartialMatch(a) || isTooShortForPartialMatch(b)) {
+    return false;
   }
-  if (b.includes(a)) {
+  if (a.includes(b) || b.includes(a)) {
     return true;
   }
   return false;
@@ -88,22 +82,28 @@ export function matchesSearchToken(haystack: readonly string[], needle: string):
 }
 
 function expandSelectedValue(value: string, catalog: readonly string[]): string[] {
-  const normalized = normalizeSearchToken(value);
-  if (isTooShortForPartialMatch(normalized)) {
+  const trimmed = value.trim();
+  if (trimmed === '') {
     return [];
   }
 
+  const normalized = normalizeSearchToken(trimmed);
   const exact = catalog.find((item) => normalizeSearchToken(item) === normalized);
   if (exact) {
     return [exact];
   }
 
-  const partialMatches = catalog.filter((item) => tokensPartialMatch(item, value));
+  // Keep short free-text as-is; do not expand via partial match.
+  if (isTooShortForPartialMatch(normalized)) {
+    return [trimmed];
+  }
+
+  const partialMatches = catalog.filter((item) => tokensPartialMatch(item, trimmed));
   if (partialMatches.length > 0) {
     return partialMatches;
   }
 
-  return [value.trim()];
+  return [trimmed];
 }
 
 /** Expand free-text / partial queries onto catalog labels when possible. */

--- a/src/app/utilities/providerSearch/providerSearchGa.ts
+++ b/src/app/utilities/providerSearch/providerSearchGa.ts
@@ -67,6 +67,16 @@ function ensureFlushLoop(): void {
   }, FLUSH_INTERVAL_MS);
 }
 
+function withPagePath(params: GaEventParams): GaEventParams {
+  if (typeof window === 'undefined') {
+    return params;
+  }
+  return {
+    ...params,
+    page_path: window.location.pathname,
+  };
+}
+
 export function queueProviderSearchGaEvent(eventName: string, params: GaEventParams): void {
   if (typeof window === 'undefined') {
     return;
@@ -74,11 +84,12 @@ export function queueProviderSearchGaEvent(eventName: string, params: GaEventPar
   if (!isProductionAnalyticsEnabled()) {
     return;
   }
+  const enriched = withPagePath(params);
   if (hasGtag()) {
-    sendGaEvent(eventName, params);
+    sendGaEvent(eventName, enriched);
     return;
   }
-  pendingEvents.push({ eventName, params });
+  pendingEvents.push({ eventName, params: enriched });
   ensureFlushLoop();
 }
 
@@ -93,27 +104,17 @@ export function isProviderSearchGaFlushLoopActiveForTests(): boolean {
   return flushTimerId !== null;
 }
 
-function withPagePath(params: GaEventParams): GaEventParams {
-  return {
-    ...params,
-    page_path: window.location.pathname,
-  };
-}
-
 export function trackProviderSearchSubmit(params: {
   surface: ProviderSearchSurface;
   interestAreas: readonly string[];
   locations: readonly string[];
 }): void {
-  queueProviderSearchGaEvent(
-    PROVIDER_SEARCH_GA.submit.eventName,
-    withPagePath({
-      category: PROVIDER_SEARCH_GA.submit.category,
-      surface: params.surface,
-      interest_areas: joinGaMultiValue(params.interestAreas),
-      locations: joinGaMultiValue(params.locations),
-    }),
-  );
+  queueProviderSearchGaEvent(PROVIDER_SEARCH_GA.submit.eventName, {
+    category: PROVIDER_SEARCH_GA.submit.category,
+    surface: params.surface,
+    interest_areas: joinGaMultiValue(params.interestAreas),
+    locations: joinGaMultiValue(params.locations),
+  });
 }
 
 export function trackProviderSearchResultsView(params: {
@@ -126,20 +127,17 @@ export function trackProviderSearchResultsView(params: {
   countEmerging: number;
   hasResults: boolean;
 }): void {
-  queueProviderSearchGaEvent(
-    PROVIDER_SEARCH_GA.resultsView.eventName,
-    withPagePath({
-      category: PROVIDER_SEARCH_GA.resultsView.category,
-      interest_areas: joinGaMultiValue(params.interestAreas),
-      locations: joinGaMultiValue(params.locations),
-      result_count_total: params.resultCountTotal,
-      count_course_endorsed: params.countCourseEndorsed,
-      count_starred_endorsed: params.countStarredEndorsed,
-      count_endorsed: params.countEndorsed,
-      count_emerging: params.countEmerging,
-      has_results: params.hasResults,
-    }),
-  );
+  queueProviderSearchGaEvent(PROVIDER_SEARCH_GA.resultsView.eventName, {
+    category: PROVIDER_SEARCH_GA.resultsView.category,
+    interest_areas: joinGaMultiValue(params.interestAreas),
+    locations: joinGaMultiValue(params.locations),
+    result_count_total: params.resultCountTotal,
+    count_course_endorsed: params.countCourseEndorsed,
+    count_starred_endorsed: params.countStarredEndorsed,
+    count_endorsed: params.countEndorsed,
+    count_emerging: params.countEmerging,
+    has_results: params.hasResults,
+  });
 }
 
 type ResultClickParams = {
@@ -166,7 +164,7 @@ function buildResultClickParams(params: ResultClickParams): GaEventParams {
 export function trackProviderSearchResultClick(params: ResultClickParams): void {
   queueProviderSearchGaEvent(
     PROVIDER_SEARCH_GA.resultClick.eventName,
-    withPagePath(buildResultClickParams(params)),
+    buildResultClickParams(params),
   );
 }
 
@@ -182,11 +180,8 @@ export function buildProviderSearchResultClickAnalytics(
 }
 
 export function trackProviderCoursesPlaceholderView(providerSlug: string): void {
-  queueProviderSearchGaEvent(
-    PROVIDER_SEARCH_GA.coursesPlaceholderView.eventName,
-    withPagePath({
-      category: PROVIDER_SEARCH_GA.coursesPlaceholderView.category,
-      provider_slug: providerSlug,
-    }),
-  );
+  queueProviderSearchGaEvent(PROVIDER_SEARCH_GA.coursesPlaceholderView.eventName, {
+    category: PROVIDER_SEARCH_GA.coursesPlaceholderView.category,
+    provider_slug: providerSlug,
+  });
 }

--- a/src/app/utilities/providerSearch/searchProviders.ts
+++ b/src/app/utilities/providerSearch/searchProviders.ts
@@ -22,14 +22,10 @@ export function matchesProviderSearchFilters(
   filters: ProviderSearchFilters,
 ): boolean {
   const areaOk = fieldAllowsEmptyOrMatch(filters.interestAreas, provider.interestAreas);
-  const locationOk = fieldAllowsEmptyOrMatch(filters.locations, provider.locations);
   if (!areaOk) {
     return false;
   }
-  if (!locationOk) {
-    return false;
-  }
-  return true;
+  return fieldAllowsEmptyOrMatch(filters.locations, provider.locations);
 }
 
 export function classifyProviderSearchTier(provider: ProviderSearchRecord): ProviderSearchTier {
@@ -61,7 +57,7 @@ function sortEndorsedProviders(providers: ProviderSearchRecord[]): ProviderSearc
   return [...providers].sort(compareCertifiedFirst);
 }
 
-export function emptyProviderSearchTierResults(): ProviderSearchTierResults {
+function emptyProviderSearchTierResults(): ProviderSearchTierResults {
   return {
     course_endorsed: [],
     endorsed: [],
@@ -70,13 +66,7 @@ export function emptyProviderSearchTierResults(): ProviderSearchTierResults {
 }
 
 function hasActiveFilters(filters: ProviderSearchFilters): boolean {
-  if (filters.interestAreas.length > 0) {
-    return true;
-  }
-  if (filters.locations.length > 0) {
-    return true;
-  }
-  return false;
+  return filters.interestAreas.length > 0 || filters.locations.length > 0;
 }
 
 export function searchProvidersByFilters(
@@ -90,7 +80,8 @@ export function searchProvidersByFilters(
     if (!browseAll && !matchesProviderSearchFilters(provider, filters)) {
       continue;
     }
-    results[classifyProviderSearchTier(provider)].push(provider);
+    const tier = classifyProviderSearchTier(provider);
+    results[tier].push(provider);
   }
 
   results.course_endorsed = sortProvidersByName(results.course_endorsed);
@@ -114,17 +105,35 @@ export type PositionedProviderSearchResult = {
   position: number;
 };
 
-/** Pure position assignment for result cards (no render-time mutation). */
+export type ProviderSearchTierGroup = {
+  tier: ProviderSearchTier;
+  items: PositionedProviderSearchResult[];
+};
+
+/** Assign global positions and group by tier in one pass. */
+export function listProviderSearchTierGroups(
+  results: ProviderSearchTierResults,
+): ProviderSearchTierGroup[] {
+  const groups: ProviderSearchTierGroup[] = [];
+  let position = 0;
+  for (const tier of PROVIDER_SEARCH_TIER_ORDER) {
+    const providers = results[tier];
+    if (providers.length === 0) {
+      continue;
+    }
+    const items: PositionedProviderSearchResult[] = [];
+    for (const provider of providers) {
+      position += 1;
+      items.push({ provider, tier, position });
+    }
+    groups.push({ tier, items });
+  }
+  return groups;
+}
+
+/** Flat list of positioned results (tests / GA helpers). */
 export function listPositionedProviderSearchResults(
   results: ProviderSearchTierResults,
 ): PositionedProviderSearchResult[] {
-  const positioned: PositionedProviderSearchResult[] = [];
-  let position = 0;
-  for (const tier of PROVIDER_SEARCH_TIER_ORDER) {
-    for (const provider of results[tier]) {
-      position += 1;
-      positioned.push({ provider, tier, position });
-    }
-  }
-  return positioned;
+  return listProviderSearchTierGroups(results).flatMap((group) => group.items);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #301 addressing the review findings. Analytics remain **production-only** (`NEXT_PUBLIC_VERCEL_ENV === 'production'` via `isProductionAnalyticsEnabled` / layout / `sendGaEvent`).

### Bugs
- Remount `/search` form via `key` so soft nav no longer ORs stale chips into the next query
- `preventDefault` on creatable Enter so the form does not also submit
- Case-insensitive option `exists()` (no more `Add "sydney"` for `Sydney`)
- Derive AU state from city tags; seed endorsed JSON with state tokens
- Partial match min length 3; exact match before the length guard
- Curated interest-area catalog only (drop profile marketing prose duplicates)
- Clear multi fields to `[]`; show clear for typed drafts; guard `withPagePath` for SSR

### SOLID / DRY / unused
- Tracker takes `filters` + `results` (derive counts)
- Shared emerging href resolver, endorsed logo helper, search-form CSS shell, `boolProp`
- Memoised `loadProviderSearchContext`; remove unused endorsed getters
- Positions grouped in one pass

### Tests
- Updated catalog/filter/tracker/dropdown/clear coverage for the above
- `npm run vercel:build` green locally (1396 tests)

## Test plan
- [x] `npm run vercel:build`
- [ ] Re-search from `/search?InterestArea=Music` with `Nursing` — URL and chips both become Nursing only
- [ ] Enter on a new creatable value adds a pill without navigating
- [ ] Search `QLD` includes Brisbane-based endorsed providers
- [ ] Confirm GA still no-ops when `NEXT_PUBLIC_VERCEL_ENV` is not `production`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-688d4ae0-40c2-4500-882d-7ee52d8fe2ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-688d4ae0-40c2-4500-882d-7ee52d8fe2ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

